### PR TITLE
fix(ci): aggregate all PR checks instead of single workflow run

### DIFF
--- a/skills/ci/scripts/gh-ci-monitor.sh
+++ b/skills/ci/scripts/gh-ci-monitor.sh
@@ -1,21 +1,63 @@
 #!/usr/bin/env bash
 # Monitor GitHub CI status for the current branch.
+# Uses `gh pr checks` to aggregate ALL checks for the PR.
+# Falls back to `gh run list` (all runs, not just one) when no PR exists.
 # Emits a line to stdout ONLY when status changes.
 # Exits when the pipeline reaches a terminal state.
 set -euo pipefail
 
 branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number --jq '.number' 2>/dev/null) || pr_number=""
 prev=""
 error_count=0
 
 while true; do
-  cur=$(gh run list --branch "$branch" --limit 1 --json status,conclusion \
-    --jq '.[0] | "\(.status)|\(.conclusion)"' 2>/dev/null) || cur="error|unknown"
+  if [ -n "$pr_number" ]; then
+    # Primary path: aggregate all PR checks via gh pr checks
+    gh pr checks "$pr_number" >/dev/null 2>&1
+    ec=$?
+    case $ec in
+      0) cur="completed|success" ;;
+      1) cur="completed|failure" ;;
+      8) cur="in_progress|null" ;;
+      *) cur="error|exit-$ec" ;;
+    esac
+  else
+    # Fallback: no PR yet — check ALL runs for the branch, not just one
+    lines=$(gh run list --branch "$branch" --json status,conclusion \
+      --jq '.[] | "\(.status)|\(.conclusion)"' 2>/dev/null) || lines=""
 
-  # No CI runs found — jq produces "null|null"
-  if [ "$cur" = "null|null" ]; then
-    echo "no-runs|$branch"
-    exit 0
+    if [ -z "$lines" ]; then
+      echo "no-runs|$branch"
+      exit 0
+    fi
+
+    # Aggregate: any in_progress → in_progress; any failure → failure; all success → success
+    has_pending=false
+    has_failure=false
+    all_completed=true
+
+    while IFS='|' read -r status conclusion; do
+      if [ "$status" != "completed" ]; then
+        all_completed=false
+        has_pending=true
+      elif [ "$conclusion" != "success" ] && [ "$conclusion" != "skipped" ]; then
+        has_failure=true
+      fi
+    done <<< "$lines"
+
+    if [ "$all_completed" = true ] && [ "$has_failure" = true ]; then
+      cur="completed|failure"
+    elif [ "$all_completed" = true ]; then
+      cur="completed|success"
+    elif [ "$has_pending" = true ]; then
+      cur="in_progress|null"
+    else
+      cur="error|unknown"
+    fi
+
+    # Re-check for PR in case it was created after push
+    pr_number=$(gh pr view --json number --jq '.number' 2>/dev/null) || pr_number=""
   fi
 
   # Track consecutive errors


### PR DESCRIPTION
## What does this PR do?

- Fix CI monitor script reporting false success when only one workflow run passes
- Replace `gh run list --limit 1` with `gh pr checks` to aggregate ALL checks for the PR
- Add fallback path that checks all runs (not just one) when no PR exists yet
- Re-detect PR creation each loop iteration so the script upgrades to `gh pr checks` automatically

### Problem

`gh run list --limit 1` returns only the single most recent workflow run. Repos with multiple parallel workflows (e.g. PR Title Lint, Code Linting, Security Scan, Deploy) would report `completed|success` as soon as any one workflow passed, completely missing failures in others.

Observed in aw-front: PR Title Lint failed, but Code Linting completed first with success. The monitor reported green while the PR was actually red.

### Solution

`gh pr checks` aggregates all checks for a PR and encodes the result in exit codes:
- Exit 0: all checks passed
- Exit 1: at least one check failed
- Exit 8: checks still pending

## Category

- [x] Bugfix

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change