### PR TITLE
feat(rtk): integrate RTK CLI proxy for token optimization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,5 @@ Detailed git, testing, and exploration rules are in `rules/` (git-conventions, e
 - Cloud: GCP primary, AWS secondary
 - Current year: 2026 - verify when generating dates, timestamps, or date-dependent logic
 - Access boundaries: .env files, credentials, and secrets are blocked by deny rules - do not attempt workarounds. For Sentry, staging databases, and external services requiring auth, ask the user for credentials or URLs rather than trying to authenticate
+
+@RTK.md

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ ln -sf ~/dev/claude/commands ~/.claude/commands
 ln -sf ~/dev/claude/hooks ~/.claude/hooks
 ln -sf ~/dev/claude/scripts ~/.claude/scripts
 ln -sf ~/dev/claude/settings.json ~/.claude/settings.json
+ln -sf ~/dev/claude/RTK.md ~/.claude/RTK.md
 ln -sf ~/dev/claude/scripts/statusline.sh ~/.claude/statusline.sh
 
 # Configure smudge/clean filter to strip ephemeral state from settings.json
@@ -47,6 +48,42 @@ git config filter.strip-ephemeral-state.smudge cat
 ```
 
 > **Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. The smudge/clean filter in `.gitattributes` automatically strips this before git sees it, so `git status` stays clean.
+
+## RTK (Token Optimization)
+
+[RTK](https://github.com/rtk-ai/rtk) is a CLI proxy written in Rust that sits between Claude Code and the shell. It intercepts common commands (`git status`, `npm test`, `grep`, `docker`, etc.), strips noise the model doesn't need (passing tests, progress bars, ASCII borders), and returns a compressed version. Reported savings are 60-90% tokens on typical dev operations, which translates to more exchanges per session before hitting rate limits.
+
+The integration lives in this repo:
+
+- `RTK.md` - meta-command reference, imported into every session via `@RTK.md` in `CLAUDE.md`
+- `rtk/config.toml` - tracked config with tee mode on (`failures`), telemetry off, default exclusions
+- `settings.json` - `PreToolUse` Bash hook that rewrites commands transparently
+
+### Installing RTK
+
+```bash
+# Install the binary and initialize the Claude Code hook
+brew install rtk
+rtk init -g --hook-only   # hook-only: the repo provides RTK.md
+
+# Symlink the tracked config (macOS)
+mkdir -p ~/Library/Application\ Support/rtk
+ln -sf ~/dev/claude/rtk/config.toml ~/Library/Application\ Support/rtk/config.toml
+
+# Verify
+rtk --version
+rtk config          # should print the symlinked config
+rtk gain            # token savings analytics
+```
+
+### Safety note
+
+RTK filters what the model sees. During complex debugging (e.g. correlating timeouts across services), compression can hide patterns that matter. Two mitigations are configured:
+
+- **Tee mode** (`failures`) preserves the full unfiltered output whenever a command fails, so raw data is always recoverable.
+- **`exclude_commands`** in `rtk/config.toml` lets you bypass filtering for specific commands when raw output is non-negotiable (prod DB sessions, incident log tailing).
+
+Use `rtk proxy <cmd>` for a one-shot unfiltered run without editing config.
 
 ## Components
 

--- a/RTK.md
+++ b/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/rtk/config.toml
+++ b/rtk/config.toml
@@ -1,0 +1,61 @@
+# RTK (Rust Token Killer) configuration
+# Upstream: https://github.com/rtk-ai/rtk
+#
+# Symlink this file to the rtk config location on your platform:
+#   macOS:  ~/Library/Application Support/rtk/config.toml
+#   Linux:  ~/.config/rtk/config.toml
+#
+# Verify with: rtk config
+
+[tracking]
+enabled = true
+history_days = 90
+
+[display]
+colors = true
+emoji = true
+max_width = 120
+
+[filters]
+# Directories rtk skips when summarising trees, greps, finds.
+ignore_dirs = [
+    ".git",
+    "node_modules",
+    "target",
+    "__pycache__",
+    ".venv",
+    "vendor",
+]
+ignore_files = [
+    "*.lock",
+    "*.min.js",
+    "*.min.css",
+]
+
+[tee]
+# Keep tee ON in "failures" mode so the full unfiltered output is preserved
+# whenever a command fails. This is the safety net for debugging cases where
+# rtk's compression hides the pattern that matters (e.g. repeated timeouts
+# across services being collapsed into one).
+enabled = true
+mode = "failures"
+max_files = 20
+max_file_size = 1048576
+
+[telemetry]
+# Opt-out by default. Flip to true only if you want to send usage data upstream.
+enabled = false
+consent_given = false
+
+[hooks]
+# Commands to bypass rtk filtering entirely. Add commands here when raw output
+# matters more than token savings (e.g. production DB sessions, incident log
+# tailing). Empty by default — extend per machine if needed.
+exclude_commands = []
+
+[limits]
+grep_max_results = 200
+grep_max_per_file = 25
+status_max_files = 15
+status_max_untracked = 10
+passthrough_max_chars = 2000

--- a/settings.json
+++ b/settings.json
@@ -105,6 +105,10 @@
             "if": "Bash(gh pr create *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 120
+          },
+          {
+            "type": "command",
+            "command": "command -v rtk >/dev/null 2>&1 && rtk hook claude || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Integrates [RTK](https://github.com/rtk-ai/rtk) — a Rust CLI proxy that sits between Claude Code and the shell, filtering noise from common dev commands (git, tests, grep, docker, aws, psql, etc.) before output reaches the model. Reported savings are 60-90% tokens on typical dev operations, which translates to roughly 3x more exchanges per session before hitting rate limits.

### What this PR adds

- **Hook**: `settings.json` gains a `PreToolUse` Bash entry running `rtk hook claude` so commands are transparently rewritten. Guarded with `command -v rtk` so machines without rtk installed aren't broken.
- **Meta-command reference**: `RTK.md` tracked at repo root and imported via `@RTK.md` in `CLAUDE.md` so the meta commands (`rtk gain`, `rtk discover`, `rtk proxy`) are discoverable every session.
- **Config**: `rtk/config.toml` tracks safe defaults — tee mode ON in `failures` mode (full unfiltered output preserved on any failure), telemetry OFF, empty `exclude_commands` for per-machine tuning.
- **README**: new "RTK (Token Optimization)" section with setup commands, symlink targets per platform, and the safety caveat (compression can hide patterns across services during complex debugging — tee mode and `rtk proxy` are the escape hatches).

### Safety note

RTK filters what the model sees. During complex debugging (e.g. correlating timeouts across services), compression can hide patterns that matter. Mitigations configured by default:

- `tee.mode = "failures"` preserves raw output whenever a command exits non-zero
- `exclude_commands` list for commands where raw output is non-negotiable
- `rtk proxy <cmd>` escape hatch for one-shot unfiltered runs

## Test plan

- [ ] `rtk --version` prints `rtk 0.37.1` or later
- [ ] Symlink `rtk/config.toml` → `~/Library/Application Support/rtk/config.toml`; `rtk config` prints the symlinked file
- [ ] Symlink `settings.json` → `~/.claude/settings.json` (separate follow-up if live/repo still diverge)
- [ ] Symlink `RTK.md` → `~/.claude/RTK.md`
- [ ] Open a new Claude Code session; confirm `@RTK.md` is loaded (assistant should be aware of `rtk gain`, `rtk discover`)
- [ ] Run `rtk gain` after a few sessions to verify token savings tracking
- [ ] Run `rtk discover` to surface commands that could be filtered
- [ ] Trigger a command that fails (e.g. failing test); confirm tee produces a recoverable unfiltered log file