### PR TITLE
chore: ban non-null assertion operator in TypeScript rules

### DIFF
--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -14,3 +14,4 @@ description: "TypeScript coding standards"
 - Zod schemas for runtime validation at system boundaries (API inputs, env vars, external data)
 - Prefer `const` over `let`, never use `var`
 - Use strict null checks - handle `null`/`undefined` explicitly
+- No non-null assertion operator (`!`) - use proper null checks, optional chaining, or narrowing instead


### PR DESCRIPTION
## Summary
- Add rule to `rules/typescript.md` banning the non-null assertion operator (`!`)
- Preferred alternatives: proper null checks, optional chaining (`?.`), or type narrowing

## Test plan
- [ ] Verify the rule renders correctly in `rules/typescript.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)