### PR TITLE
chore: add agent frontmatter, skills, references, and engineering principles

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "drawio": {
+      "command": "npx",
+      "args": ["-y", "@drawio/mcp"]
+    }
+  }
+}

--- a/agents/aws-expert.md
+++ b/agents/aws-expert.md
@@ -1,3 +1,8 @@
+---
+name: AWS Expert
+description: AWS architecture, solutions design, and cloud optimization
+---
+
 # Senior AWS Expert
 
 ## Identity

--- a/agents/backend-staff-engineer.md
+++ b/agents/backend-staff-engineer.md
@@ -1,3 +1,8 @@
+---
+name: Backend Staff Engineer
+description: High-throughput backend systems, APIs, databases, and event-driven architectures
+---
+
 # Senior Backend Staff Engineer
 
 ## Identity

--- a/agents/cybersecurity-expert.md
+++ b/agents/cybersecurity-expert.md
@@ -1,3 +1,8 @@
+---
+name: Cybersecurity Expert
+description: Application security, penetration testing, and security architecture
+---
+
 # Senior Cybersecurity Expert
 
 ## Identity

--- a/agents/devops-engineer.md
+++ b/agents/devops-engineer.md
@@ -1,3 +1,8 @@
+---
+name: DevOps Engineer
+description: Infrastructure-as-code, CI/CD pipelines, and production operations at scale
+---
+
 # Senior DevOps Engineer
 
 ## Identity

--- a/agents/frontend-staff-engineer.md
+++ b/agents/frontend-staff-engineer.md
@@ -1,3 +1,8 @@
+---
+name: Frontend Staff Engineer
+description: Frontend architecture, React/TypeScript components, and web performance
+---
+
 # Senior Frontend Staff Engineer
 
 ## Identity

--- a/agents/gcp-expert.md
+++ b/agents/gcp-expert.md
@@ -1,3 +1,8 @@
+---
+name: GCP Expert
+description: Google Cloud Platform architecture, IAM, and cloud cost optimization
+---
+
 # Senior GCP Expert
 
 ## Identity

--- a/agents/gdpr-expert.md
+++ b/agents/gdpr-expert.md
@@ -1,3 +1,8 @@
+---
+name: GDPR Expert
+description: GDPR compliance, data protection impact assessments, and privacy engineering
+---
+
 # Senior GDPR Expert
 
 ## Identity

--- a/agents/gtm-expert.md
+++ b/agents/gtm-expert.md
@@ -1,3 +1,8 @@
+---
+name: GTM Expert
+description: Google Tag Manager, server-side tagging, and measurement strategies
+---
+
 # Senior GTM Expert
 
 ## Identity

--- a/agents/networking-expert.md
+++ b/agents/networking-expert.md
@@ -1,3 +1,8 @@
+---
+name: Networking Expert
+description: Network architecture, protocols, and zero-trust security
+---
+
 # Senior Networking Expert
 
 ## Identity

--- a/agents/postgresql-expert.md
+++ b/agents/postgresql-expert.md
@@ -1,3 +1,8 @@
+---
+name: PostgreSQL Expert
+description: PostgreSQL optimization, query planning, and database operations
+---
+
 # Senior PostgreSQL Expert
 
 ## Identity

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,3 +1,8 @@
+---
+name: PR Reviewer
+description: Code review for quality, security, and maintainability
+---
+
 # Senior PR Reviewer
 
 ## Identity
@@ -18,12 +23,15 @@ You are a Senior PR Reviewer with 15+ years of experience reviewing code across 
 ## Thinking Approach
 
 1. **Understand intent first** — read the PR description, linked issues, and commit messages before looking at code
-2. **Review for correctness** — does the code do what it claims? Are edge cases handled? Are error paths covered?
-3. **Review for clarity** — can another engineer understand this code in 6 months without context?
-4. **Review for safety** — could this change break production? Is it backward-compatible? Are migrations reversible?
-5. **Review for scope** — does the PR only contain changes related to its stated goal? Flag scope creep.
-6. **Review for completeness** — are tests included? Are types accurate? Is documentation updated if needed?
-7. **Prioritize feedback** — distinguish between blockers, suggestions, and nits. Not every comment has equal weight.
+2. **Review across five axes** — evaluate every change through these lenses:
+   - **Correctness** — does the code do what it claims? Edge cases handled? Error paths covered?
+   - **Design/Architecture** — does it follow vertical slicing? Are abstractions justified? Does it respect module boundaries?
+   - **Simplicity** — could this be simpler? Is there unnecessary complexity, over-engineering, or premature abstraction?
+   - **Security** — could this change introduce vulnerabilities? See `references/security-checklist.md`
+   - **Testability** — is the code structured for testing? Are dependencies injectable? Are tests included and meaningful?
+3. **Review for safety** — could this change break production? Is it backward-compatible? Are migrations reversible?
+4. **Review for scope** — does the PR only contain changes related to its stated goal? Flag scope creep.
+5. **Prioritize feedback** — distinguish between blockers, suggestions, and nits. Not every comment has equal weight.
 
 ## Response Style
 

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -1,3 +1,8 @@
+---
+name: Product Manager
+description: Product strategy, discovery, and cross-functional execution
+---
+
 # Senior Product Manager
 
 ## Identity

--- a/agents/qa-expert.md
+++ b/agents/qa-expert.md
@@ -1,3 +1,8 @@
+---
+name: QA Expert
+description: Test strategy, test automation, and quality engineering
+---
+
 # Senior QA Expert
 
 ## Identity
@@ -18,12 +23,13 @@ You are a Senior QA Expert with 15+ years of experience in test strategy, test a
 ## Thinking Approach
 
 1. **Test at the right level** - business logic in unit tests, integration points in integration tests, critical user journeys in E2E tests
-2. **Shift left** - find defects as early as possible; a bug caught in a unit test is 100x cheaper than one caught in production
-3. **Test behavior, not implementation** - tests should survive refactoring; if changing internals breaks tests, the tests are wrong
-4. **Deterministic by default** - every test must produce the same result every time; flakiness is a defect in the test, not a feature
-5. **Fast feedback loops** - test suites that take 30+ minutes don't get run; optimize for speed without sacrificing coverage
-6. **Risk-based prioritization** - test the most critical paths first; 100% coverage is a vanity metric
-7. **Accessibility is not optional** - if it's not accessible, it's not done; test early, test often, test with real assistive technology
+2. **Prove-it pattern for bugs** - for every bug fix, first write a test that fails proving the bug exists. The fix is only valid when that test turns green. If you cannot write a failing test, you do not fully understand the bug - investigate further before coding a fix. See `references/testing-patterns.md` for the full pattern.
+3. **Shift left** - find defects as early as possible; a bug caught in a unit test is 100x cheaper than one caught in production
+4. **Test behavior, not implementation** - tests should survive refactoring; if changing internals breaks tests, the tests are wrong
+5. **Deterministic by default** - every test must produce the same result every time; flakiness is a defect in the test, not a feature
+6. **Fast feedback loops** - test suites that take 30+ minutes don't get run; optimize for speed without sacrificing coverage
+7. **Risk-based prioritization** - test the most critical paths first; 100% coverage is a vanity metric
+8. **Accessibility is not optional** - if it's not accessible, it's not done; test early, test often, test with real assistive technology
 
 ## Response Style
 

--- a/agents/staff-engineer.md
+++ b/agents/staff-engineer.md
@@ -1,3 +1,8 @@
+---
+name: Staff Engineer
+description: System design, architecture decisions, and technical leadership
+---
+
 # Senior Staff Engineer
 
 ## Identity

--- a/agents/ux-expert.md
+++ b/agents/ux-expert.md
@@ -1,3 +1,8 @@
+---
+name: UX Expert
+description: User experience design, usability, and design systems
+---
+
 # Senior UX Expert
 
 ## Identity

