### PR TITLE
fix(mr): require explicit approval before MR/PR creation

### DIFF
--- a/skills/mr/SKILL.md
+++ b/skills/mr/SKILL.md
@@ -11,7 +11,12 @@
 4. **Ensure conventional commits**: all commits on the branch should use conventional commit format
 5. **Check for env-specific values**: scan diff for hard-coded URLs, credentials, environment names that look wrong for the target branch
 6. **Push branch** with `-u` flag
-7. **Create MR/PR using the template**:
+7. **Preview and wait for approval**:
+   - Print the planned MR/PR title, the fully filled-in description body, and the target branch to the chat
+   - Explicitly stop and wait for the user to confirm in a subsequent turn (e.g. "go", "create it", "lgtm")
+   - Ambiguous or non-committal replies do not count as approval — ask again rather than proceed
+   - Do NOT call `gh pr create` / `glab mr create` until that explicit confirmation arrives
+8. **Create MR/PR using the template**:
    - If `.github/pull_request_template.md` or `.gitlab/merge_request_templates/` exists, use that template
    - Otherwise use `~/.claude/pull_request_template.md`
    - Fill in the description explaining what changed and why
@@ -21,7 +26,7 @@
    - Check "Considered the security impact of these changes" - always check, we always consider it
    - Check "No credentials or secrets in the code" only if verified
    - Do NOT edit the template structure, wording, or add extra sections - only fill in data and check boxes
-8. **Set dependencies for stacked MRs/PRs**:
+9. **Set dependencies for stacked MRs/PRs**:
    If the target branch is not the default branch (`main`/`master`/`develop`), check for a base MR/PR:
 
    **GitLab:**
@@ -41,7 +46,7 @@
    - GitHub has no native dependency enforcement. Instead, add `Depends on #<base-pr-number>` in the PR description (under Linked Issues or similar). This is a widely recognized convention that third-party apps (e.g., Dependent Issues, PR Dependencies) can enforce via status checks.
    - Mention in description: `> **Stacked PR**: depends on #<base-pr-number>. Retarget to main/develop after #<base-pr-number> is merged.`
 
-9. **Report**: print the MR/PR URL. If a dependency was set, mention it.
+10. **Report**: print the MR/PR URL. If a dependency was set, mention it.
 
 ## Rules
 
@@ -49,3 +54,7 @@
 - Pass the body via HEREDOC for correct formatting
 - If auth fails, stop and ask the user to authenticate - do not retry
 - If the repo has a specific MR template, prefer it over the default
+- Never reference local Claude artifacts (research notes, plans, session summaries under `.claude/state/`, etc.) in the MR/PR description — they only have value locally and mean nothing to reviewers
+- Never pass `--yes` or any other non-interactive auto-accept flag to `glab mr create` / `gh pr create`
+- This approval gate applies even when auto mode is active — auto mode is not a license to open MRs/PRs without a human checkpoint
+- **Scope of the approval gate**: the gate is specifically on the `glab mr create` / `gh pr create` invocation. Related operations that happen before it — pushing the branch, drafting the body, transitioning the Jira ticket — do not need a separate prompt once MR creation itself has been approved in the same turn


### PR DESCRIPTION
## What does this PR do?

Tightens the `/mr` skill so it never auto-creates an MR/PR without an explicit in-turn user approval, even under auto mode. Adds a "Preview and wait for approval" step between push and create, bans `--yes` / non-interactive flags on `glab mr create` / `gh pr create`, and clarifies that the gate is scoped to the create invocation (not push, body drafting, or Jira transitions). Also forbids referencing local Claude artifacts (research, plans, session notes) in MR/PR descriptions since they only have value locally.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

N/A

## Review checklist

### General

- [ ] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant