### PR TITLE
chore: tighten setup based on insights audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 - **Existing patterns**: follow the conventions already in the codebase - consistency over personal preference
 - **Context first**: before choosing an approach, check how similar problems are already solved in the codebase - grep for existing patterns, read neighboring files, and follow established conventions rather than guessing
 - **Verification**: always run `/user:verify-done` before pushing - never push without all checks passing
+- **Atomic feature unit**: "implement" means implement + commit on a feature branch + push + open PR. Never stop after the code change. Never commit to `main`/`master` directly. If on a protected branch, create a feature branch first.
 - **Parallelization**: when a task has 2+ independent sub-tasks touching different files, split across multiple agents using git worktrees - see `rules/parallel-agents.md`
 
 Detailed git, testing, and exploration rules are in `rules/` (git-conventions, engineering-principles).

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Reusable workflows invoked on-demand. Cost ~200 tokens when idle (metadata only)
 | `review-pr` | `/review-pr 567` | Structured PR review with BLOCKER/ISSUE/SUGGESTION/NIT/PRAISE severity |
 | `ci` | `/ci` | Monitor CI pipeline status, analyze failures, propose fixes. Use with `/loop 2m /ci` for auto-polling |
 | `mr` | `/mr` | Create MR/PR with template, conventional commit checks, and stacked MR/PR dependency support |
+| `debug` | `/debug <error\|alert>` | Structured incident investigation: evidence, ranked hypotheses, minimal fix, regression test |
 
 ### Commands (`commands/`)
 
@@ -150,6 +151,7 @@ Automation scripts triggered at lifecycle events. Configured in `settings.json` 
 | Hook | Event | Purpose |
 | --- | --- | --- |
 | `pre-pr-test-gate.sh` | PreToolUse (gh pr create) | Block PR creation if tests fail |
+| `pre-push-gate.sh` | PreToolUse (git push) | Hard-block `git push` if lint/typecheck/test/build fail. Bypass with `SKIP_PUSH_GATE=1` |
 | `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
 | `post-edit-typecheck.sh` | PostToolUse (Write/Edit) | Run typecheck and lint on .ts/.tsx files after edits |
 | `watch-pr-checks.sh` | PostToolUse (gh pr create) | Poll CI checks in background, notify on pass/fail |

--- a/hooks/pre-push-gate.sh
+++ b/hooks/pre-push-gate.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Pre-push gate: block `git push` if lint/typecheck/test/build fail.
+# Runs as a PreToolUse hook on Bash(git push *).
+# Exit code 2 blocks the action and sends the error message to Claude.
+# Bypass with SKIP_PUSH_GATE=1 in the environment.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate on `git push` (and not `git push --help`, etc.)
+case "$COMMAND" in
+  *"git push --help"*|*"git push -h"*) exit 0 ;;
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+# Honor escape hatch
+if [ "$SKIP_PUSH_GATE" = "1" ]; then
+  echo "SKIP_PUSH_GATE=1 - bypassing pre-push gate." >&2
+  exit 0
+fi
+
+# Find project root: walk up looking for package.json or *.tf
+DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+PROJECT_ROOT=""
+PROJECT_TYPE=""
+while [ "$DIR" != "/" ] && [ -n "$DIR" ]; do
+  if [ -f "$DIR/package.json" ]; then
+    PROJECT_ROOT="$DIR"
+    PROJECT_TYPE="node"
+    break
+  fi
+  if ls "$DIR"/*.tf >/dev/null 2>&1; then
+    PROJECT_ROOT="$DIR"
+    PROJECT_TYPE="terraform"
+    break
+  fi
+  DIR=$(dirname "$DIR")
+done
+
+# No matching project - skip silently (Claude config repo, dotfiles, docs-only)
+[ -z "$PROJECT_ROOT" ] && exit 0
+
+cd "$PROJECT_ROOT" || exit 0
+
+run_step() {
+  local label="$1"
+  local cmd="$2"
+  echo "[pre-push-gate] $label..." >&2
+  if command -v rtk >/dev/null 2>&1; then
+    OUT=$(rtk proxy bash -c "$cmd" 2>&1)
+  else
+    OUT=$(bash -c "$cmd" 2>&1)
+  fi
+  STATUS=$?
+  if [ $STATUS -ne 0 ]; then
+    echo "[pre-push-gate] $label FAILED. Fix before pushing (or set SKIP_PUSH_GATE=1 to bypass):" >&2
+    echo "$OUT" | tail -40 >&2
+    exit 2
+  fi
+}
+
+if [ "$PROJECT_TYPE" = "node" ]; then
+  has_script() {
+    node -e "const p=require('./package.json'); process.exit(p.scripts?.['$1'] ? 0 : 1)" 2>/dev/null
+  }
+  has_script lint && run_step "lint" "CI=true npm run lint --silent"
+  has_script typecheck && run_step "typecheck" "CI=true npm run typecheck --silent"
+  has_script test && run_step "test" "CI=true npm test --silent"
+  has_script build && run_step "build" "CI=true npm run build --silent"
+fi
+
+if [ "$PROJECT_TYPE" = "terraform" ]; then
+  command -v terraform >/dev/null 2>&1 || exit 0
+  run_step "terraform fmt" "terraform fmt -check -recursive"
+  run_step "terraform validate" "terraform validate"
+fi
+
+echo "[pre-push-gate] All checks passed." >&2
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -121,6 +121,12 @@
           },
           {
             "type": "command",
+            "if": "Bash(git push *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-push-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-push-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 300
+          },
+          {
+            "type": "command",
             "command": "command -v rtk >/dev/null 2>&1 && rtk hook claude || true"
           }
         ]

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -24,8 +24,7 @@ For each task in the plan:
 4. **Compile continuously**: the project must build after every increment. Run typecheck after each file change.
 5. **Test alongside**: write tests as part of the increment, not as a separate step afterward
 6. **Checkpoint**: after completing each task:
-   - Run typecheck and lint before staging - do not rely on post-edit hooks alone
-   - Run `/user:verify-done` (typecheck + lint + tests + build)
+   - Run `/user:verify-done` (typecheck + lint + tests + build) - do not rely on post-edit hooks alone
    - If all pass, commit with a conventional commit message
    - If any fail, fix before moving to the next task - never accumulate errors across tasks
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: debug
+description: "Structured production-incident investigation. Forces evidence-first hypothesis ranking before any code change. Use when given an error message, Sentry alert, failing log, or 'investigate <X>' request."
+---
+
+Investigate the issue: $ARGUMENTS
+
+Hard rule: do NOT write any fix until Phase 3 is reached and the user (or the evidence in Phase 2) has confirmed the root cause.
+
+## Phase 1 - Evidence
+
+Gather, do not theorize. Save findings to `.claude/state/research/YYYY-MM-DD-debug-<short-slug>.md`.
+
+- Reproduce locally if feasible. Capture exact error, stack trace, request ID, timestamp.
+- Pull logs (Sentry, Cloud Run, container, browser console) for the affected window.
+- `git log -p --since='2 weeks ago' -- <suspect-paths>` to surface recent changes that touched the code path.
+- Confirm scope: how many users / requests / environments are affected.
+- Check related state: env vars set on the deployed service, DB row state, feature flags, recent deploys.
+
+If the user already supplied a hypothesis, treat it as a candidate but still gather evidence to confirm or reject.
+
+## Phase 2 - Hypotheses
+
+List 2-3 possible root causes ranked by evidence strength. For each:
+
+- **Hypothesis** - one line.
+- **Evidence for** - log lines, commits, or code paths that support it (with file:line refs).
+- **Evidence against** - what would have to be true that isn't.
+- **Cheapest verification** - what one command, query, or read would confirm or rule it out.
+
+Pick the top candidate. If two are tied or the user has a strong prior, ask the user to choose. Do not proceed to Phase 3 on a guess.
+
+## Phase 3 - Fix
+
+- Minimal change first per CLAUDE.md (1-5 lines, ideally). State the change before applying it.
+- Add a regression test that reproduces the original failure and now passes.
+- Run `/user:verify-done` (lint + typecheck + test + build).
+- Commit on a feature branch with a conventional message that names the root cause.
+- Open a PR per `mr` skill. PR body: link to the alert/log, root cause statement with evidence, and why this fix is correct.
+
+## Anti-patterns - reject these
+
+- Adding retry / fallback / try-catch as a "fix" before root cause is confirmed.
+- Introducing new abstractions, services, or workspaces as part of a debug fix.
+- Editing logs to make the symptom disappear.
+- Expanding scope ("while I'm here, let me also...").
+- Pushing before all checks pass green locally.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -9,12 +9,9 @@ Validate and ship: $ARGUMENTS
 
 Run these checks in order. Stop at the first failure.
 
-### 1. Code Quality (run /user:verify-done)
+### 1. Code Quality
 
-- [ ] `npx tsc --noEmit` passes (zero type errors)
-- [ ] Linting passes (zero errors, zero warnings)
-- [ ] All tests pass (unit + integration + E2E)
-- [ ] Build succeeds
+- [ ] Run `/user:verify-done` - stop on first failure (typecheck + lint + tests + build)
 - [ ] No debugging artifacts (`console.log`, `debugger`, `.only()`, `TODO` without issue link)
 
 ### 2. Git Hygiene
@@ -26,7 +23,7 @@ Run these checks in order. Stop at the first failure.
 - [ ] No merge conflict markers in code
 - [ ] No sensitive files staged (`.env`, credentials, keys)
 
-### 3. Security Review (load `cybersecurity-expert` agent, see `references/security-checklist.md`)
+### 3. Security Review (see `references/security-checklist.md`; invoke `cybersecurity-expert` agent for risky changes)
 
 - [ ] No secrets in code or commit history
 - [ ] Dependencies clean: `npm audit` with zero critical/high


### PR DESCRIPTION
## Summary

Audit of recent `/insights` reports (personal + work) identified pre-push verification gaps and missed PR follow-through as top friction. This batch closes those gaps and trims drift in existing skills.

- **`hooks/pre-push-gate.sh`** - new PreToolUse hook on `Bash(git push *)`. Hard-block when lint/typecheck/test/build fails. Detects node + terraform projects; skips silently elsewhere. `SKIP_PUSH_GATE=1` bypasses.
- **`skills/debug/SKILL.md`** - new structured-investigation skill: evidence first, 2-3 ranked hypotheses with for/against, minimal fix, regression test. Anti-patterns explicitly rejected (no premature retry/fallback, no scope creep).
- **`CLAUDE.md`** - new behavioral rule: "implement" is atomic (code + commit on feature branch + push + PR). No `main` commits.
- **`skills/ship/SKILL.md`** - de-duplicated verify-done checklist; cybersecurity-expert reference fixed (was load-but-never-invoke).
- **`skills/build/SKILL.md`** - dropped redundant typecheck+lint line ahead of verify-done.
- **`README.md`** - registered `/debug` skill and `pre-push-gate.sh` hook.
- **`settings.json`** - wired pre-push hook into PreToolUse with same fallback pattern as pre-pr-test-gate.

## Test plan

- [x] `bash -n hooks/pre-push-gate.sh` - syntax OK
- [x] Hook runs in claude repo (no package.json) - exits 0 silently
- [x] Hook ignores non-push commands - exits 0
- [x] `SKIP_PUSH_GATE=1` bypass works
- [ ] Push from a Node repo with broken types - confirm hard block (manual)
- [ ] Invoke `/debug "fake error"` in a session - confirm evidence-first behavior (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)