### PR TITLE
feat: track settings.json, add pre-PR test gate, and harden deny list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+settings.json text eol=lf filter=strip-ephemeral-state

--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ ln -sf ~/dev/claude/commands ~/.claude/commands
 ln -sf ~/dev/claude/hooks ~/.claude/hooks
 ln -sf ~/dev/claude/scripts ~/.claude/scripts
 ln -sf ~/dev/claude/settings.json ~/.claude/settings.json
+
+# Configure smudge/clean filter to strip ephemeral state from settings.json
+git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState)" 2>/dev/null || cat'
+git config filter.strip-ephemeral-state.smudge cat
 ```
 
-> **Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. These changes will show as uncommitted diffs - just discard them with `git checkout settings.json`.
+> **Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. The smudge/clean filter in `.gitattributes` automatically strips this before git sees it, so `git status` stays clean.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Out of the box, Claude Code is capable but generic. This configuration adds opin
 
 ```text
 CLAUDE.md                      # Core rules (workflow, security, behavioral constraints)
+settings.json                  # Global settings (hooks, deny list, permissions)
 agents/                        # 15 expert agent personas
 commands/                      # Slash commands for frequent workflows
 hooks/                         # Automation scripts (formatting, typechecking)
@@ -37,7 +38,10 @@ ln -sf ~/dev/claude/skills ~/.claude/skills
 ln -sf ~/dev/claude/commands ~/.claude/commands
 ln -sf ~/dev/claude/hooks ~/.claude/hooks
 ln -sf ~/dev/claude/scripts ~/.claude/scripts
+ln -sf ~/dev/claude/settings.json ~/.claude/settings.json
 ```
+
+> **Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. These changes will show as uncommitted diffs - just discard them with `git checkout settings.json`.
 
 ## Components
 
@@ -99,10 +103,11 @@ Slash commands for frequent workflows. Available as `/user:<name>`.
 
 ### Hooks (`hooks/`)
 
-Automation scripts triggered at lifecycle events. Configured in `~/.claude/settings.json`.
+Automation scripts triggered at lifecycle events. Configured in `settings.json` (symlinked to `~/.claude/settings.json`).
 
 | Hook | Event | Purpose |
 | --- | --- | --- |
+| `pre-pr-test-gate.sh` | PreToolUse (gh pr create) | Block PR creation if tests fail |
 | `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
 | `post-edit-typecheck.sh` | PostToolUse (Write/Edit) | Run typecheck and lint on .ts/.tsx files after edits |
 | `watch-pr-checks.sh` | PostToolUse (gh pr create) | Poll CI checks in background, notify on pass/fail |
@@ -131,8 +136,10 @@ Session artifacts saved at the project level so they persist across sessions and
 
 ## Security
 
-- Comprehensive deny list in `settings.json` blocking 35+ sensitive file patterns
-- Bash command restrictions blocking destructive operations (`rm -rf`, `git push --force`, `sudo`)
+- Comprehensive deny list in `settings.json` blocking 35+ sensitive file patterns (env files, SSH/GPG keys, credentials, cloud configs, shell history)
+- Bash command restrictions blocking destructive operations (`rm -rf`, `git push --force`, `sudo`, `DROP TABLE`)
+- Lock file protection prevents edits to `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+- PreToolUse gate blocks PR creation when tests fail
 - PostToolUse formatting hook validates files before processing
 - Agent guardrails enforce security checks across all domains
 

--- a/hooks/pre-pr-test-gate.sh
+++ b/hooks/pre-pr-test-gate.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Pre-PR test gate: block PR creation if tests fail.
+# Runs as a PreToolUse hook on Bash(gh pr create *).
+# Exit code 2 blocks the action and sends the error message to Claude.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate on gh pr create
+case "$COMMAND" in
+  *"gh pr create"*) ;;
+  *) exit 0 ;;
+esac
+
+# Find project root (look for package.json)
+DIR="${CLAUDE_PROJECT_DIR:-.}"
+PROJECT_ROOT=""
+while [ "$DIR" != "/" ]; do
+  [ -f "$DIR/package.json" ] && PROJECT_ROOT="$DIR" && break
+  DIR=$(dirname "$DIR")
+done
+
+# No package.json - skip (not a JS/TS project)
+[ -z "$PROJECT_ROOT" ] && exit 0
+
+cd "$PROJECT_ROOT" || exit 0
+
+# Check if a test script exists
+HAS_TEST=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.test ? 0 : 1)" 2>/dev/null && echo yes || echo no)
+
+if [ "$HAS_TEST" != "yes" ]; then
+  exit 0
+fi
+
+# Run tests
+echo "Running tests before PR creation..."
+TEST_OUTPUT=$(npm test 2>&1)
+TEST_EXIT=$?
+
+if [ $TEST_EXIT -ne 0 ]; then
+  echo "Tests failed - fix before creating PR:"
+  echo "$TEST_OUTPUT" | tail -20
+  exit 2
+fi
+
+echo "All tests passed."
+exit 0

--- a/hooks/pre-pr-test-gate.sh
+++ b/hooks/pre-pr-test-gate.sh
@@ -34,7 +34,7 @@ fi
 
 # Run tests
 echo "Running tests before PR creation..."
-TEST_OUTPUT=$(npm test 2>&1)
+TEST_OUTPUT=$(CI=true npm test 2>&1)
 TEST_EXIT=$?
 
 if [ $TEST_EXIT -ne 0 ]; then

--- a/settings.json
+++ b/settings.json
@@ -43,15 +43,26 @@
       "Edit(~/.gnupg/**)",
       "Edit(~/.aws/**)",
       "Edit(~/.npmrc)",
+      "Edit(~/.netrc)",
       "Edit(~/.docker/config.json)",
       "Edit(~/.gitconfig)",
+      "Edit(~/.kube/**)",
+      "Edit(~/.config/gcloud/**)",
+      "Edit(~/.azure/**)",
       "Edit(**/*.pem)",
       "Edit(**/*.key)",
       "Edit(**/*-key.json)",
       "Write(**/.env)",
       "Write(**/.env.*)",
       "Write(~/.ssh/**)",
+      "Write(~/.gnupg/**)",
       "Write(~/.aws/**)",
+      "Write(~/.kube/**)",
+      "Write(~/.config/gcloud/**)",
+      "Write(~/.azure/**)",
+      "Write(~/.npmrc)",
+      "Write(~/.netrc)",
+      "Write(~/.gitconfig)",
       "Write(~/.docker/config.json)",
       "Write(**/*.pem)",
       "Write(**/*.key)",
@@ -92,7 +103,7 @@
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/pre-pr-test-gate.sh 2>/dev/null || ~/.claude/hooks/pre-pr-test-gate.sh 2>/dev/null",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 120
           }
         ]
@@ -145,16 +156,6 @@
           {
             "type": "command",
             "command": "echo 'Reminder: follow the 4-phase workflow (Research - Plan - Annotate - Implement). Check loaded rules and agent routing. Run tests before declaring done.'"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "INPUT=$(cat); if [ \"$(echo \"$INPUT\" | jq -r '.stop_hook_active')\" = \"true\" ]; then exit 0; fi; exit 0"
           }
         ]
       }

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(~/.ssh/**)",
+      "Read(~/.gnupg/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gcloud/**)",
+      "Read(~/.kube/**)",
+      "Read(~/.docker/config.json)",
+      "Read(~/.npmrc)",
+      "Read(~/.netrc)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/*.pfx)",
+      "Read(**/*.jks)",
+      "Read(**/*-key.json)",
+      "Read(**/service-account*.json)",
+      "Read(**/credentials.json)",
+      "Read(**/.vault-token)",
+      "Read(**/.htpasswd)",
+      "Read(~/.git-credentials)",
+      "Read(~/.gitconfig)",
+      "Read(**/.terraform.tfstate*)",
+      "Read(~/.terraformrc)",
+      "Read(~/.config/terraform/**)",
+      "Read(~/.yarnrc.yml)",
+      "Read(~/.yarnrc)",
+      "Read(~/.pnpmrc)",
+      "Read(~/.config/npm/**)",
+      "Read(~/.zsh_history)",
+      "Read(~/.bash_history)",
+      "Read(~/.config/Code/User/globalStorage/**)",
+      "Read(**/*.kubeconfig)",
+      "Read(~/.config/gke-gcloud-auth-plugin/**)",
+      "Read(~/.azure/**)",
+      "Edit(**/.env)",
+      "Edit(**/.env.*)",
+      "Edit(~/.ssh/**)",
+      "Edit(~/.gnupg/**)",
+      "Edit(~/.aws/**)",
+      "Edit(~/.npmrc)",
+      "Edit(~/.docker/config.json)",
+      "Edit(~/.gitconfig)",
+      "Edit(**/*.pem)",
+      "Edit(**/*.key)",
+      "Edit(**/*-key.json)",
+      "Write(**/.env)",
+      "Write(**/.env.*)",
+      "Write(~/.ssh/**)",
+      "Write(~/.aws/**)",
+      "Write(~/.docker/config.json)",
+      "Write(**/*.pem)",
+      "Write(**/*.key)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(dd *)",
+      "Bash(mkfs *)",
+      "Bash(shred *)",
+      "Bash(chmod * ~/.ssh/*)",
+      "Bash(chmod * ~/.gnupg/*)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard *)",
+      "Bash(git clean -fd *)",
+      "Bash(git clean -f *)",
+      "Bash(git push origin master *)",
+      "Bash(git push origin main *)",
+      "Bash(git push * master)",
+      "Bash(git push * main)",
+      "Bash(gh pr merge *)",
+      "Edit(**/package-lock.json)",
+      "Edit(**/yarn.lock)",
+      "Edit(**/pnpm-lock.yaml)",
+      "Write(**/package-lock.json)",
+      "Write(**/yarn.lock)",
+      "Write(**/pnpm-lock.yaml)",
+      "Bash(*DROP TABLE*)",
+      "Bash(*DROP DATABASE*)",
+      "Bash(*TRUNCATE TABLE*)"
+    ]
+  },
+  "effortLevel": "high",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/pre-pr-test-gate.sh 2>/dev/null || ~/.claude/hooks/pre-pr-test-gate.sh 2>/dev/null",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/auto-format.sh 2>/dev/null || ~/.claude/hooks/auto-format.sh 2>/dev/null || true",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/post-edit-typecheck.sh 2>/dev/null || ~/.claude/hooks/post-edit-typecheck.sh 2>/dev/null || true",
+            "timeout": 60
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "nohup bash -c '~/.claude/hooks/watch-pr-checks.sh' >/dev/null 2>&1 &",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude Code needs your attention\" with title \"Claude Code\"'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Reminder: follow the 4-phase workflow (Research - Plan - Annotate - Implement). Check loaded rules and agent routing. Run tests before declaring done.'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); if [ \"$(echo \"$INPUT\" | jq -r '.stop_hook_active')\" = \"true\" ]; then exit 0; fi; exit 0"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Evaluated [@zodchiii's "8 Claude Code Hooks"](https://x.com/zodchiii/status/2040000216456143002) thread and integrated the ideas that add genuine value. Also tracks `settings.json` in git so hooks, deny list, and permissions are version-controlled and reproducible across machines. Addressed findings from security, DevOps, and code quality reviews.

## How `settings.json` works

```
~/dev/claude/settings.json  (tracked in git - source of truth)
        |
        | ln -sf
        v
