### PR TITLE
docs: restructure README and move reference content into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,37 @@
 # Claude Code Configuration
 
-Custom configuration for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) -a global `CLAUDE.md` with workflow rules and code standards, plus 15 expert agent personas with strict guardrails, review checklists, and red-flag detection.
+Custom configuration for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that turns it into a disciplined engineering partner with structured workflows, strict guardrails, and domain-specific expertise.
 
-## Setup
+## Why
 
-Copy the global configuration and agents into your Claude Code directory:
+Out of the box, Claude Code is capable but generic. This configuration adds opinionated defaults - a mandatory research-plan-implement workflow, security boundaries, code standards, and 15 expert agents that activate automatically based on task context. The result is more consistent, reviewable, and safe output.
+
+## What's Included
+
+- **[`CLAUDE.md`](CLAUDE.md)** - global rules: workflow phases, security, code standards, behavioral constraints, agent routing
+- **[`agents/`](agents/)** - 15 expert agent personas across engineering, infrastructure, security, compliance, analytics, and product/design
+- **[`.github/pull_request_template.md`](.github/pull_request_template.md)** - PR template
+- **[`.github/workflows/`](.github/workflows/)** - CI workflow for markdown linting
+
+## Quick Start
 
 ```bash
 cp CLAUDE.md ~/.claude/CLAUDE.md
 cp -r agents/ ~/.claude/agents/
 ```
 
-## Global Configuration
-
-[`CLAUDE.md`](CLAUDE.md) defines the rules that apply across all projects:
-
-- **Workflow** -Research, Plan, Annotate, Implement (no skipping phases)
-- **Security** -never read secrets, credentials, or private keys
-- **Code Standards** -TypeScript (no `any`), Zod validation, soft deletes, Vitest, complete code only
-- **Behavioral Rules** -scope discipline, ask before architectural choices, build/typecheck/lint/test before done
-
 ## Agents
 
-### Engineering
+15 agents organized into 5 categories: Engineering, Infrastructure & Data, Marketing & Analytics, Security & Compliance, and Product & Design. Each agent includes strict guardrails, review checklists, and red-flag detection.
 
-| Agent | File | Focus |
-| --- | --- | --- |
-| Senior Staff Engineer | [`staff-engineer.md`](agents/staff-engineer.md) | System design, code architecture, design principles, DDD, SOLID |
-| Senior Frontend Staff Engineer | [`frontend-staff-engineer.md`](agents/frontend-staff-engineer.md) | React, component architecture, rendering strategies, Core Web Vitals, accessibility |
-| Senior Backend Staff Engineer | [`backend-staff-engineer.md`](agents/backend-staff-engineer.md) | API design, database engineering, event-driven architecture, caching, resilience |
-| Senior DevOps Engineer | [`devops-engineer.md`](agents/devops-engineer.md) | IaC, containers, Kubernetes, CI/CD, observability, SRE |
-| Senior QA Expert | [`qa-expert.md`](agents/qa-expert.md) | Test strategy, test automation, CI testing, performance testing, accessibility testing |
+See the [Agent Reference](docs/agents.md) for the full listing and structure.
 
-### Infrastructure & Data
+## Configuration
 
-| Agent | File | Focus |
-| --- | --- | --- |
-| Senior AWS Expert | [`aws-expert.md`](agents/aws-expert.md) | AWS services, Well-Architected Framework, cost optimization, IAM |
-| Senior GCP Expert | [`gcp-expert.md`](agents/gcp-expert.md) | GCP services, Cloud Run, BigQuery, IAM, networking |
-| Senior PostgreSQL Expert | [`postgresql-expert.md`](agents/postgresql-expert.md) | Query optimization, indexing, partitioning, replication, schema design |
-| Senior Networking Expert | [`networking-expert.md`](agents/networking-expert.md) | TCP/IP, DNS, load balancing, CDN, VPN, network security |
+`CLAUDE.md` defines research-plan-implement workflow, security rules, TypeScript code standards, behavioral constraints (scope discipline, conventional commits, semver), and automatic agent routing.
 
-### Marketing & Analytics
+See the [Configuration Guide](docs/configuration.md) for a detailed walkthrough.
 
-| Agent | File | Focus |
-| --- | --- | --- |
-| Senior GTM Expert | [`gtm-expert.md`](agents/gtm-expert.md) | Server-side tagging, GTM web/server containers, data layer, Consent Mode v2, Conversion APIs |
+## CI
 
