### PR TITLE
fix(ci): remove errexit to prevent gh pr checks exit 8 killing monitor

### DIFF
--- a/skills/ci/scripts/gh-ci-monitor.sh
+++ b/skills/ci/scripts/gh-ci-monitor.sh
@@ -4,7 +4,9 @@
 # Falls back to `gh run list` (all runs, not just one) when no PR exists.
 # Emits a line to stdout ONLY when status changes.
 # Exits when the pipeline reaches a terminal state.
-set -euo pipefail
+set -uo pipefail
+# Note: no -e — gh pr checks uses non-standard exit codes (8 = pending)
+# that would terminate the script under errexit
 
 branch=$(git branch --show-current)
 pr_number=$(gh pr view --json number --jq '.number' 2>/dev/null) || pr_number=""


### PR DESCRIPTION
## What does this PR do?

- Remove `set -e` (errexit) from `gh-ci-monitor.sh` to prevent `gh pr checks` exit code 8 (pending) from terminating the script
- Keep `set -uo pipefail` for unset variable protection and pipe failure detection
- All non-zero exit codes from `gh pr checks` are already handled explicitly in the `case` statement

### Problem

`gh pr checks` uses non-standard exit codes: 0 = all pass, 1 = failure, **8 = pending**. With `set -e`, exit code 8 terminates the script immediately instead of continuing to poll — the monitor dies on the first check while CI is still running.

### Root cause

The previous fix (PR #24) replaced `gh run list` with `gh pr checks` but kept `set -euo pipefail`. The `gh pr checks` call on line 17 isn't guarded by `|| true` or a subshell, so `errexit` catches exit code 8 before the `ec=$?` on line 18 can capture it.

## Category

- [x] Bugfix

## Review checklist

### General

- [x] Changes have been tested locally
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change