### PR TITLE
chore: prefer options object for 3+ params in TypeScript

### DIFF
--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -8,6 +8,7 @@ description: "TypeScript coding standards"
 - No `any` or `unknown` - use proper types, generics, or branded types
 - 2-space indentation, single quotes
 - Prefer `interface` over `type` for object shapes (unless union/intersection needed)
+- Prefer an options object when a function takes 3+ parameters, or when any parameter is optional. Destructure inside the function body. Exceptions: tightly coupled, order-intuitive positional params where the order IS the contract (e.g., `clamp(value, min, max)`, `range(start, end, step)`, `lerp(a, b, t)`), and variadic/rest functions. Boolean parameters should always be passed via an options object regardless of count - avoid "flag soup" like `doThing(true, false, true)`
 - Destructure imports when possible: `import { foo } from 'bar'`
 - No barrel exports (`index.ts` re-exports) - import directly from source
 - No default exports - use named exports only


### PR DESCRIPTION
## Summary

- Add a TypeScript rule to `rules/typescript.md` preferring an options object when a function takes 3+ parameters, or when any parameter is optional.
- Call out explicit exceptions so the rule does not fight natural positional signatures: tightly coupled order-intuitive params (`clamp`, `range`, `lerp`), and variadic/rest functions.
- Require that boolean parameters always go through an options object regardless of count, to avoid "flag soup" like `doThing(true, false, true)`.

## Why

Positional parameters get unreadable past 2 args and force `undefined` placeholders as soon as a mid-list optional is skipped. An options object fixes readability, forward compatibility (adding an optional field is non-breaking), and boolean call-site clarity. The rule is scoped to TS/JS because Python already has native keyword args and Go/Rust have their own idioms.

## Test plan

- [ ] Confirm the new bullet sits alongside the other "shape of code" bullets in `rules/typescript.md` and matches the existing dash/no-trailing-period style.
- [ ] In a fresh Claude Code session, ask for a TS function with 4 inputs and verify it uses an options object.
- [ ] Ask for `clamp(value, min, max)` and verify the exception is respected (keeps positional params).
- [ ] Ask for a function with boolean flags and verify they are passed via the options object, not positional.