### PR TITLE
fix(ci): use pull_request_target for notifications to support fork PRs

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -3,11 +3,20 @@
 # ==============================================
 # Sends Telegram notifications for PR events
 # using the notify.yml reusable workflow.
+#
+# SAFETY: uses pull_request_target (not pull_request) so vars.* are
+# available for fork PRs. This is only safe because the reusable
+# workflow chain never runs `actions/checkout` and never executes any
+# code from the PR head - it only reads event payload metadata. Do NOT
+# add `actions/checkout` (or anything that fetches the PR head ref) to
+# this workflow or to the upstream notify.yml chain without re-doing
+# the security review, or this becomes the classic pull_request_target
+# pwn pattern.
 
 name: Notifications
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed, synchronize, labeled, review_requested]
     branches: [master]
   issue_comment:


### PR DESCRIPTION
## What does this PR do?

Switches the Notifications workflow trigger from `pull_request` to `pull_request_target` so `vars.TELEGRAM_API_URL` and `vars.TELEGRAM_CHAT_ID` resolve for PRs opened from forks. Without this, fork PRs (like #20) reach `send-telegram-message.yml` with empty inputs and `curl` exits with code 3 ("URL malformed").

Adds an inline SAFETY comment pinning the no-checkout invariant: this is only safe because the upstream `notify.yml` chain never runs `actions/checkout` and never executes any code from the PR head. Adding checkout (or any code execution from the PR head ref) would turn this into the classic `pull_request_target` pwn pattern.

## Category

- [x] Bugfix
- [x] CI/CD

## Linked issues

Failing checks on #20: `notify / pr-updated / notify / Send Telegram Message` and `notify / pr-merged / notify / Send Telegram Message`.

## Review checklist

### General

- [ ] Changes have been tested locally _(workflow trigger change - cannot fully validate before merge; will be confirmed by the next fork PR)_
- [ ] Tests have been added or updated where needed _(N/A - workflow-only)_
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant

## Security review

Reviewed by Cybersecurity Expert and DevOps Engineer agents. Both approve.

**Why `pull_request_target` is safe here**: the upstream `notify.yml` chain (`pr-opened.yml`, `pr-updated.yml`, `pr-merged.yml`, `pr-closed.yml`, `pr-review-requested.yml`, `pr-commented.yml`, `pr-review.yml`, `pr-review-comment.yml`, `send-telegram-message.yml`) was audited for shell injection via attacker-controlled PR metadata (title, branch name, author, commit messages, comment bodies). Every event field flows through one of two safe paths:

1. `${{ github.event.pull_request.X }}` interpolated into a `with: message:` input value (workflow-call input passing, never re-parsed as shell)
2. Built inside an `actions/github-script` JS block via `context.payload.X` (object access, no template literals)

Both paths funnel into `send-telegram-message.yml`, which uses `env: MESSAGE_TEXT: ${{ inputs.message }}` plus `jq -n --arg text "$MESSAGE_TEXT"`. Bash parameter expansion does not re-parse the value as code, so the chain is closed end-to-end.

Workflow permissions remain `contents: read` + `pull-requests: read`. No expansion needed and no `id-token` scope.

## Optional follow-ups (not in this PR)

- Pin `domengabrovsek/github-actions/.github/workflows/notify.yml` to a commit SHA instead of `@master` for supply-chain hygiene.
- Promote `TELEGRAM_API_URL` / `TELEGRAM_CHAT_ID` from vars to secrets if you want them masked in run logs (low impact: a chat ID and webhook URL alone do not let an attacker post to the chat).