### PR TITLE
chore: harden workflow with security, state persistence, hooks, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@ These rules apply to every project. Project-level CLAUDE.md files override where
 
 ## Workflow: Research - Plan - Implement
 
-1. **Research**: read every relevant file, produce a research artifact with findings and open questions. No solutions yet.
-2. **Plan**: produce a plan with goal, approach, file-by-file changes (with code snippets), task checklist. Include exact paths and line ranges. Flag risks. Wait for approval.
+1. **Research**: read every relevant file, produce a research artifact. Save to `.claude/state/research/`. No solutions yet.
+2. **Plan**: produce a plan with goal, approach, file-by-file changes, task checklist. Save to `.claude/state/plans/`. Wait for approval.
 3. **Annotate**: user annotates the plan. Address every annotation, re-present. Repeat until explicit approval.
 4. **Implement**: execute the approved plan task by task. Run typecheck continuously. Build + lint + test must pass before done.
+5. **Summarize**: save a session diary entry to `.claude/state/sessions/` when work is complete.
 
 For trivial changes (typos, one-liner fixes, config tweaks): skip straight to implementation. If in doubt, ask.
 
@@ -24,12 +25,9 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 
 ## Code Standards
 
-- TypeScript: no `any` or `unknown` - use proper types. 2-space indent, single quotes
 - Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
-- Zod schemas for runtime validation at system boundaries
-- Database: soft delete only, explicit migrations only - never auto-sync schemas
-- Tests: Vitest preferred, mock external deps, manual class instantiation over DI in tests
 - Complete code only - no TODOs, no placeholders, no incomplete implementations
+- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security)
 
 ## Behavioral Rules
 

