### PR TITLE
feat: add CI/MR skills, typecheck hook, and notify script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Out of the box, Claude Code is capable but generic. This configuration adds opin
 CLAUDE.md                      # Core rules (workflow, security, behavioral constraints)
 agents/                        # 15 expert agent personas
 commands/                      # Slash commands for frequent workflows
-hooks/                         # Automation scripts (formatting, PR watching)
+hooks/                         # Automation scripts (formatting, typechecking)
 rules/                         # Modular instruction files (always-loaded + path-scoped)
+scripts/                       # Utility scripts (notifications)
 skills/                        # Reusable workflows with supporting files
 docs/                          # Reference documentation
 pull_request_template.md       # Default PR template
@@ -35,6 +36,7 @@ ln -sf ~/dev/claude/rules ~/.claude/rules
 ln -sf ~/dev/claude/skills ~/.claude/skills
 ln -sf ~/dev/claude/commands ~/.claude/commands
 ln -sf ~/dev/claude/hooks ~/.claude/hooks
+ln -sf ~/dev/claude/scripts ~/.claude/scripts
 ```
 
 ## Components
@@ -80,6 +82,8 @@ Reusable workflows invoked on-demand. Cost ~200 tokens when idle (metadata only)
 | `ship` | `/ship` | Pre-launch validation and release workflow |
 | `fix-issue` | `/fix-issue 1234` | Full issue resolution: fetch, research, plan, implement, test, PR |
 | `review-pr` | `/review-pr 567` | Structured PR review with BLOCKER/ISSUE/SUGGESTION/NIT/PRAISE severity |
+| `ci` | `/ci` | Monitor CI pipeline status, analyze failures, propose fixes. Use with `/loop 2m /ci` for auto-polling |
+| `mr` | `/mr` | Create MR/PR with template, conventional commit checks, and stacked MR/PR dependency support |
 
 ### Commands (`commands/`)
 
@@ -100,9 +104,18 @@ Automation scripts triggered at lifecycle events. Configured in `~/.claude/setti
 | Hook | Event | Purpose |
 | --- | --- | --- |
 | `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
+| `post-edit-typecheck.sh` | PostToolUse (Write/Edit) | Run typecheck and lint on .ts/.tsx files after edits |
 | `watch-pr-checks.sh` | PostToolUse (gh pr create) | Poll CI checks in background, notify on pass/fail |
 | Notification | Notification | macOS desktop notification when Claude needs input |
 | Compact reminder | SessionStart (compact) | Re-inject workflow context after compaction |
+
+### Scripts (`scripts/`)
+
+Utility scripts referenced by skills and hooks.
+
+| Script | Purpose |
+| --- | --- |
+| `notify.sh` | Send macOS desktop notification unless a terminal or IDE is in the foreground |
 
 ### State (`.claude/state/` per project)
 

--- a/hooks/post-edit-typecheck.sh
+++ b/hooks/post-edit-typecheck.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Post-edit hook: run typecheck and lint for .ts/.tsx files
+# Uses npm scripts if available, falls back to npx tsc / npm run lint
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only process .ts and .tsx files
+case "$FILE" in
+  *.ts|*.tsx) ;;
+  *) exit 0 ;;
+esac
+
+# Walk up to find the nearest package.json
+DIR=$(dirname "$FILE")
+while [[ "$DIR" != "/" && "$DIR" != "." ]]; do
+  if [[ -f "$DIR/package.json" ]]; then
+    cd "$DIR"
+
+    # Typecheck: prefer npm script, fall back to npx tsc
+    HAS_TYPECHECK=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.typecheck ? 0 : 1)" 2>/dev/null && echo yes || echo no)
+    if [[ "$HAS_TYPECHECK" == "yes" ]]; then
+      npm run typecheck 2>&1
+    else
+      npx tsc --noEmit 2>&1
+    fi
+    TC_EXIT=$?
+
+    # Lint: prefer lint:fix, fall back to lint
+    HAS_LINT_FIX=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.['lint:fix'] ? 0 : 1)" 2>/dev/null && echo yes || echo no)
+    HAS_LINT=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.lint ? 0 : 1)" 2>/dev/null && echo yes || echo no)
+    if [[ "$HAS_LINT_FIX" == "yes" ]]; then
+      npm run lint:fix 2>&1
+    elif [[ "$HAS_LINT" == "yes" ]]; then
+      npm run lint 2>&1
+    fi
+    LF_EXIT=$?
+
+    if [[ $TC_EXIT -ne 0 ]]; then
+      exit $TC_EXIT
+    fi
+    exit $LF_EXIT
+  fi
+  DIR=$(dirname "$DIR")
+done

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Send a macOS desktop notification unless a terminal emulator or IDE is in the foreground.
+# Usage: ~/.claude/scripts/notify.sh "your message here"
+
+MSG="${1:-Claude Code needs your input}"
+
+# Apps where the user is likely already seeing Claude output
+FOREGROUND_APPS="wezterm-gui|Ghostty|iTerm2|Alacritty|kitty|Terminal|Code|Cursor"
+
+FRONT_APP=$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null)
+
+if echo "$FRONT_APP" | grep -qE "$FOREGROUND_APPS"; then
+  exit 0
+fi
+
+osascript -e "display notification \"$MSG\" with title \"Claude Code\" sound name \"default\""

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -1,0 +1,48 @@
+# Monitor CI Pipeline
+
+Use `/loop 2m /ci` to poll CI every 2 minutes automatically.
+
+## Workflow
+
+1. **Detect VCS platform**: `.gitlab-ci.yml` -> glab, `.github/` -> gh
+2. **Check pipeline status** (non-interactive commands only):
+   - GitLab: `glab ci status`
+   - GitHub: `gh pr checks` or `gh run list --branch <current-branch>`
+3. **If pipeline is still running**: report current status and stop (the /loop will re-invoke)
+4. **If pipeline passes**:
+   - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"`
+   - Report success and stop
+5. **If pipeline fails**:
+   a. Fetch the job log:
+      - GitLab: `glab ci trace <job-id>`
+      - GitHub: `gh run view <run-id> --log-failed`
+   b. Do NOT pipe output through head, tail, grep, or any other command - run the commands directly
+   c. Analyze the root cause - identify the specific failure (test, lint, type check, build, coverage, etc.)
+   d. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
+   e. **Propose the fix to the user** - explain what failed and what you'd change. Do NOT push automatically
+   f. Wait for user approval before implementing the fix
+   g. After approval: fix, commit with a descriptive message, push
+
+## Important: Non-interactive commands only
+
+These commands require a TTY and will NOT work - never use them:
+
+- `glab ci view` (interactive TUI)
+- `gh run watch` (interactive watcher)
+- Any command with `--web` flag (opens browser)
+
+Safe commands to use:
+
+- `glab ci status`, `glab ci list`, `glab ci trace <job-id>`
+- `gh pr checks`, `gh run list`, `gh run view <run-id> --log-failed`
+
+## Loop cleanup
+
+If invoked via `/loop`, call `CronDelete` to cancel the polling job once the pipeline reaches a terminal state (passed or failed). Don't leave it running.
+
+## Guardrails
+
+- After 3 consecutive failures on the **same issue**, stop and escalate - something structural is wrong
+- Never weaken tests, skip linting, or lower coverage thresholds to make CI pass
+- Never use `--no-verify` or skip hooks
+- If a failure looks unrelated to your changes (flaky test, infra issue), flag it to the user rather than trying to fix it