--- a/references/security-checklist.md
+++ b/references/security-checklist.md
@@ -1,0 +1,78 @@
+# Security Checklist
+
+Reusable security checklist mapped to OWASP Top 10. Referenced by the review-pr skill and cybersecurity agent.
+
+## Input Validation (OWASP A03: Injection)
+
+- [ ] All external input validated at system boundaries (API requests, webhooks, URL params, env vars)
+- [ ] Validation uses schema library (Zod) - not manual checks
+- [ ] SQL queries use parameterized statements or ORM methods - never string concatenation
+- [ ] GraphQL queries have depth/complexity limits
+- [ ] File uploads validated: type, size, extension, content-type header match
+- [ ] Path traversal prevented: no user input in file paths without sanitization
+
+## Output Encoding (OWASP A03: Injection, A07: XSS)
+
+- [ ] User-generated content escaped before rendering in HTML
+- [ ] Content-Security-Policy header set (no `unsafe-inline` or `unsafe-eval` without justification)
+- [ ] No `dangerouslySetInnerHTML` or `eval()` with user data
+- [ ] API responses do not leak stack traces, internal paths, or server info
+- [ ] Error messages are generic for users, detailed in logs
+
+## Authentication & Sessions (OWASP A01: Broken Access Control, A07: Identification Failures)
+
+- [ ] Passwords hashed with bcrypt, scrypt, or argon2 - never MD5/SHA
+- [ ] Session tokens are httpOnly, secure, sameSite=strict/lax
+- [ ] JWT tokens have reasonable expiry and are validated server-side
+- [ ] No auth tokens stored in localStorage - use httpOnly cookies
+- [ ] Multi-factor authentication available for sensitive operations
+- [ ] Rate limiting on login/signup/password-reset endpoints
+- [ ] Account lockout or progressive delays after failed attempts
+
+## Authorization (OWASP A01: Broken Access Control)
+
+- [ ] Every mutation/query accessing user data verifies permissions
+- [ ] No reliance on client-side checks only - server enforces all access control
+- [ ] CORS configured with explicit origins - no wildcard `*` for authenticated endpoints
+- [ ] Admin endpoints require elevated privileges and are audited
+- [ ] Principle of least privilege applied to all service accounts and IAM roles
+
+## Transport & Headers (OWASP A02: Cryptographic Failures, A05: Misconfiguration)
+
+- [ ] HTTPS only - no mixed content, HSTS header set
+- [ ] Security headers configured: X-Frame-Options, X-Content-Type-Options, Referrer-Policy
+- [ ] TLS 1.2+ required - no fallback to older protocols
+- [ ] Cookies marked secure (only sent over HTTPS)
+
+## Secrets Management (OWASP A02: Cryptographic Failures)
+
+- [ ] No secrets in source code, commit history, or CI logs
+- [ ] Secrets loaded from environment variables or secret manager (not config files)
+- [ ] `.env*`, `*.pem`, `*.key`, `credentials.json` in `.gitignore`
+- [ ] API keys scoped to minimum required permissions
+- [ ] Secrets rotated on a schedule and after any suspected exposure
+
+## Dependencies (OWASP A06: Vulnerable Components)
+
+- [ ] `npm audit` (or equivalent) runs in CI with zero critical/high vulnerabilities
+- [ ] Dependencies pinned to specific versions (lockfile committed)
+- [ ] No dependencies with known CVEs in production
+- [ ] New dependencies justified: bundle size, maintenance status, license, security posture
+- [ ] Unused dependencies removed
+
+## Database Security (OWASP A03: Injection, A04: Insecure Design)
+
+- [ ] Database credentials not hardcoded - loaded from environment/secret manager
+- [ ] Database ports not exposed to public internet
+- [ ] Migrations are backward-compatible and reversible
+- [ ] Sensitive data (PII, financial) encrypted at rest
+- [ ] Database backups encrypted and access-controlled
+- [ ] Connection pooling configured with appropriate limits
+
+## Logging & Monitoring (OWASP A09: Logging Failures)
+
+- [ ] Security events logged: auth failures, permission denials, input validation failures
+- [ ] No sensitive data in logs (passwords, tokens, PII, credit cards)
+- [ ] Structured logging with correlation IDs for traceability
+- [ ] Alerts configured for anomalous patterns (spike in auth failures, unusual access patterns)
+- [ ] No `console.log` with sensitive data in production code

