### PR TITLE
chore: reconcile live settings drift into tracked config

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,27 +1,47 @@
-#!/bin/bash
-# Claude Code status line - version controlled, symlink to ~/.claude/statusline.sh
-# Setup: ln -sf ~/dev/claude/scripts/statusline.sh ~/.claude/statusline.sh
+#!/bin/sh
+# ANSI color codes
+RESET='\033[0m'
+BOLD='\033[1m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+GREEN='\033[32m'
+RED='\033[31m'
+DIM='\033[2m'
 
 input=$(cat)
+cwd=$(echo "$input" | jq -r '.cwd')
+folder=$(basename "$cwd")
 
-MODEL=$(echo "$input" | jq -r '.model.display_name // empty')
-DIR=$(echo "$input" | jq -r '.workspace.current_dir // empty')
+# Git branch
+branch=$(git -C "$cwd" -c core.hooksPath=/dev/null symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
 
-# Git info (if in a repo)
-BRANCH=$(git -C "$DIR" branch --show-current 2>/dev/null)
-REPO=$(basename "$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)
-
-# Node version (if .nvmrc or package.json exists)
-NODE_V=""
-if [ -f "$DIR/.nvmrc" ] || [ -f "$DIR/package.json" ]; then
-  NODE_V=$(node -v 2>/dev/null)
+# Git dirty indicator: fast porcelain check, limit output to avoid slow large repos
+if [ -n "$branch" ]; then
+  dirty=$(git -C "$cwd" -c core.hooksPath=/dev/null status --porcelain 2>/dev/null | head -1)
+  if [ -n "$dirty" ]; then
+    git_color="$RED"
+    git_marker="*"
+  else
+    git_color="$GREEN"
+    git_marker=""
+  fi
 fi
 
-# Build status line
-parts=""
-[ -n "$MODEL" ] && parts="$MODEL"
-[ -n "$REPO" ] && parts="$parts | $REPO"
-[ -n "$BRANCH" ] && parts="$parts ($BRANCH)"
-[ -n "$NODE_V" ] && parts="$parts | node $NODE_V"
+# Node version: prefer .nvmrc (fast file read), fall back to node -v
+node_version=""
+if [ -f "$cwd/.nvmrc" ]; then
+  node_version="v$(cat "$cwd/.nvmrc" | tr -d '[:space:]')"
+elif command -v node >/dev/null 2>&1; then
+  node_version=$(node -v 2>/dev/null)
+fi
 
-echo "$parts"
+# Build output
+printf "${BOLD}${CYAN}%s${RESET}" "$folder"
+
+if [ -n "$branch" ]; then
+  printf " ${DIM}on${RESET} ${git_color}%s%s${RESET}" "$branch" "$git_marker"
+fi
+
+if [ -n "$node_version" ]; then
+  printf " ${DIM}node${RESET} ${YELLOW}%s${RESET}" "$node_version"
+fi

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "autoUpdatesChannel": "stable",
+  "minimumVersion": "2.1.92",
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  },
   "permissions": {
     "deny": [
       "Read(**/.env)",
@@ -8,6 +16,11 @@
       "Read(~/.gnupg/**)",
       "Read(~/.aws/**)",
       "Read(~/.config/gcloud/**)",
+      "Read(~/.config/gh/hosts.yml)",
+      "Read(~/.gradle/gradle.properties)",
+      "Read(~/.pypirc)",
+      "Read(~/.terraform.d/**)",
+      "Read(~/.vault-token)",
       "Read(~/.kube/**)",
       "Read(~/.docker/config.json)",
       "Read(~/.npmrc)",
@@ -94,7 +107,7 @@
       "Bash(*TRUNCATE TABLE*)"
     ]
   },
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Follow-up to #27. Before this change, the live `~/.claude/settings.json` was a **1.1K real file** that had drifted from the **4.7K tracked version** — the repo's comprehensive deny list and hooks were never actually active. Now that settings.json is symlinked, this commit reconciles live-only config back into the tracked source so symlinking preserves existing behavior instead of silently stripping it.

### Settings additions (live-only → tracked)

- 5 deny entries that existed only on live: `~/.config/gh/hosts.yml`, `~/.gradle/gradle.properties`, `~/.pypirc`, `~/.terraform.d/**`, `~/.vault-token`
- `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (enables experimental agent teams)
- `autoUpdatesChannel: "stable"`
- `minimumVersion: "2.1.92"`
- `enabledPlugins.frontend-design@claude-plugins-official: true`
- `effortLevel: "high"` → `"xhigh"` to match live

### Statusline replacement

Replaced `scripts/statusline.sh` with the actually-running version from `~/.claude/statusline-command.sh`. The previous tracked script (852B, shows model name) was never wired up; the live script (1.2K, has ANSI colors, git dirty indicator, `.nvmrc` fallback) is what's actually been running on the machine. Filename stays as `statusline.sh` per the README convention — `settings.json` already points at `~/.claude/statusline.sh`.

### Symlinks created locally

After merging, the live state is:

- `~/.claude/settings.json` → `~/dev/claude/settings.json`
- `~/.claude/RTK.md` → `~/dev/claude/RTK.md`
- `~/.claude/statusline.sh` → `~/dev/claude/scripts/statusline.sh`

Pre-symlink backups saved to `~/.claude/.pre-symlink-backup/`. The orphaned `~/.claude/statusline-command.sh` is no longer referenced anywhere and can be deleted once this PR is verified.

## Test plan

- [ ] `jq -e . ~/.claude/settings.json` returns valid JSON through the symlink
- [ ] `jq '.effortLevel' ~/.claude/settings.json` returns `"xhigh"`
- [ ] `jq '(.permissions.deny | length)' ~/.claude/settings.json` returns ≥ 85
- [ ] `readlink ~/.claude/settings.json ~/.claude/RTK.md ~/.claude/statusline.sh` all show repo targets
- [ ] New Claude Code session loads without errors; statusline renders with colors + dirty indicator
- [ ] `rtk --version` still works (hook still wired)