--- a/README.md
+++ b/README.md
@@ -6,32 +6,124 @@ Custom configuration for [Claude Code](https://docs.anthropic.com/en/docs/claude
 
 Out of the box, Claude Code is capable but generic. This configuration adds opinionated defaults - a mandatory research-plan-implement workflow, security boundaries, code standards, and 15 expert agents that activate automatically based on task context. The result is more consistent, reviewable, and safe output.
 
-## What's Included
+## Repository Structure
 
-- **[`CLAUDE.md`](CLAUDE.md)** - global rules: workflow phases, security, code standards, behavioral constraints, agent routing
-- **[`agents/`](agents/)** - 15 expert agent personas across engineering, infrastructure, security, compliance, analytics, and product/design
-- **[`.github/pull_request_template.md`](.github/pull_request_template.md)** - PR template
-- **[`.github/workflows/`](.github/workflows/)** - CI workflow for markdown linting
-
-## Quick Start
-
-```bash
-cp CLAUDE.md ~/.claude/CLAUDE.md
-cp -r agents/ ~/.claude/agents/
+```text
+CLAUDE.md                      # Core rules (workflow, security, behavioral constraints)
+agents/                        # 15 expert agent personas
+commands/                      # Slash commands for frequent workflows
+hooks/                         # Automation scripts (formatting, PR watching)
+rules/                         # Modular instruction files (always-loaded + path-scoped)
+skills/                        # Reusable workflows with supporting files
+docs/                          # Reference documentation
+pull_request_template.md       # Default PR template
+.github/workflows/             # CI (markdown linting)
 ```
 
-## Agents
+## Setup
 
-15 agents organized into 5 categories: Engineering, Infrastructure & Data, Marketing & Analytics, Security & Compliance, and Product & Design. Each agent includes strict guardrails, review checklists, and red-flag detection.
+Symlink the repo contents to `~/.claude/` so changes auto-sync:
 
-See the [Agent Reference](docs/agents.md) for the full listing and structure.
+```bash
+# Clone the repo
+git clone git@github.com:domengabrovsek/claude.git ~/dev/claude
 
-## Configuration
+# Symlink to ~/.claude/
+ln -sf ~/dev/claude/CLAUDE.md ~/.claude/CLAUDE.md
+ln -sf ~/dev/claude/agents ~/.claude/agents
+ln -sf ~/dev/claude/rules ~/.claude/rules
+ln -sf ~/dev/claude/skills ~/.claude/skills
+ln -sf ~/dev/claude/commands ~/.claude/commands
+ln -sf ~/dev/claude/hooks ~/.claude/hooks
+```
 
-`CLAUDE.md` defines research-plan-implement workflow, security rules, TypeScript code standards, behavioral constraints (scope discipline, conventional commits, semver), and automatic agent routing.
+## Components
 
-See the [Configuration Guide](docs/configuration.md) for a detailed walkthrough.
+### CLAUDE.md
+
+Core rules loaded every session (~50 lines). Kept lean - detailed standards live in `rules/`.
+
+- 5-phase workflow: Research - Plan - Annotate - Implement - Summarize
+- Security boundaries
+- Behavioral constraints (scope discipline, verification gates)
+
+### Rules (`rules/`)
+
+Modular instruction files. **Always-loaded** rules have no frontmatter. **Path-scoped** rules use `globs:` frontmatter and only load when editing matching files, saving tokens.
+
+| Rule | Scope | Loads when... |
+| --- | --- | --- |
+| `agent-routing.md` | Always | Every session (agent selection table) |
+| `git-conventions.md` | Always | Every session (commits, PRs, semver) |
+| `file-naming.md` | Always | Every session (timestamp convention) |
+| `state-persistence.md` | Always | Every session (artifact saving) |
+| `typescript.md` | `**/*.ts,**/*.tsx` | Editing TypeScript files |
+| `tests.md` | `**/*.test.ts,**/*.spec.ts` | Editing test files |
+| `database.md` | `**/migrations/**,**/*.sql` | Editing database/migration files |
+| `infrastructure.md` | `**/Dockerfile,**/*.tf` | Editing infrastructure files |
+
+### Agents (`agents/`)
+
+15 expert agent personas across 5 categories. Each follows a 9-section structure with strict guardrails, review checklists, and red-flag detection. Loaded automatically via the routing table in `rules/agent-routing.md`.
+
+See [Agent Reference](docs/agents.md) for the full listing.
+
+### Skills (`skills/`)
+
+Reusable workflows invoked on-demand. Cost ~200 tokens when idle (metadata only) vs. full cost if in CLAUDE.md.
+
+| Skill | Trigger | Purpose |
+| --- | --- | --- |
+| `fix-issue` | `/fix-issue 1234` | Full issue resolution: fetch, research, plan, implement, test, PR |
+| `review-pr` | `/review-pr 567` | Structured PR review with BLOCKER/ISSUE/SUGGESTION/NIT/PRAISE severity |
+
+### Commands (`commands/`)
+
+Slash commands for frequent workflows. Available as `/user:<name>`.
+
+| Command | Trigger | Purpose |
+| --- | --- | --- |
+| `research` | `/user:research <topic>` | Phase 1: explore codebase, save findings to `.claude/state/research/` |
+| `plan` | `/user:plan` | Phase 2: create implementation plan, save to `.claude/state/plans/` |
+| `summarize` | `/user:summarize` | Save session diary to `.claude/state/sessions/` |
+| `typecheck` | `/user:typecheck` | Run tsc and fix all type errors |
+| `ci-check` | `/user:ci-check` | Run local CI checks (lint + typecheck + test + build) |
+| `verify-done` | `/user:verify-done` | Full quality gate before declaring work done |
+
+### Hooks (`hooks/`)
+
+Automation scripts triggered at lifecycle events. Configured in `~/.claude/settings.json`.
+
+| Hook | Event | Purpose |
+| --- | --- | --- |
+| `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
+| `watch-pr-checks.sh` | PostToolUse (gh pr create) | Poll CI checks in background, notify on pass/fail |
+| Notification | Notification | macOS desktop notification when Claude needs input |
+| Compact reminder | SessionStart (compact) | Re-inject workflow context after compaction |
+
+### State (`.claude/state/` per project)
+
+Session artifacts saved at the project level so they persist across sessions and machines.
+
+```text
+.claude/state/
+  research/    # Research artifacts from Phase 1
+  plans/       # Implementation plans from Phase 2
+  sessions/    # Session diary entries from Phase 5
+```
+
+## Security
+
+- Comprehensive deny list in `settings.json` blocking 35+ sensitive file patterns
+- Bash command restrictions blocking destructive operations (`rm -rf`, `git push --force`, `sudo`)
+- PostToolUse formatting hook validates files before processing
+- Agent guardrails enforce security checks across all domains
 
 ## CI
 
 Markdown linting runs on every push and PR via GitHub Actions.
+
+## Documentation
+
+- [Agent Reference](docs/agents.md) - full agent listing and structure
+- [Configuration Guide](docs/configuration.md) - detailed walkthrough of all settings

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -92,62 +92,7 @@ These are non-negotiable. Any violation is a **BLOCKER** on the PR.
 
 ## Review Checklist
 
-When reviewing a PR, systematically verify:
-
-### Code Quality
-
-- [ ] Changes match the stated PR description and linked issue
-- [ ] No unrelated changes (formatting, refactors, dead code cleanup) mixed in
-- [ ] Naming is consistent with project conventions and ubiquitous language
-- [ ] Functions are focused — single responsibility, reasonable length (<30 lines)
-- [ ] No code duplication introduced — reuse existing utilities or extract shared logic
-- [ ] Path aliases (`@services/*`, `@models/*`, etc.) used instead of relative imports
-
-### TypeScript
-
-- [ ] No `any`, `unknown`, or type assertions (`as`) outside system boundaries
-- [ ] New interfaces/types are precise — no overly broad types
-- [ ] Discriminated unions used for variant types
-- [ ] Strict null checks respected — no `!` non-null assertions without justification
-
-### GraphQL & API
-
-- [ ] Schema changes are backward-compatible (no removed fields without deprecation)
-- [ ] Resolvers use DataLoaders for related entity lookups — no N+1 queries
-- [ ] Input types are validated before processing
-- [ ] Permission checks in place for new queries/mutations
-- [ ] Error codes follow existing conventions
-
-### Database
-
-- [ ] Migrations are backward-compatible and reversible
-- [ ] Migration files are `.js` (not `.ts`) per project convention
-- [ ] New queries use indexes — no full table scans on large tables
-- [ ] Soft delete respected — no hard deletes without explicit justification
-- [ ] Transactions used for multi-step writes
-
-### Security
-
-- [ ] No secrets, credentials, or PII in code or logs
-- [ ] User input validated at boundaries
-- [ ] Authorization checks on all protected endpoints
-- [ ] No open redirect, SSRF, or injection vectors introduced
-- [ ] Dependencies free of known critical vulnerabilities
-
-### Testing
-
-- [ ] New behavior has corresponding tests
-- [ ] Tests cover both happy path and error cases
-- [ ] Tests are deterministic — no time-dependent or order-dependent assertions
-- [ ] Mocks are at module boundaries — not on internal functions
-- [ ] Test descriptions clearly state what is being tested
-
-### Performance
-
-- [ ] No unnecessary database queries in loops
-- [ ] No memory leaks (event listeners, intervals, unclosed streams)
-- [ ] Pagination used for list queries that could return large result sets
-- [ ] No blocking operations on hot paths
+Use the detailed checklist from the review-pr skill: `skills/review-pr/checklist.md`
 
 ## Red Flags
 

--- a/commands/ci-check.md
+++ b/commands/ci-check.md
@@ -1,9 +1,8 @@
-Run local CI checks equivalent to the GitHub Actions pipeline. Stop at the first failure.
+Run local CI checks that mirror the actual CI/CD pipeline. Before running anything, discover what the pipeline does:
 
-1. **Lint**: run the project's linter (e.g., `npm run lint` or `npx biome check .`)
-2. **Typecheck**: run `npx tsc --noEmit`
-3. **Tests**: run `npm test` (or `npx vitest run`)
-4. **Build**: run `npm run build`
+1. **Discover CI steps**: read `.github/workflows/*.yml` (or `.gitlab-ci.yml`, `Jenkinsfile`, etc.) to find the actual CI jobs and commands. Also read `package.json` scripts to understand what each npm script does.
+2. **Build a checklist**: list the exact commands CI runs (e.g., `npm run lint`, `npx tsc --noEmit`, `npm test`, `npm run build`). Only run what CI actually runs - do not guess or add extra steps.
+3. **Run each step in order**: execute the discovered commands in the same order as CI. Stop at the first failure.
+4. **Report results**: for each step, show the command that was run and whether it passed or failed. If all pass, output "All CI checks passed." If any fail, show the failure details.
 
-Report results for each step. If all pass, output "All CI checks passed."
-If any fail, stop and report the failure details.
+If no CI configuration is found, say so and ask the user what checks to run.

--- a/commands/ci-check.md
+++ b/commands/ci-check.md
@@ -1,0 +1,9 @@
+Run local CI checks equivalent to the GitHub Actions pipeline. Stop at the first failure.
+
+1. **Lint**: run the project's linter (e.g., `npm run lint` or `npx biome check .`)
+2. **Typecheck**: run `npx tsc --noEmit`
+3. **Tests**: run `npm test` (or `npx vitest run`)
+4. **Build**: run `npm run build`
+
+Report results for each step. If all pass, output "All CI checks passed."
+If any fail, stop and report the failure details.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,11 +1,13 @@
 Start Phase 2 (Plan) based on the most recent research artifact or the topic: $ARGUMENTS
 
-Produce a plan as a markdown file named `YYYY-MM-DD-plan-<topic>.md` (use today's date) containing:
+Check `.claude/state/research/` for a related research artifact first.
+
+Save the plan to `.claude/state/plans/YYYY-MM-DD-plan-<topic>.md` (use today's date) containing:
 
 - **Goal**: what we're trying to achieve
 - **Approach**: the chosen strategy and why
 - **File-by-file changes**: exact file paths, line ranges, and code snippets for each change
-- **Task checklist**: ordered list of implementation steps
+- **Task checklist**: ordered list of implementation steps (use `- [ ]` checkboxes)
 - **Risks**: what could go wrong, trade-offs, alternatives considered
 
 Flag anything that needs user input. Do NOT implement yet - wait for explicit approval.

--- a/commands/research.md
+++ b/commands/research.md
@@ -2,7 +2,7 @@ Start Phase 1 (Research) for the following topic: $ARGUMENTS
 
 Use subagents to explore the codebase efficiently. Read all relevant files, check git history for context, and investigate related patterns.
 
-Produce a research artifact as a markdown file named `YYYY-MM-DD-research-<topic>.md` (use today's date) containing:
+Save the research artifact to `.claude/state/research/YYYY-MM-DD-research-<topic>.md` (use today's date) containing:
 
 - **Findings**: what you discovered in the codebase
 - **Open questions**: things that need clarification

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,5 +1,0 @@
-Review the current branch's changes against the base branch. Use `git diff main...HEAD` to see all changes.
-
-Load the pr-reviewer agent methodology from `~/.claude/agents/pr-reviewer.md`. Output findings in the structured format: BLOCKER > ISSUE > SUGGESTION > NIT > PRAISE. Include a verdict (APPROVE / REQUEST_CHANGES / NEEDS_DISCUSSION).
-
-If `$ARGUMENTS` is provided, review that specific PR using `gh pr diff $ARGUMENTS` instead.

--- a/commands/summarize.md
+++ b/commands/summarize.md
@@ -1,4 +1,9 @@
-Summarize the current session's work. Format as a brief status update:
+Summarize the current session's work and save it to `.claude/state/sessions/YYYY-MM-DD-<topic>.md` (use today's date and a brief topic slug).
+
+Format the file as:
+
+```markdown
+# Session: <date> - <topic>
 
 ## What was done
 
@@ -16,4 +21,9 @@ Summarize the current session's work. Format as a brief status update:
 
 - Unresolved decisions or blockers
 
-Keep it concise - suitable for a standup update or handoff to another session.
+## Key decisions
+
+- Important choices made during this session and why
+```
+
+Also output the summary to the conversation. Keep it concise - suitable for a standup update or handoff to another session.

--- a/commands/verify-done.md
+++ b/commands/verify-done.md
@@ -1,11 +1,10 @@
-Comprehensive quality gate before declaring work done. Run ALL checks:
+Comprehensive quality gate before declaring work done.
 
-1. **Typecheck**: `npx tsc --noEmit` - zero errors
-2. **Lint**: project linter - zero errors
-3. **Tests**: `npm test` - all passing
-4. **Build**: `npm run build` - succeeds
-5. **Git status**: show uncommitted changes
-6. **Diff review**: summarize what changed (files, lines added/removed)
+1. **Discover CI steps**: read `.github/workflows/*.yml` (or `.gitlab-ci.yml`, `Jenkinsfile`, etc.) and `package.json` scripts to find the actual checks CI runs. Only run what CI actually runs - do not guess or add extra steps.
+2. **Run each CI step in order**: execute the discovered commands (lint, typecheck, test, build, etc.) in the same order as CI. Stop at the first failure.
+3. **Git status**: show uncommitted changes and untracked files.
+4. **Diff review**: summarize what changed in this session (files, lines added/removed).
 
-If all pass: output "READY - all quality gates passed."
-If any fail: list failures and stop. Do NOT declare work done.
+If all CI steps pass and git status is clean: output "READY - all quality gates passed."
+If any step fails: list failures and stop. Do NOT declare work done.
+If no CI configuration is found, say so and ask the user what checks to run.

--- a/commands/verify-done.md
+++ b/commands/verify-done.md
@@ -1,0 +1,11 @@
+Comprehensive quality gate before declaring work done. Run ALL checks:
+
+1. **Typecheck**: `npx tsc --noEmit` - zero errors
+2. **Lint**: project linter - zero errors
+3. **Tests**: `npm test` - all passing
+4. **Build**: `npm run build` - succeeds
+5. **Git status**: show uncommitted changes
+6. **Diff review**: summarize what changed (files, lines added/removed)
+
+If all pass: output "READY - all quality gates passed."
+If any fail: list failures and stop. Do NOT declare work done.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Expert Agents
 
-15 expert agent personas with strict guardrails, review checklists, and red-flag detection. Each agent is loaded automatically by Claude Code when a task matches its domain.
+15 expert agent personas with strict guardrails, review checklists, and red-flag detection. Each agent is loaded automatically by Claude Code when a task matches its domain via the routing table in [`rules/agent-routing.md`](../rules/agent-routing.md).
 
 ## Engineering
 
@@ -41,6 +41,12 @@
 | Senior Product Manager | [`product-manager.md`](../agents/product-manager.md) | Product strategy, user stories, prioritization, roadmapping, metrics |
 | Senior UX Expert | [`ux-expert.md`](../agents/ux-expert.md) | Interaction design, usability, accessibility, design systems, information architecture |
 
+## Code Review
+
+| Agent | File | Focus |
+| --- | --- | --- |
+| Senior PR Reviewer | [`pr-reviewer.md`](../agents/pr-reviewer.md) | Structured severity-based code reviews, TypeScript/Node.js, GraphQL, database, security |
+
 ## Agent Structure
 
 Every agent follows the same 9-section structure:
@@ -54,3 +60,9 @@ Every agent follows the same 9-section structure:
 7. **Red Flags** - patterns that trigger immediate investigation (12-15 per agent)
 8. **Tools & Frameworks** - recommended tooling
 9. **Integration with Workflow** - how the agent works within the research/plan/implement phases
+
+## Routing
+
+The routing table in [`rules/agent-routing.md`](../rules/agent-routing.md) maps domain triggers to agent files. Claude loads matching agents automatically before starting work. Multiple agents load simultaneously when a task crosses domains (e.g., a new API endpoint loads backend + security + QA).
+
+Additional routing triggers added for: error handling/resilience, API design, data modeling, test strategy/architecture, performance optimization, and PR review.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,49 +1,156 @@
 # Configuration Guide
 
-[`CLAUDE.md`](../CLAUDE.md) defines the global rules that apply across all projects. Project-level `CLAUDE.md` files can override where they conflict.
+## CLAUDE.md
 
-## Workflow: Research - Plan - Implement
+[`CLAUDE.md`](../CLAUDE.md) defines the core rules loaded every session. Kept intentionally lean (~50 lines) - detailed standards live in `rules/` to save tokens.
 
-Every non-trivial task follows a strict 4-phase workflow:
+### Workflow: Research - Plan - Implement - Summarize
 
-1. **Research** - read all relevant files, produce a research artifact with findings and open questions. No solutions yet.
-2. **Plan** - produce a detailed plan with goal, approach, file-by-file changes (with code snippets), and a task checklist. Wait for approval.
-3. **Annotation Cycle** - the user annotates the plan with notes, questions, or corrections. Address every annotation and re-present. Repeat until explicit approval.
+Every non-trivial task follows a 5-phase workflow:
+
+1. **Research** - read all relevant files, produce a research artifact. Save to `.claude/state/research/`. No solutions yet.
+2. **Plan** - produce a detailed plan with goal, approach, file-by-file changes, and task checklist. Save to `.claude/state/plans/`. Wait for approval.
+3. **Annotate** - user annotates the plan. Address every annotation and re-present. Repeat until explicit approval.
 4. **Implement** - execute the approved plan task by task. Run typecheck continuously. Build + lint + test must pass before done.
+5. **Summarize** - save a session diary entry to `.claude/state/sessions/`.
 
 Trivial changes (typos, one-liner fixes, config tweaks) can skip straight to implementation.
 
-Research and plan files use the naming convention `YYYY-MM-DD-descriptive-name.md`.
-
-## Security
+### Security
 
 - Never read or process files containing secrets, credentials, API keys, or private keys
 - Sensitive file patterns: `.env*`, `*.pem`, `*.key`, `credentials.json`, `service-account*.json`
 - Home directory secrets (`~/.aws`, `~/.ssh`, `~/.config/gcloud`, `~/.kube`) are off-limits
 - Ask the user to provide only non-sensitive parts when needed for debugging
 
-## Code Standards
+### Code Standards
 
-- TypeScript: no `any` or `unknown` - use proper types. 2-space indent, single quotes
-- Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
-- Zod schemas for runtime validation at system boundaries
-- Database: soft delete only, explicit migrations only - never auto-sync schemas
-- Tests: Vitest preferred, mock external deps, manual class instantiation over DI in tests
-- Complete code only - no TODOs, no placeholders, no incomplete implementations
+Detailed standards live in path-scoped rule files that only load when relevant:
 
-## Behavioral Rules
+- [`rules/typescript.md`](../rules/typescript.md) - TypeScript conventions (loads for `**/*.ts,**/*.tsx`)
+- [`rules/tests.md`](../rules/tests.md) - testing standards (loads for `**/*.test.ts,**/*.spec.ts`)
+- [`rules/database.md`](../rules/database.md) - database conventions (loads for `**/migrations/**,**/*.sql`)
+- [`rules/infrastructure.md`](../rules/infrastructure.md) - infra standards (loads for `**/Dockerfile,**/*.tf`)
+
+### Behavioral Rules
 
 - **Scope** - only implement what was asked, no drive-by refactors or unsolicited improvements
 - **Decisions** - ask before making architectural choices
 - **Cost** - warn before any change that increases costs
-- **Git** - never auto-commit or push, use conventional commits, follow semver
-- **PR descriptions** - bullet points in the summary, use the repo's PR template if available
 - **Verification** - build + typecheck + lint + tests must all pass before considering work done
 - **Existing patterns** - follow codebase conventions over personal preference
 
+## Rules (`rules/`)
+
+Modular instruction files split by concern. Two types:
+
+### Always-loaded (no frontmatter)
+
+These load every session alongside CLAUDE.md:
+
+- [`agent-routing.md`](../rules/agent-routing.md) - agent selection table and loading rules
+- [`git-conventions.md`](../rules/git-conventions.md) - conventional commits, semver, PR templates, `gh` CLI
+- [`file-naming.md`](../rules/file-naming.md) - `YYYY-MM-DD-descriptive-name.md` convention
+- [`state-persistence.md`](../rules/state-persistence.md) - artifact saving to `.claude/state/`
+
+### Path-scoped (with `globs:` frontmatter)
+
+These only load when Claude works on matching files, saving tokens:
+
+- [`typescript.md`](../rules/typescript.md) - loads for `**/*.ts,**/*.tsx`
+- [`tests.md`](../rules/tests.md) - loads for `**/*.test.ts,**/*.spec.ts`
+- [`database.md`](../rules/database.md) - loads for `**/migrations/**,**/*.sql,**/prisma/**`
+- [`infrastructure.md`](../rules/infrastructure.md) - loads for `**/Dockerfile,**/*.tf,**/.github/workflows/**`
+
+## Skills (`skills/`)
+
+Reusable workflows with supporting files. Auto-invoked when Claude recognizes a matching task, or triggered manually via slash command. Cost ~200 tokens when idle (metadata only).
+
+### fix-issue
+
+**Trigger:** `/fix-issue 1234`
+
+Full issue resolution workflow: fetch issue details, research codebase, reproduce with failing test, propose fix plan, implement, test, commit, create PR. Saves research and plans to `.claude/state/`.
+
+### review-pr
+
+**Trigger:** `/review-pr 567`
+
+Structured PR review using the pr-reviewer agent methodology. Outputs findings as BLOCKER > ISSUE > SUGGESTION > NIT > PRAISE with a verdict. Includes a detailed [checklist](../skills/review-pr/checklist.md) covering correctness, type safety, security, GDPR/privacy, database, testing, performance, code quality, and scope.
+
+## Commands (`commands/`)
+
+Slash commands for frequent workflows. Available as `/user:<name>`.
+
+| Command | Purpose |
+| --- | --- |
+| [`research`](../commands/research.md) | Start Phase 1 - explore codebase, save to `.claude/state/research/` |
+| [`plan`](../commands/plan.md) | Start Phase 2 - create implementation plan, save to `.claude/state/plans/` |
+| [`summarize`](../commands/summarize.md) | Save session diary to `.claude/state/sessions/` |
+| [`typecheck`](../commands/typecheck.md) | Run tsc and fix all type errors iteratively |
+| [`ci-check`](../commands/ci-check.md) | Run local CI checks (lint + typecheck + test + build) |
+| [`verify-done`](../commands/verify-done.md) | Full quality gate before declaring work done |
+
+## Hooks (`hooks/`)
+
+Automation scripts triggered at lifecycle events. Configured in `~/.claude/settings.json` (not in repo - personal config).
+
+### auto-format.sh
+
+**Event:** PostToolUse (Write|Edit)
+
+Automatically formats files after Claude edits them. Detects the project's formatter (Biome > Prettier > fallback) and validates the file exists and is text before formatting. Timeout: 30 seconds.
+
+### watch-pr-checks.sh
+
+**Event:** PostToolUse (Bash, when `gh pr create` runs)
+
+Spawns in the background after PR creation. Polls `gh pr checks` every 30 seconds and sends a macOS notification with sound when checks pass (Glass) or fail (Basso). Times out after 30 minutes.
+
+### Other hooks (in settings.json)
+
+- **Notification** (permission_prompt|idle_prompt) - macOS desktop notification when Claude needs input
+- **SessionStart** (compact) - re-injects workflow reminder after context compaction
+- **Stop** - safe no-op hook (placeholder for future task verification)
+
+## Settings (`~/.claude/settings.json`)
+
+Not in the repo (contains personal config). Key sections:
+
+### Permissions deny list
+
+35+ patterns blocking reads/edits/writes of sensitive files:
+
+- Environment files (`.env*`)
+- SSH/GPG keys (`~/.ssh/**`, `~/.gnupg/**`)
+- Cloud credentials (`~/.aws/**`, `~/.config/gcloud/**`, `~/.kube/**`, `~/.azure/**`)
+- Terraform state (`**/.terraform.tfstate*`, `~/.terraformrc`)
+- Package manager tokens (`~/.npmrc`, `~/.yarnrc.yml`, `~/.pnpmrc`)
+- Git credentials (`~/.git-credentials`, `~/.gitconfig`)
+- Shell history (`~/.zsh_history`, `~/.bash_history`)
+- IDE secrets (`~/.config/Code/User/globalStorage/**`)
+- Certificates and keys (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`)
+
+### Bash command restrictions
+
+Blocked destructive commands: `rm -rf`, `sudo`, `dd`, `mkfs`, `shred`, `git push --force`, `git reset --hard`, `git clean -f`, `chmod` on sensitive directories.
+
+## State (`.claude/state/`)
+
+Session artifacts saved at the project level (not global). Created on demand in each project's `.claude/` directory.
+
+```text
+.claude/state/
+  research/    # Research artifacts from Phase 1
+  plans/       # Implementation plans from Phase 2
+  sessions/    # Session diary entries from Phase 5
+```
+
+Naming convention: `YYYY-MM-DD-descriptive-name.md`
+
 ## Expert Agents
 
-Claude Code automatically loads expert agents based on task context. The routing table in `CLAUDE.md` maps domain triggers (e.g., "React, components, CSS") to agent files (e.g., `frontend-staff-engineer.md`).
+Claude loads expert agents automatically based on task context via the routing table in [`rules/agent-routing.md`](../rules/agent-routing.md).
 
 Key rules:
 
@@ -53,12 +160,9 @@ Key rules:
 - UI work always includes frontend + ux + qa agents
 - EU data handling always includes the gdpr agent
 - Guardrails from all loaded agents apply simultaneously
+- Skip agent loading for trivial changes
 
 See [Agent Reference](agents.md) for the full list and structure.
-
-## Learning from Mistakes
-
-When corrected by the user, the relevant `CLAUDE.md` is updated so the mistake is not repeated. Global corrections go in the global file; project-specific corrections go in the project's `CLAUDE.md`.
 
 ## Environment
 

--- a/hooks/auto-format.sh
+++ b/hooks/auto-format.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Auto-format files after Write/Edit tool use.
+# Detects project formatter (Biome > Prettier) and formats accordingly.
+# Exits 0 always (non-blocking) - formatting failure should not block edits.
+
+FILE=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Skip if no file path or file doesn't exist
+[ -z "$FILE" ] && exit 0
+[ -f "$FILE" ] || exit 0
+
+# Skip binary files
+file "$FILE" 2>/dev/null | grep -q "text" || exit 0
+
+# Skip files that formatters don't handle
+case "$FILE" in
+  *.png|*.jpg|*.gif|*.ico|*.woff|*.woff2|*.ttf|*.eot|*.lock) exit 0 ;;
+esac
+
+# Find project root (look for package.json)
+DIR=$(dirname "$FILE")
+PROJECT_ROOT=""
+while [ "$DIR" != "/" ]; do
+  [ -f "$DIR/package.json" ] && PROJECT_ROOT="$DIR" && break
+  DIR=$(dirname "$DIR")
+done
+
+# No project root found, skip
+[ -z "$PROJECT_ROOT" ] && exit 0
+
+cd "$PROJECT_ROOT" || exit 0
+
+# Try Biome first (if configured)
+if [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
+  npx biome format --write "$FILE" 2>/dev/null && exit 0
+fi
+
+# Try Prettier (if configured or available)
+if [ -f ".prettierrc" ] || [ -f ".prettierrc.json" ] || [ -f ".prettierrc.yml" ] || [ -f "prettier.config.js" ] || [ -f "prettier.config.mjs" ]; then
+  npx prettier --write "$FILE" 2>/dev/null && exit 0
+fi
+
+# Fallback: try prettier if it's in node_modules
+if [ -f "node_modules/.bin/prettier" ]; then
+  npx prettier --write "$FILE" 2>/dev/null && exit 0
+fi
+
+exit 0

--- a/hooks/watch-pr-checks.sh
+++ b/hooks/watch-pr-checks.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Watch PR CI checks in the background and send a macOS notification when done.
+# Usage: watch-pr-checks.sh [pr-number-or-url]
+# If no argument, detects the PR for the current branch.
+
+PR_REF="${1:-}"
+
+# If no PR ref given, try to get it from the current branch
+if [ -z "$PR_REF" ]; then
+  PR_REF=$(gh pr view --json number -q '.number' 2>/dev/null)
+fi
+
+if [ -z "$PR_REF" ]; then
+  exit 0
+fi
+
+PR_TITLE=$(gh pr view "$PR_REF" --json title -q '.title' 2>/dev/null || echo "PR #$PR_REF")
+
+# Poll every 30 seconds, max 60 attempts (30 minutes)
+MAX_ATTEMPTS=60
+ATTEMPT=0
+
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 30
+
+  # Get check status
+  CHECKS=$(gh pr checks "$PR_REF" 2>/dev/null)
+  if [ $? -ne 0 ]; then
+    continue
+  fi
+
+  # Count statuses
+  PENDING=$(echo "$CHECKS" | grep -c "pending\|queued\|in_progress" 2>/dev/null || echo "0")
+  FAILED=$(echo "$CHECKS" | grep -c "fail" 2>/dev/null || echo "0")
+
+  # If nothing is pending, checks are done
+  if [ "$PENDING" -eq 0 ]; then
+    if [ "$FAILED" -gt 0 ]; then
+      osascript -e "display notification \"$FAILED check(s) failed on: $PR_TITLE\" with title \"PR Checks Failed\" sound name \"Basso\""
+    else
+      osascript -e "display notification \"All checks passed on: $PR_TITLE\" with title \"PR Checks Passed\" sound name \"Glass\""
+    fi
+    exit 0
+  fi
+done
+
+# Timeout
+osascript -e "display notification \"Timed out waiting for checks on: $PR_TITLE\" with title \"PR Checks Timeout\""
+exit 0

--- a/rules/agent-routing.md
+++ b/rules/agent-routing.md
@@ -20,6 +20,12 @@ Before starting any non-trivial task, determine which expert agents are relevant
 | GTM, tags, server-side tagging, data layer, GA4, CAPI | `gtm-expert.md` | Tag management, analytics, tracking, consent mode |
 | Product, user story, prioritization, roadmap, metrics | `product-manager.md` | Feature planning, requirements, success criteria |
 | UX, usability, accessibility, WCAG, design, interaction | `ux-expert.md` | UI/UX design, accessibility, user experience |
+| Error handling, resilience, circuit breaker, retry, timeout | `backend-staff-engineer.md` | Designing failure modes, degradation patterns |
+| API design, REST, GraphQL, schema, contracts | `backend-staff-engineer.md` | Designing APIs, versioning, breaking changes |
+| Data model, schema design, normalization, ERD | `postgresql-expert.md` | Designing database structure from scratch |
+| Test strategy, test architecture, test pyramid, coverage | `qa-expert.md` | Planning test approach before implementation |
+| Performance, profiling, latency, p99, load testing | `backend-staff-engineer.md` + `frontend-staff-engineer.md` | Performance work (load both for full-stack) |
+| PR review, code review | `pr-reviewer.md` | Reviewing pull requests or code changes |
 
 ## Rules
 

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -1,5 +1,7 @@
 # Git Conventions
 
+- NEVER push directly to the default branch (master/main) - always use a feature branch and create a PR
+- NEVER merge PRs automatically - always wait for the user to merge manually
 - Never auto-commit or push - wait for explicit instructions
 - Always use conventional commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, etc.)
 - Scope is optional, e.g. `feat(auth): add token refresh`

--- a/rules/state-persistence.md
+++ b/rules/state-persistence.md
@@ -1,0 +1,17 @@
+# State Persistence
+
+All work artifacts must be saved to the project-level `.claude/state/` directory so they persist across sessions and machines.
+
+## Directories
+
+- `.claude/state/research/` - research artifacts from Phase 1
+- `.claude/state/plans/` - implementation plans from Phase 2
+- `.claude/state/sessions/` - session diary entries from Phase 5 (Summarize)
+
+## Rules
+
+- Create `.claude/state/` directories if they don't exist before writing
+- Use naming convention: `YYYY-MM-DD-descriptive-name.md`
+- Every non-trivial session should end with a summary saved to `.claude/state/sessions/`
+- Plans and research are per-project, not global
+- Check `.claude/state/` for relevant past work before starting new research

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -8,9 +8,9 @@ Fix the GitHub issue: $ARGUMENTS
 Follow this workflow:
 
 1. **Fetch**: run `gh issue view $ARGUMENTS --json title,body,labels,assignees,comments` to get full issue details
-2. **Research**: use subagents to explore the codebase and understand the problem area. Read linked files, related tests, and recent git history for the affected code.
+2. **Research**: use subagents to explore the codebase and understand the problem area. Read linked files, related tests, and recent git history. Save findings to `.claude/state/research/YYYY-MM-DD-issue-<number>.md`.
 3. **Reproduce**: if possible, write a failing test that reproduces the issue
-4. **Plan**: propose a fix plan with:
+4. **Plan**: propose a fix plan and save to `.claude/state/plans/YYYY-MM-DD-fix-issue-<number>.md` with:
    - Root cause analysis
    - Files to change (with specific line ranges)
    - Risks and edge cases

--- a/skills/review-pr/checklist.md
+++ b/skills/review-pr/checklist.md
@@ -17,11 +17,25 @@ Systematically verify each area:
 
 ## Security
 
-- [ ] No secrets in code (API keys, tokens, passwords)
+- [ ] No secrets in code (API keys, tokens, passwords, credentials)
 - [ ] No SQL injection vectors (parameterized queries only)
 - [ ] No XSS vectors (user input properly escaped)
 - [ ] Authorization checks on every mutation accessing user data
 - [ ] Input validation at system boundaries (Zod schemas)
+- [ ] No PII in logs (names, emails, phone numbers, IPs)
+- [ ] No custom cryptography (use established libraries)
+- [ ] JWT/session tokens stored securely (httpOnly cookies, not localStorage)
+- [ ] CORS policy is restrictive (no wildcard on authenticated endpoints)
+- [ ] Error responses don't leak internal details to clients
+- [ ] Dependencies free of known critical vulnerabilities
+
+## Privacy & GDPR
+
+- [ ] Personal data processing has documented lawful basis
+- [ ] Data retention periods defined for new PII fields
+- [ ] Consent collection is granular (not bundled or pre-ticked)
+- [ ] Right to erasure supported (soft delete + cleanup job)
+- [ ] No PII transferred outside EEA without safeguards (SCCs)
 
 ## Database
 


### PR DESCRIPTION
## What does this PR do?

Applies all improvements from the multi-expert analysis (architecture, security, DevOps/QA) plus state persistence and documentation updates.

## Category

- [x] Chore (dependencies, docs, config)

## Changes

### Security hardening
- Expand PR review checklist with 11 security checks (OWASP) + 5 GDPR/privacy checks
- Remove duplicate review command (attack surface reduction)

### State persistence (`.claude/state/` per project)
- Add state-persistence rule enforcing `.claude/state/` convention
- Update research, plan, summarize commands to save artifacts to `.claude/state/`
- Update fix-issue skill to persist research/plans to `.claude/state/`
- State is per-project (not global) so it works across machines

### CLAUDE.md deduplication
- Remove duplicated code standards (already in rules/typescript.md, database.md, tests.md)
- Add Phase 5 (Summarize) to workflow

### Agent improvements
- Slim pr-reviewer from 186 to ~130 lines (references skill checklist instead of duplicating)
- Expand agent routing with triggers for error handling, API design, test strategy, performance, PR review

### New commands
- `/user:ci-check` - local CI mirror (lint + typecheck + test + build)
- `/user:verify-done` - full quality gate before declaring work done

### Hooks
- `auto-format.sh` - robust formatter (detects Biome/Prettier, validates files, 30s timeout)
- `watch-pr-checks.sh` - background CI polling with macOS notifications on pass/fail

### Documentation
- Rewrite README with full repo structure, symlink setup guide, component tables
- Rewrite configuration guide covering all settings (rules, skills, commands, hooks, state, deny list)
- Update agent reference with PR Reviewer category and routing section

## Linked issues

N/A

## Review checklist

### General

- [x] Changes have been tested locally
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code