~/.claude/settings.json  (symlink - Claude Code reads this)
```

A `.gitattributes` smudge/clean filter strips ephemeral `feedbackSurveyState` before git sees it, so `git status` stays clean even though Claude Code writes runtime state to the file.

## Changes

### `settings.json` (new - tracked, symlinked to `~/.claude/settings.json`)
- **PreToolUse hook**: `pre-pr-test-gate.sh` blocks `gh pr create` if `npm test` fails (120s timeout). Uses `if/else` existence check to preserve exit codes (not `||` which would mask exit code 2).
- **PostToolUse hooks**: `auto-format.sh` + `post-edit-typecheck.sh` chain on every Write/Edit
- **PostToolUse hook**: `watch-pr-checks.sh` monitors CI in background after PR creation
- **Notification hook**: macOS notification when Claude needs input
- **SessionStart hook**: workflow reminder after compaction
- **Deny list (45+ patterns)**:
  - Read/Edit/Write symmetry for all sensitive paths (`~/.gnupg`, `~/.kube`, `~/.config/gcloud`, `~/.azure`, `~/.npmrc`, `~/.netrc`, `~/.gitconfig`)
  - Env files, SSH keys, credentials, cloud configs, shell history
  - Lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`)
  - Destructive bash (`rm -rf`, `sudo`, `git push --force`, `git reset --hard`)
  - SQL destructive ops (`DROP TABLE`, `DROP DATABASE`, `TRUNCATE TABLE`)

### `hooks/pre-pr-test-gate.sh` (new)
- Runs `CI=true npm test` before allowing `gh pr create`
- Finds project root by walking up to nearest `package.json`
- Skips gracefully if no test script exists
- Exit code 2 blocks PR creation, shows last 20 lines of test output

### `.gitattributes` (new)
- Smudge/clean filter `strip-ephemeral-state` strips `feedbackSurveyState` from settings.json before staging
- Requires one-time setup: `git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState)" 2>/dev/null || cat'`

### `README.md` (updated)
- Added `settings.json` to repo structure
- Added symlink + git filter setup instructions
- Added `pre-pr-test-gate.sh` to hooks table
- Updated security section with deny list details

## Review findings addressed

| Finding | Severity | Fix |
|---------|----------|-----|
| `\|\|` fallback masks exit code 2 in PreToolUse | BLOCKER | Changed to `if/else` existence check with `exec` |
| Deny list Write/Edit gaps for sensitive paths | MEDIUM | Added Write/Edit for gnupg, kube, gcloud, azure, npmrc, netrc, gitconfig |
| Jest `--watch` mode in non-TTY | MEDIUM | Added `CI=true` to `npm test` |
| Stop hook is dead code (no-op) | LOW | Removed |
| Ephemeral state dirties git status | BLOCKER | Added `.gitattributes` smudge/clean filter |

## Evaluated and skipped

| Hook from tweet | Reason skipped |
|------|--------|
| Auto-format | Already exists with Biome > Prettier detection |
| Run tests after every edit | Too slow; typecheck+lint is the right tradeoff |
| Command logging | Marginal value over conversation history |
| Auto-commit | Contradicts git-conventions.md ("Never auto-commit") |
| Block dangerous commands | Already covered by deny list patterns |

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Inspired by https://x.com/zodchiii/status/2040000216456143002

## Review checklist

### General

- [x] Changes have been tested locally
- [x] No unnecessary changes outside the scope of this PR
- [x] Reviewed by 3 expert agents (security, DevOps, code quality)
- [x] All review findings addressed

### Security

- [x] No credentials or secrets in committed files
- [x] settings.json uses `~` and `$CLAUDE_PROJECT_DIR` - no absolute user paths
- [x] Read/Edit/Write deny symmetry verified for all sensitive paths
- [x] Hook scripts reviewed for command injection, path traversal, quoting

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] README updated with setup instructions and documentation