--- a/references/testing-patterns.md
+++ b/references/testing-patterns.md
@@ -1,0 +1,141 @@
+# Testing Patterns
+
+Reusable testing methodology reference. Referenced by the /test skill and QA agent.
+
+## Testing Pyramid
+
+Choose the lowest test level that captures the behavior:
+
+### Unit Tests (preferred - fast, isolated, deterministic)
+
+**Use for**: business logic, utility functions, state transformations, validation rules, data formatting
+
+```text
+- Pure functions and calculations
+- State machine transitions
+- Validation logic (schema, business rules)
+- Error handling branches
+- Edge cases (empty input, boundary values, null/undefined)
+```
+
+### Integration Tests (moderate - verify boundaries)
+
+**Use for**: API endpoints, database queries, service interactions, middleware chains
+
+```text
+- API request/response contracts
+- Database queries with real/test database
+- External service integration (with test doubles at the HTTP boundary)
+- Middleware and auth flows
+- Message queue producers/consumers
+```
+
+### E2E Tests (selective - slow, brittle, expensive)
+
+**Use for**: critical user journeys only, not business logic
+
+```text
+- Login -> perform core action -> verify result
+- Checkout/payment flow (happy path + key error)
+- Onboarding/signup flow
+- Cross-service data flow verification
+```
+
+## Prove-It Pattern (Bug Fixes)
+
+Every bug fix must follow this sequence:
+
+1. **Reproduce**: write a test that triggers the exact bug
+2. **Confirm RED**: run the test - it must fail, proving the bug exists
+3. **Fix**: implement the minimum code change to fix the root cause
+4. **Confirm GREEN**: run the test - it must pass
+5. **Regression**: run the full test suite to verify nothing else broke
+
+If you cannot write a failing test, you do not fully understand the bug. Investigate further before coding a fix.
+
+## Test Data Patterns
+
+### Factory Pattern (preferred)
+
+Create test data with sensible defaults and explicit overrides:
+
+```typescript
+function createUser(overrides: Partial<User> = {}): User {
+  return {
+    id: randomUUID(),
+    name: 'Test User',
+    email: `test-${randomUUID()}@example.com`,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+// Usage
+const admin = createUser({ role: 'admin' });
+const deletedUser = createUser({ deletedAt: new Date() });
+```
+
+### Builder Pattern (for complex objects)
+
+Use when objects have many optional fields or require construction steps:
+
+```typescript
+const order = OrderBuilder.create()
+  .withCustomer(customer)
+  .withItems([item1, item2])
+  .withDiscount(10)
+  .build();
+```
+
+### Rules
+
+- Never use production data in tests
+- Never hardcode IDs, dates, or values that could collide
+- Use `faker` or random generators for string fields
+- Isolate test data per test - no shared mutable state
+
+## Mock Boundaries
+
+### What to Mock
+
+- External HTTP APIs (use `msw` or `nock` at the network boundary)
+- Time (`vi.useFakeTimers()`) when testing time-dependent logic
+- Environment variables when testing config-dependent behavior
+- File system when testing file operations
+
+### What NOT to Mock
+
+- Your own code (internal modules, utilities, helpers)
+- The database in integration tests - use a real test database
+- Third-party library internals (mock the interface you own, not the library)
+- More than 2 modules in a single test file - if you need more, you are testing at the wrong level
+
+### Test Double Types
+
+- **Stub**: returns canned data - use for queries
+- **Spy**: records calls - use for verifying side effects
+- **Fake**: simplified real implementation - use for in-memory repositories
+- **Mock**: pre-programmed expectations - use sparingly, prefer stubs
+
+## Flaky Test Prevention
+
+- No `setTimeout` or `waitForTimeout` with fixed delays - use proper wait conditions
+- No shared mutable state between tests - each test sets up and tears down its own data
+- No dependency on test execution order - every test must pass with `test.only()`
+- No reliance on wall clock time - use fake timers
+- No assertions on randomly generated data without seeding
+- No E2E tests without retry strategy (network, browser, API flakiness)
+- No file system tests without temp directory isolation
+
+## Test Naming
+
+Test names should read like specifications:
+
+```text
+- "returns empty array when no users match the filter"
+- "throws ValidationError when email format is invalid"
+- "sends notification email after successful order placement"
+- "denies access when user lacks admin role"
+```
+
+Avoid: `"test1"`, `"should work"`, `"handles edge case"`, `"user test"`

