### PR TITLE
ci: add Telegram notifications workflow

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,0 +1,29 @@
+# ==============================================
+# Pull Request Notifications
+# ==============================================
+# Sends Telegram notifications for PR events
+# using the notify.yml reusable workflow.
+
+name: Notifications
+
+on:
+  pull_request:
+    types: [opened, closed, synchronize, labeled, review_requested]
+    branches: [master]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    uses: domengabrovsek/github-actions/.github/workflows/notify.yml@master
+    with:
+      api_url: ${{ vars.TELEGRAM_API_URL }}
+      chat_id: ${{ vars.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/notifications.yml` that triggers the reusable `domengabrovsek/github-actions/.github/workflows/notify.yml` workflow
- Sends Telegram notifications for PR opened/closed/synchronize/labeled/review_requested, review submissions, review comments, and issue comments
- Mirrors the setup already in use in the `personal-api` repo

## Test plan
- [ ] Ensure repo variables `TELEGRAM_API_URL` and `TELEGRAM_CHAT_ID` are set under Settings -> Secrets and variables -> Actions -> Variables
- [ ] Verify a Telegram notification is received when this PR is opened