### PR TITLE
chore: replace em dash with hyphen in rtk config comment

### DIFF
--- a/rtk/config.toml
+++ b/rtk/config.toml
@@ -50,7 +50,7 @@ consent_given = false
 [hooks]
 # Commands to bypass rtk filtering entirely. Add commands here when raw output
 # matters more than token savings (e.g. production DB sessions, incident log
-# tailing). Empty by default — extend per machine if needed.
+# tailing). Empty by default - extend per machine if needed.
 exclude_commands = []
 
 [limits]


### PR DESCRIPTION
## Summary

Fixes a single em dash that slipped into `rtk/config.toml:53` via #27. Global CLAUDE.md rule is "Never use em dashes anywhere - use a regular hyphen/dash instead".

One-character replacement: em-dash -> hyphen.

## Out of scope

A full-repo sweep turned up **49 more em dash occurrences** in pre-existing files (`agents/pr-reviewer.md`, `skills/ci/**`, and likely others). Those predate this session and are intentionally not touched here. Leaving the call on whether to do a repo-wide sweep to a separate PR since it would touch many agent/skill prompts and may warrant a review pass.

## Test plan

- [ ] `grep "\xe2\x80\x94" rtk/config.toml` returns nothing
- [ ] Markdown lint still passes