### PR TITLE
chore: add semver rule, PR template fallback, and default PR template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ Research and plan files must use dashes for multi-word names and include a times
 - **Cost**: warn before any change that increases costs (new cloud resources, paid services, upgraded tiers)
 - **Git**: never auto-commit or push  - wait for explicit instructions
 - **Commits**: always use conventional commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, etc.). Scope is optional, e.g. `feat(auth): add token refresh`. Never add Co-Authored-By or any AI attribution to commits
-- **PR descriptions**: always use bullet points in the summary section, not prose paragraphs
+- **Versioning**: follow semantic versioning (semver) - MAJOR for breaking changes, MINOR for new features, PATCH for fixes
+- **PR descriptions**: always use bullet points in the summary section, not prose paragraphs. If the repo has a PR template (`.github/pull_request_template.md`), use it. If not, use the default template at `~/.claude/pull_request_template.md`
 - **Verification**: build + typecheck + lint + tests must all pass before considering work done
 - **Conciseness**: be direct and terse during implementation  - save explanations for when asked
 - **Existing patterns**: follow the conventions already in the codebase  - consistency over personal preference

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,34 @@
+## What does this PR do?
+
+> Briefly explain what changed and why.
+
+## Category
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Chore (dependencies, docs, config)
+- [ ] CI/CD
+- [ ] Infrastructure
+
+## Linked issues
+
+> Reference any related issues, tickets, or PRs.
+
+## Review checklist
+
+### General
+
+- [ ] Changes have been tested locally
+- [ ] Tests have been added or updated where needed
+- [ ] No unnecessary changes outside the scope of this PR
+
+### Security
+
+- [ ] Considered the security impact of these changes
+- [ ] No credentials or secrets in the code
+
+### For reviewers
+
+- [ ] PR description provides enough context to understand the change
+- [ ] Screenshots or logs included where relevant


### PR DESCRIPTION
## What does this PR do?

- Add semantic versioning (semver) rule to behavioral rules
- Add PR template fallback logic: use repo-specific template if available, otherwise use default at `~/.claude/pull_request_template.md`
- Create a generic, project-agnostic default PR template

## Category

- [x] Chore (dependencies, docs, config)

## Review checklist

### General

- [x] Changes have been tested locally
- [x] No unnecessary changes outside the scope of this PR

### For reviewers

- [x] PR description provides enough context to understand the change