--- a/rules/engineering-principles.md
+++ b/rules/engineering-principles.md
@@ -1,0 +1,67 @@
+# Engineering Principles
+
+Universal principles that apply to all implementation work, regardless of domain or language.
+
+## Change Sizing
+
+- **Target ~100 lines per commit** - small changes are easier to review, test, and revert
+- **300 lines is acceptable** for cohesive changes that cannot be split without losing context
+- **1000+ lines must be split** - no exceptions. Break into sequential PRs or stacked commits
+- **PRs touching 15+ files need justification** - rename/migration is fine; "I was in the area" is not
+
+## Vertical Slicing
+
+Implement features as thin end-to-end slices, not horizontal layers.
+
+- **Good**: one complete feature path (UI + API + DB + test) that a user can interact with
+- **Bad**: "all database models first, then all API routes, then all UI components"
+- Each slice should be independently deployable and testable
+- If a slice is too large, narrow the scope (fewer fields, simpler validation, fewer edge cases)
+
+## Chesterton's Fence
+
+Before removing or changing existing code, understand why it exists.
+
+- Run `git blame` and read the commit message that introduced the code
+- Check linked issues or PRs for context
+- If no context exists and the code seems unnecessary, ask - do not silently remove
+- "I don't understand why this is here" is a reason to investigate, not a reason to delete
+
+## Shift Left
+
+Catch problems as early as possible in the development cycle.
+
+Priority order (earliest to latest):
+
+1. **Type system** - catch at compile time
+2. **Linting rules** - catch at save/commit time
+3. **Unit tests** - catch at test time
+4. **Integration tests** - catch at CI time
+5. **Runtime validation** - catch at execution time
+6. **Monitoring/alerting** - catch in production
+
+Prefer solutions higher on this list. If something can be caught by the type system, don't write a test for it - fix the types.
+
+## Context Hierarchy
+
+When information conflicts, follow this priority order:
+
+1. **Rules files** (rules/, CLAUDE.md) - highest authority
+2. **Specifications** (.claude/state/specs/) - agreed requirements
+3. **Source code** - current implementation
+4. **Error output** - runtime signals
+5. **Conversation history** - may be stale or misremembered
+
+## Anti-Rationalization
+
+Never accept these shortcuts, regardless of justification:
+
+| Shortcut | Common excuse | Why it's wrong |
+| --- | --- | --- |
+| Skip tests | "It's too simple to break" | Simple code becomes complex; the test catches regressions |
+| Use `any` type | "I'll fix it later" | Later never comes; `any` spreads through the codebase |
+| Skip error handling | "This can't fail" | Everything can fail; unhandled errors crash production |
+| Hardcode values | "It's just for now" | Hardcoded values become permanent; extract to config immediately |
+| Leave TODOs | "I'll come back to it" | TODOs without issue links are dead code; create a ticket or fix it now |
+| Copy-paste with tweaks | "It's faster" | Duplication diverges; extract a shared function or accept the repetition consciously |
+| Skip the spec/plan | "I already know what to do" | You know what you think you need to do; the spec catches what you missed |

--- a/rules/state-persistence.md
+++ b/rules/state-persistence.md
@@ -5,6 +5,7 @@ All work artifacts must be saved to the project-level `.claude/state/` directory
 ## Directories
 
 - `.claude/state/research/` - research artifacts from Phase 1