-### Security & Compliance
-
-| Agent | File | Focus |
-| --- | --- | --- |
-| Senior Cybersecurity Expert | [`cybersecurity-expert.md`](agents/cybersecurity-expert.md) | OWASP, auth, cryptography, supply chain security, threat modeling |
-| Senior GDPR Expert | [`gdpr-expert.md`](agents/gdpr-expert.md) | EU data protection, DPIAs, consent management, data subject rights, international transfers |
-
-### Product & Design
-
-| Agent | File | Focus |
-| --- | --- | --- |
-| Senior Product Manager | [`product-manager.md`](agents/product-manager.md) | Product strategy, user stories, prioritization, roadmapping, metrics |
-| Senior UX Expert | [`ux-expert.md`](agents/ux-expert.md) | Interaction design, usability, accessibility, design systems, information architecture |
-
-## Agent Structure
-
-Every agent follows the same 9-section structure:
-
-1. **Identity** -role, experience, certifications
-2. **Core Expertise** -domain knowledge areas
-3. **Thinking Approach** -7 principles that guide reasoning
-4. **Response Style** -communication patterns
-5. **Strict Guardrails** -non-negotiable rules flagged as BLOCKER (18-24 per agent)
-6. **Review Checklist** -verification items for code/architecture review (12-14 per agent)
-7. **Red Flags** -patterns that trigger immediate investigation (12-15 per agent)
-8. **Tools & Frameworks** -recommended tooling
-9. **Integration with Workflow** -how the agent works within the research/plan/implement phases
+Markdown linting runs on every push and PR via GitHub Actions.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,56 @@
+# Expert Agents
+
+15 expert agent personas with strict guardrails, review checklists, and red-flag detection. Each agent is loaded automatically by Claude Code when a task matches its domain.
+
+## Engineering
+
+| Agent | File | Focus |
+| --- | --- | --- |
+| Senior Staff Engineer | [`staff-engineer.md`](../agents/staff-engineer.md) | System design, code architecture, design principles, DDD, SOLID |
+| Senior Frontend Staff Engineer | [`frontend-staff-engineer.md`](../agents/frontend-staff-engineer.md) | React, component architecture, rendering strategies, Core Web Vitals, accessibility |
+| Senior Backend Staff Engineer | [`backend-staff-engineer.md`](../agents/backend-staff-engineer.md) | API design, database engineering, event-driven architecture, caching, resilience |
+| Senior DevOps Engineer | [`devops-engineer.md`](../agents/devops-engineer.md) | IaC, containers, Kubernetes, CI/CD, observability, SRE |
+| Senior QA Expert | [`qa-expert.md`](../agents/qa-expert.md) | Test strategy, test automation, CI testing, performance testing, accessibility testing |
+
+## Infrastructure & Data
+
+| Agent | File | Focus |
+| --- | --- | --- |
+| Senior AWS Expert | [`aws-expert.md`](../agents/aws-expert.md) | AWS services, Well-Architected Framework, cost optimization, IAM |
+| Senior GCP Expert | [`gcp-expert.md`](../agents/gcp-expert.md) | GCP services, Cloud Run, BigQuery, IAM, networking |
+| Senior PostgreSQL Expert | [`postgresql-expert.md`](../agents/postgresql-expert.md) | Query optimization, indexing, partitioning, replication, schema design |
+| Senior Networking Expert | [`networking-expert.md`](../agents/networking-expert.md) | TCP/IP, DNS, load balancing, CDN, VPN, network security |
+
+## Marketing & Analytics
+
+| Agent | File | Focus |
+| --- | --- | --- |
+| Senior GTM Expert | [`gtm-expert.md`](../agents/gtm-expert.md) | Server-side tagging, GTM web/server containers, data layer, Consent Mode v2, Conversion APIs |
+
+## Security & Compliance
+
+| Agent | File | Focus |
+| --- | --- | --- |
+| Senior Cybersecurity Expert | [`cybersecurity-expert.md`](../agents/cybersecurity-expert.md) | OWASP, auth, cryptography, supply chain security, threat modeling |
+| Senior GDPR Expert | [`gdpr-expert.md`](../agents/gdpr-expert.md) | EU data protection, DPIAs, consent management, data subject rights, international transfers |
+
+## Product & Design
+
+| Agent | File | Focus |
+| --- | --- | --- |
+| Senior Product Manager | [`product-manager.md`](../agents/product-manager.md) | Product strategy, user stories, prioritization, roadmapping, metrics |
+| Senior UX Expert | [`ux-expert.md`](../agents/ux-expert.md) | Interaction design, usability, accessibility, design systems, information architecture |
+
+## Agent Structure
+
+Every agent follows the same 9-section structure:
+
+1. **Identity** - role, experience, certifications
+2. **Core Expertise** - domain knowledge areas
+3. **Thinking Approach** - 7 principles that guide reasoning
+4. **Response Style** - communication patterns
+5. **Strict Guardrails** - non-negotiable rules flagged as BLOCKER (18-24 per agent)
+6. **Review Checklist** - verification items for code/architecture review (12-14 per agent)
+7. **Red Flags** - patterns that trigger immediate investigation (12-15 per agent)
+8. **Tools & Frameworks** - recommended tooling
+9. **Integration with Workflow** - how the agent works within the research/plan/implement phases

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,69 @@
+# Configuration Guide
+
+[`CLAUDE.md`](../CLAUDE.md) defines the global rules that apply across all projects. Project-level `CLAUDE.md` files can override where they conflict.
+
+## Workflow: Research - Plan - Implement
+
+Every non-trivial task follows a strict 4-phase workflow:
+
+1. **Research** - read all relevant files, produce a research artifact with findings and open questions. No solutions yet.
+2. **Plan** - produce a detailed plan with goal, approach, file-by-file changes (with code snippets), and a task checklist. Wait for approval.
+3. **Annotation Cycle** - the user annotates the plan with notes, questions, or corrections. Address every annotation and re-present. Repeat until explicit approval.
+4. **Implement** - execute the approved plan task by task. Run typecheck continuously. Build + lint + test must pass before done.
+
+Trivial changes (typos, one-liner fixes, config tweaks) can skip straight to implementation.
+
+Research and plan files use the naming convention `YYYY-MM-DD-descriptive-name.md`.
+
+## Security
+
+- Never read or process files containing secrets, credentials, API keys, or private keys
+- Sensitive file patterns: `.env*`, `*.pem`, `*.key`, `credentials.json`, `service-account*.json`
+- Home directory secrets (`~/.aws`, `~/.ssh`, `~/.config/gcloud`, `~/.kube`) are off-limits
+- Ask the user to provide only non-sensitive parts when needed for debugging
+
+## Code Standards
+
+- TypeScript: no `any` or `unknown` - use proper types. 2-space indent, single quotes
+- Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
+- Zod schemas for runtime validation at system boundaries
+- Database: soft delete only, explicit migrations only - never auto-sync schemas
+- Tests: Vitest preferred, mock external deps, manual class instantiation over DI in tests
+- Complete code only - no TODOs, no placeholders, no incomplete implementations
+
+## Behavioral Rules
+
+- **Scope** - only implement what was asked, no drive-by refactors or unsolicited improvements
+- **Decisions** - ask before making architectural choices
+- **Cost** - warn before any change that increases costs
+- **Git** - never auto-commit or push, use conventional commits, follow semver
+- **PR descriptions** - bullet points in the summary, use the repo's PR template if available
+- **Verification** - build + typecheck + lint + tests must all pass before considering work done
+- **Existing patterns** - follow codebase conventions over personal preference
+
+## Expert Agents
+
+Claude Code automatically loads expert agents based on task context. The routing table in `CLAUDE.md` maps domain triggers (e.g., "React, components, CSS") to agent files (e.g., `frontend-staff-engineer.md`).
+
+Key rules:
+
+- Always load agents before the research phase
+- Load multiple agents when a task crosses domains
+- Feature planning always includes the product-manager agent
+- UI work always includes frontend + ux + qa agents
+- EU data handling always includes the gdpr agent
+- Guardrails from all loaded agents apply simultaneously
+
+See [Agent Reference](agents.md) for the full list and structure.
+
+## Learning from Mistakes
+
+When corrected by the user, the relevant `CLAUDE.md` is updated so the mistake is not repeated. Global corrections go in the global file; project-specific corrections go in the project's `CLAUDE.md`.
+
+## Environment
+
+- macOS, zsh, Node.js (check `.nvmrc`), npm
+- Docker for local services
+- Cloud: GCP primary, AWS secondary
+- Git + GitHub for version control and CI/CD
+- `gh` CLI for all GitHub operations


### PR DESCRIPTION
## What does this PR do?

- Rewrites README to be concise and scannable for newcomers
- Moves detailed agent tables and structure docs into `docs/agents.md`
- Moves detailed CLAUDE.md configuration walkthrough into `docs/configuration.md`
- README now links to dedicated docs instead of embedding all reference content

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

> None

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant