### PR TITLE
chore(rules): ban issue/PR/ticket numbers in code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 - Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
 - Complete code only - no TODOs, no placeholders, no incomplete implementations
 - Use Context7 MCP to pull latest docs when working with specific technologies (NestJS, PostgreSQL, Drizzle, etc.) - don't rely on potentially outdated training knowledge
+- Never reference issue, PR, or ticket numbers in code comments (no `pentla-api#535`, `PR #561`, `(#545)`, `Fixes #123`, etc.). They rot as soon as trackers move, and the PR description or git blame is the right place for that context. Comments should describe the WHY in self-contained prose.
 - Detailed standards are in rules/ (typescript, tests, database, infrastructure, security)
 
 ## Docs Sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 - Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
 - Complete code only - no TODOs, no placeholders, no incomplete implementations
 - Use Context7 MCP to pull latest docs when working with specific technologies (NestJS, PostgreSQL, Drizzle, etc.) - don't rely on potentially outdated training knowledge
-- Never reference issue, PR, or ticket numbers in code comments (no `pentla-api#535`, `PR #561`, `(#545)`, `Fixes #123`, etc.). They rot as soon as trackers move, and the PR description or git blame is the right place for that context. Comments should describe the WHY in self-contained prose.
+- Never reference issue, PR, or ticket numbers in code comments (no `owner/repo#535`, `PR #561`, `(#545)`, `Fixes #123`, `JIRA-1234`, etc.). They rot as soon as trackers move, and the PR description or git blame is the right place for that context. Comments should describe the WHY in self-contained prose.
 - Detailed standards are in rules/ (typescript, tests, database, infrastructure, security)
 
 ## Docs Sync


### PR DESCRIPTION
## Summary

Adds a single rule to `CLAUDE.md`:

> Never reference issue, PR, or ticket numbers in code comments (no `owner/repo#535`, `PR #561`, `(#545)`, `Fixes #123`, `JIRA-1234`, etc.). They rot as soon as trackers move, and the PR description or git blame is the right place for that context. Comments should describe the WHY in self-contained prose.

Tracker references go stale the moment a ticket is renamed, migrated, closed, or deleted. The PR description and `git blame` are durable; comments should describe the WHY in self-contained prose.

## Test plan

- [ ] CI markdown lint passes
- [ ] Rule is picked up in a new Claude Code session (ask the assistant to write a comment referencing `#123` - it should decline or rewrite without the reference)