+- `.claude/state/specs/` - specification documents from the /spec skill
 - `.claude/state/plans/` - implementation plans from Phase 2
 - `.claude/state/sessions/` - session diary entries from Phase 5 (Summarize)
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: build
+description: "Implement code incrementally with quality gates. Use when the user says 'build', 'implement', or when starting the implementation phase of an approved plan."
+---
+
+Implement the approved plan incrementally: $ARGUMENTS
+
+Follow these disciplines:
+
+## Before Starting
+
+- Verify an approved plan exists (in `.claude/state/plans/` or the current conversation)
+- If no plan exists, stop and ask the user to run /plan first
+- Read the plan and identify the task list
+
+## Increment Rules
+
+For each task in the plan:
+
+1. **Ask**: "What is the simplest thing that could work?"
+2. **Scope**: touch only what the task requires - no drive-by refactors, no "while I'm here" changes
+3. **Slice vertically**: implement one user-visible slice at a time (UI + API + DB + test), not horizontal layers
+4. **Size check**: each increment should change ~100 lines. If approaching 300, stop and split. Never exceed 1000 lines in a single commit.
+5. **Compile continuously**: the project must build after every increment. Run typecheck after each file change.
+6. **Test alongside**: write tests as part of the increment, not as a separate step afterward
+7. **Checkpoint**: after completing each task:
+   - Run /verify-done (typecheck + lint + tests + build)
+   - If all pass, commit with a conventional commit message
+   - If any fail, fix before moving to the next task
+
+## Anti-Rationalization
+
+Refuse these shortcuts regardless of justification:
+
+- "I'll add tests later" - write them now, as part of this increment
+- "This is too simple to test" - if it has logic, it gets a test
+- "I'll clean this up in a follow-up" - clean it now or create an issue
+- "Let me just use `any` for now" - use proper types from the start
+- "I'll skip error handling for the happy path first" - handle errors as you go
+- "Let me do all the scaffolding first" - vertical slices, not horizontal layers
+
+## Feature Flags
+
+If the feature is large and will take multiple sessions:
+
+- Use a feature flag to keep incomplete work behind a toggle
+- Each increment should be independently mergeable (behind the flag)
+- The flag is removed only when the full feature is complete and tested
+
+## Completion
+
+After all tasks are done:
+
+- Run /verify-done one final time
+- Summarize what was built and what changed
+- Flag any deferred items or follow-up work as issues

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ship
+description: "Pre-launch validation and release workflow. Use when the user says 'ship', 'release', 'deploy', or 'ready to merge'."
+---
+
+Validate and ship: $ARGUMENTS
+
+## Pre-Ship Checklist
+
+Run these checks in order. Stop at the first failure.
+
+### 1. Code Quality (run /verify-done)
+
+- [ ] `npx tsc --noEmit` passes (zero type errors)
+- [ ] Linting passes (zero errors, zero warnings)
+- [ ] All tests pass (unit + integration + E2E)
+- [ ] Build succeeds
+- [ ] No debugging artifacts (`console.log`, `debugger`, `.only()`, `TODO` without issue link)
+
+### 2. Git Hygiene
+
+- [ ] Branch is rebased onto target: `git fetch origin main && git rebase origin/main`
+- [ ] No uncommitted changes: `git status` is clean
+- [ ] Commits follow conventional format (`feat:`, `fix:`, `refactor:`, etc.)
+- [ ] Each commit is atomic (one logical change per commit)
+- [ ] No merge conflict markers in code
+- [ ] No sensitive files staged (`.env`, credentials, keys)
+
+### 3. Security Review (see `references/security-checklist.md`)
+
+- [ ] No secrets in code or commit history
+- [ ] Dependencies clean: `npm audit` with zero critical/high
+- [ ] Input validation at system boundaries
+- [ ] Auth/authorization checks on new endpoints
+- [ ] Security headers configured if applicable
+
+### 4. Change Review
+
+- [ ] Summarize what changed (files, lines added/removed)
+- [ ] Flag risky changes: auth logic, migrations, public API changes, config changes
+- [ ] Verify backward compatibility for API changes
+- [ ] If migrations exist: verify they are reversible and backward-compatible
+
+### 5. Documentation
+
+- [ ] README updated if public API or setup steps changed
+- [ ] Changelog or release notes drafted if applicable
+- [ ] Architecture Decision Record written if a significant technical decision was made
+
+### 6. Version (if applicable)
+
+- Determine version bump from conventional commits:
+  - `fix:` commits = PATCH bump
+  - `feat:` commits = MINOR bump
+  - `BREAKING CHANGE:` = MAJOR bump
+- Update version in package.json if needed
+
+## Ship It
+
+If all checks pass:
+
+1. Create PR with `gh pr create` - include summary, test plan, and any deployment notes
+2. Link related issues in the PR description
+3. Request reviewers if specified
+4. Report: "READY TO SHIP - all pre-launch checks passed"
+
+If any check fails:
+
+1. List failures with specific details
+2. Stop - do NOT create the PR until all checks pass

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: spec
+description: "Define requirements before planning. Use when starting a new feature, when requirements are ambiguous, or when the user says 'write a spec' or 'define requirements'."
+---
+
+Write a specification for: $ARGUMENTS
+
+Follow this workflow:
+
+1. **Discovery**: ask the user clarifying questions before writing anything. Cover:
+   - **Who** - who is the user/audience for this feature?
+   - **What** - what exactly should it do? What is the expected behavior?
+   - **Why** - what problem does it solve? What is the success metric?
+   - **Constraints** - what technical, time, or scope constraints exist?
+   - **Boundaries** - what is explicitly out of scope?
+   - Ask all questions at once. Wait for answers before proceeding.
+
+2. **Draft the spec**: based on the answers, write a specification with these sections:
+
+```markdown
+# Spec: <title>
+
+## Problem Statement
+<What problem does this solve and for whom?>
+
+## User Stories
+- As a <role>, I want <capability> so that <benefit>
+
+## Acceptance Criteria
+- [ ] <Specific, testable criterion>
+- [ ] <Specific, testable criterion>
+
+## Non-Functional Requirements
+- Performance: <latency, throughput targets>
+- Security: <auth, data handling requirements>
+- Accessibility: <WCAG level, specific requirements>
+
+## Technical Constraints
+- <Stack, infrastructure, API compatibility requirements>
+
+## Out of Scope
+- <Explicitly excluded from this work>
+
+## Open Questions
+- <Anything unresolved that needs a decision>
+```
+
+1. **Save**: save the spec to `.claude/state/specs/YYYY-MM-DD-spec-<topic>.md`
+2. **Review**: present the spec to the user. Wait for approval before proceeding to /plan.
+3. **Iterate**: if the user has feedback, update the spec and re-present. Repeat until approved.
+
+Do NOT proceed to planning or implementation until the spec is explicitly approved.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: test
+description: "Write tests using TDD workflow. Use when the user says 'write tests', 'add tests', 'TDD', or 'prove-it pattern'."
+---
+
+Write tests for: $ARGUMENTS
+
+## Choose the Workflow
+
+### For New Features: RED-GREEN-REFACTOR
+
+1. **RED**: write a failing test that describes the expected behavior
+   - Test name reads like a specification: "returns empty array when no users match"
+   - Run the test - confirm it fails for the right reason (not a syntax error)
+2. **GREEN**: write the minimum code to make the test pass
+   - Do not optimize, do not handle edge cases yet - just make it green
+3. **REFACTOR**: improve the code while keeping tests green
+   - Extract duplication, improve naming, simplify logic
+   - Run tests after each refactor step
+4. **Repeat**: add the next test for the next behavior. Continue the cycle.
+
+### For Bug Fixes: PROVE-IT Pattern
+
+1. **Reproduce**: write a test that triggers the exact bug as reported
+2. **Confirm RED**: run the test - it must fail, proving the bug exists in code
+3. **Fix**: implement the minimum change to fix the root cause
+4. **Confirm GREEN**: run the test - it must now pass
+5. **Regression**: run the full test suite to verify nothing else broke
+
+If you cannot write a failing test, you do not fully understand the bug. Investigate further.
+
+## Test Level Selection
+
+Pick the lowest level that captures the behavior (see `references/testing-patterns.md`):
+
+| Behavior | Test Level | Why |
+| --- | --- | --- |
+| Pure logic, calculations, validation | Unit test | Fast, isolated, deterministic |
+| API request/response contracts | Integration test | Verifies real boundaries |
+| Database queries, migrations | Integration test | Needs real database behavior |
+| Critical user journeys | E2E test | Tests the full stack |
+| Visual appearance, layout | Visual regression | Screenshot comparison |
+
+## Test Quality Gates
+
+Before considering tests complete:
+
+- [ ] Happy path covered
+- [ ] Edge cases covered (empty input, boundary values, null/undefined)
+- [ ] Error paths covered (invalid input, network failure, timeout)
+- [ ] Each test is independent - passes with `test.only()`
+- [ ] No hardcoded test data - using factories or builders
+- [ ] Mocks only at module boundaries - not on internal code
+- [ ] Test names read like specifications
+- [ ] All tests pass, no flaky behavior
+- [ ] Run full test suite to check for regressions


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (`name`, `description`) to all 15 agent definitions for structured metadata
- Enhance PR reviewer agent with structured review axes (correctness, design, simplicity, security, testability)
- Add prove-it pattern to QA expert for bug fix validation
- Add new rules: engineering principles (change sizing, vertical slicing, Chesterton's fence, shift left)
- Add reference docs: security checklist and testing patterns
- Add skills: build, ship, spec, test, review-pr, fix-issue
- Add drawio MCP server config (`.mcp.json`)
- Add specs directory to state persistence rule

## Test plan
- [ ] Verify agent frontmatter is correctly parsed by Claude Code
- [ ] Verify new skills are discoverable and functional
- [ ] Verify references are accessible from agent prompts
- [ ] Verify MCP drawio server connects successfully