### PR TITLE
feat(ci): use Monitor tool instead of /loop polling

### DIFF
--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -1,27 +1,38 @@
 # Monitor CI Pipeline
 
-Use `/loop 2m /ci` to poll CI every 2 minutes automatically.
-
 ## Workflow
 
 1. **Detect VCS platform**: `.gitlab-ci.yml` -> glab, `.github/` -> gh
-2. **Check pipeline status** (non-interactive commands only):
-   - GitLab: `glab ci status`
-   - GitHub: `gh pr checks` or `gh run list --branch <current-branch>`
-3. **If pipeline is still running**: report current status and stop (the /loop will re-invoke)
-4. **If pipeline passes**:
-   - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"`
-   - Report success and stop
-5. **If pipeline fails**:
-   a. Fetch the job log:
-      - GitLab: `glab ci trace <job-id>`
-      - GitHub: `gh run view <run-id> --log-failed`
-   b. Do NOT pipe output through head, tail, grep, or any other command - run the commands directly
-   c. Analyze the root cause - identify the specific failure (test, lint, type check, build, coverage, etc.)
-   d. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
-   e. **Propose the fix to the user** - explain what failed and what you'd change. Do NOT push automatically
-   f. Wait for user approval before implementing the fix
-   g. After approval: fix, commit with a descriptive message, push
+2. **Start a Monitor** with the matching script:
+   - GitHub: `bash ~/.claude/skills/ci/scripts/gh-ci-monitor.sh`
+   - GitLab: `bash ~/.claude/skills/ci/scripts/glab-ci-monitor.sh`
+   - Use `persistent: false`, `timeout_ms: 3600000` (1 hour ceiling — CI pipelines can be long)
+   - Description: "CI pipeline on <branch-name>"
+3. **React to Monitor notifications**:
+   - `no-runs|<branch>`: no CI runs found for this branch — inform the user and stop
+   - `error|persistent-failure`: the monitor script hit 5 consecutive errors — report and stop
+   - Status change (e.g., `in_progress|null` → `completed|success`): acknowledge briefly
+   - **Pipeline passes** (`completed|success`):
+     - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"`
+     - Report success
+   - **Pipeline fails** (`completed|failure` or any non-success conclusion):
+     a. Fetch the job log:
+        - GitLab: `glab ci trace <job-id>`
+        - GitHub: `gh run view <run-id> --log-failed`
+     b. Do NOT pipe output through head, tail, grep, or any other command - run the commands directly
+     c. Analyze the root cause - identify the specific failure (test, lint, type check, build, coverage, etc.)
+     d. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
+     e. **Propose the fix to the user** - explain what failed and what you'd change. Do NOT push automatically
+     f. Wait for user approval before implementing the fix
+     g. After approval: fix, commit with a descriptive message, push
+
+## How it works
+
+The monitor scripts poll CI status every 30 seconds but only emit a line when the status **changes**. This means:
+- Zero token cost while the pipeline is running and status hasn't changed
+- Claude reacts within ~30s of a status change (vs up to 2 min with /loop)
+- No CronDelete cleanup needed — the script exits on terminal state, ending the Monitor
+- If `gh`/`glab` fails 5 times in a row (auth expired, network down), the script exits with an error notification
 
 ## Important: Non-interactive commands only
 
@@ -35,10 +46,6 @@ Safe commands to use:
 
 - `glab ci status`, `glab ci list`, `glab ci trace <job-id>`
 - `gh pr checks`, `gh run list`, `gh run view <run-id> --log-failed`
-
-## Loop cleanup
-
-If invoked via `/loop`, call `CronDelete` to cancel the polling job once the pipeline reaches a terminal state (passed or failed). Don't leave it running.
 
 ## Guardrails
 

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -29,6 +29,7 @@
 ## How it works
 
 The monitor scripts poll CI status every 30 seconds but only emit a line when the status **changes**. This means:
+
 - Zero token cost while the pipeline is running and status hasn't changed
 - Claude reacts within ~30s of a status change (vs up to 2 min with /loop)
 - No CronDelete cleanup needed — the script exits on terminal state, ending the Monitor

--- a/skills/ci/scripts/gh-ci-monitor.sh
+++ b/skills/ci/scripts/gh-ci-monitor.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Monitor GitHub CI status for the current branch.
+# Emits a line to stdout ONLY when status changes.
+# Exits when the pipeline reaches a terminal state.
+set -euo pipefail
+
+branch=$(git branch --show-current)
+prev=""
+error_count=0
+
+while true; do
+  cur=$(gh run list --branch "$branch" --limit 1 --json status,conclusion \
+    --jq '.[0] | "\(.status)|\(.conclusion)"' 2>/dev/null) || cur="error|unknown"
+
+  # No CI runs found — jq produces "null|null"
+  if [ "$cur" = "null|null" ]; then
+    echo "no-runs|$branch"
+    exit 0
+  fi
+
+  # Track consecutive errors
+  if [[ "$cur" == error* ]]; then
+    error_count=$((error_count + 1))
+    if [ "$error_count" -ge 5 ]; then
+      echo "error|persistent-failure"
+      exit 1
+    fi
+  else
+    error_count=0
+  fi
+
+  if [ "$cur" != "$prev" ]; then
+    echo "$cur"
+    prev="$cur"
+    # Exit on any completed status regardless of conclusion
+    if [[ "$cur" == completed\|* ]]; then
+      exit 0
+    fi
+  fi
+
+  sleep 30
+done

--- a/skills/ci/scripts/glab-ci-monitor.sh
+++ b/skills/ci/scripts/glab-ci-monitor.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Monitor GitLab CI status for the current branch.
+# Emits a line to stdout ONLY when status changes.
+# Exits when the pipeline reaches a terminal state.
+set -euo pipefail
+
+prev=""
+error_count=0
+
+while true; do
+  raw=$(glab ci status 2>/dev/null) || raw="error|unknown"
+  cur="${raw%%$'\n'*}"
+
+  # Track consecutive errors
+  if [[ "$cur" == error* ]]; then
+    error_count=$((error_count + 1))
+    if [ "$error_count" -ge 5 ]; then
+      echo "error|persistent-failure"
+      exit 1
+    fi
+  else
+    error_count=0
+  fi
+
+  if [ "$cur" != "$prev" ]; then
+    echo "$cur"
+    prev="$cur"
+    case "$cur" in
+      *passed*|*failed*|*canceled*|*skipped*) exit 0 ;;
+    esac
+  fi
+
+  sleep 30
+done


### PR DESCRIPTION
## What does this PR do?

- Replace `/loop`-based CI polling with Claude Code's Monitor tool
- Add standalone shell scripts (`gh-ci-monitor.sh`, `glab-ci-monitor.sh`) that poll every 30s and only emit on status change
- Rewrite `/ci` skill to launch a Monitor instead of `/loop`, react to notifications for pass/fail
- Benefits: zero token cost while waiting, ~30s reaction time (vs ~2m), no CronDelete cleanup needed

## Category

- [x] Feature

## Linked issues

None

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code