--- a/skills/mr/SKILL.md
+++ b/skills/mr/SKILL.md
@@ -1,0 +1,51 @@
+# Create Merge Request / Pull Request
+
+## Workflow
+
+1. **Detect VCS platform**: check for `.gitlab-ci.yml` (-> glab) or `.github/` (-> gh)
+2. **Determine base branch**:
+   - Default for GitLab repos: `main`
+   - Default for GitHub repos: `develop`
+   - If the user specifies a different target, use that instead
+3. **Review all commits on the branch**: run `git log <base>..HEAD` and `git diff <base>...HEAD` to understand the full changeset
+4. **Ensure conventional commits**: all commits on the branch should use conventional commit format
+5. **Check for env-specific values**: scan diff for hard-coded URLs, credentials, environment names that look wrong for the target branch
+6. **Push branch** with `-u` flag
+7. **Create MR/PR using the template**:
+   - If `.github/pull_request_template.md` or `.gitlab/merge_request_templates/` exists, use that template
+   - Otherwise use `~/.claude/pull_request_template.md`
+   - Fill in the description explaining what changed and why
+   - Check the relevant category box(es) - exactly one or more of: Bugfix, Feature, Refactor, Chore, CI/CD, Infrastructure
+   - Check "Changes have been tested locally" only if tests were actually run
+   - Check "No unnecessary changes outside the scope of this PR" only if true
+   - Check "Considered the security impact of these changes" - always check, we always consider it
+   - Check "No credentials or secrets in the code" only if verified
+   - Do NOT edit the template structure, wording, or add extra sections - only fill in data and check boxes
+8. **Set dependencies for stacked MRs/PRs**:
+   If the target branch is not the default branch (`main`/`master`/`develop`), check for a base MR/PR:
+
+   **GitLab:**
+   - Find the base MR: `glab mr list --source-branch <target-branch>`
+   - If found, create a blocking dependency after MR creation:
+
+     ```sh
+     glab api --method POST "projects/<url-encoded-project-path>/merge_requests/<our-iid>/blocks" \
+       -f "blocking_merge_request_iid=<base-mr-iid>"
+     ```
+
+   - HTTP 409 is fine - GitLab may auto-detect some dependencies
+   - Mention in description: `> **Stacked MR**: depends on !<base-iid>. Retarget to main after !<base-iid> is merged.`
+
+   **GitHub:**
+   - Find the base PR: `gh pr list --head <target-branch> --json number,title --jq '.[0]'`
+   - GitHub has no native dependency enforcement. Instead, add `Depends on #<base-pr-number>` in the PR description (under Linked Issues or similar). This is a widely recognized convention that third-party apps (e.g., Dependent Issues, PR Dependencies) can enforce via status checks.
+   - Mention in description: `> **Stacked PR**: depends on #<base-pr-number>. Retarget to main/develop after #<base-pr-number> is merged.`
+
+9. **Report**: print the MR/PR URL. If a dependency was set, mention it.
+
+## Rules
+
+- Use CLI tools (`gh pr create` / `glab mr create`), not MCP tools or APIs (except `glab api` for MR dependencies - `glab mr create` has no dependency flag)
+- Pass the body via HEREDOC for correct formatting
+- If auth fails, stop and ask the user to authenticate - do not retry
+- If the repo has a specific MR template, prefer it over the default


### PR DESCRIPTION
## What does this PR do?

Contributes four self-contained additions from my personal `~/.claude` setup back to the upstream repo:

- **`/ci` skill** - CI pipeline monitoring with `/loop` integration, failure analysis, and non-interactive command guardrails (supports both glab and gh)
- **`/mr` skill** - MR/PR creation with stacked dependency support, template detection, and conventional commit enforcement (supports both glab and gh)
- **`post-edit-typecheck.sh` hook** - Runs typecheck and lint:fix on .ts/.tsx files after Write/Edit operations (complementary to the existing `auto-format.sh`)
- **`notify.sh` script** - macOS desktop notification utility that skips notification when a terminal emulator (WezTerm, Ghostty, iTerm2, Alacritty, Kitty, Terminal) or IDE (VS Code, Cursor) is in the foreground

All additions are self-contained - no changes to CLAUDE.md or existing rules/skills/hooks.

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

> N/A

## Review checklist

### General

- [ ] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant