### PR TITLE
fix(statusline): strip leading v from .nvmrc to avoid duplicated prefix

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -30,7 +30,7 @@ fi
 # Node version: prefer .nvmrc (fast file read), fall back to node -v
 node_version=""
 if [ -f "$cwd/.nvmrc" ]; then
-  node_version="v$(cat "$cwd/.nvmrc" | tr -d '[:space:]')"
+  node_version="v$(cat "$cwd/.nvmrc" | tr -d '[:space:]' | sed 's/^v//')"
 elif command -v node >/dev/null 2>&1; then
   node_version=$(node -v 2>/dev/null)
 fi


### PR DESCRIPTION
## What does this PR do?

The statusline unconditionally prepends `v` to the `.nvmrc` contents, so projects whose `.nvmrc` already includes the prefix (e.g. `v24.14.0`) end up rendering as `vv24.14.0`. Strip any leading `v` before re-adding it so both the `.nvmrc` path and the `node -v` fallback produce a single prefix.

## Category

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant