### PR TITLE
feat: Phase 1 cross-session repo lock (advisory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Slash commands for frequent workflows. Available as `/user:<name>`.
 | `summarize` | `/user:summarize` | Save session diary to `.claude/state/sessions/` |
 | `typecheck` | `/user:typecheck` | Run tsc and fix all type errors |
 | `verify-done` | `/user:verify-done` | Full quality gate before declaring work done (lint + typecheck + test + build + git status) |
+| `locks` | `/user:locks [--prune\|--release <hash>]` | List active Claude session locks across repos; prune stale; force-release |
 
 ### Hooks (`hooks/`)
 
@@ -152,6 +153,7 @@ Automation scripts triggered at lifecycle events. Configured in `settings.json` 
 | --- | --- | --- |
 | `pre-pr-test-gate.sh` | PreToolUse (gh pr create) | Block PR creation if tests fail |
 | `pre-push-gate.sh` | PreToolUse (git push) | Hard-block `git push` if lint/typecheck/test/build fail. Bypass with `SKIP_PUSH_GATE=1` |
+| `repo-lock-status.sh` | SessionStart (startup\|resume) | Phase 1 advisory notice when another live Claude session holds the repo lock. No blocking. |
 | `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
 | `post-edit-typecheck.sh` | PostToolUse (Write/Edit) | Run typecheck and lint on .ts/.tsx files after edits |
 | `watch-pr-checks.sh` | PostToolUse (gh pr create) | Poll CI checks in background, notify on pass/fail |
@@ -166,6 +168,7 @@ Utility scripts referenced by skills and hooks.
 | --- | --- |
 | `notify.sh` | Send macOS desktop notification unless a terminal or IDE is in the foreground |
 | `statusline.sh` | Status line showing model, repo, branch, and node version. Symlink to `~/.claude/statusline.sh` |
+| `repo-lock.sh` | Repo lock manager. `claim/release/check/list/prune` against `~/.claude/locks/<sha1>.json`. Used by isolation hooks. |
 
 ### State (`.claude/state/` per project)
 

--- a/commands/locks.md
+++ b/commands/locks.md
@@ -1,0 +1,15 @@
+---
+description: "List active Claude session locks across all repos. Shows live sessions, stale locks, and pruning controls."
+---
+
+Run `~/.claude/scripts/repo-lock.sh list` and report:
+
+- Each lock's repo path, session_id, pid, branch, claimed_at, last_seen, and live/stale flag
+- Sessions that hold a lock on the current repo (if any)
+
+If $ARGUMENTS contains:
+
+- `--prune` - run `~/.claude/scripts/repo-lock.sh prune` to remove stale locks
+- `--release <hash>` or `--release <repo-path>` - run with FORCE=1 to free a stuck lock
+
+Otherwise just show the listing. Do not modify anything without an explicit flag.

--- a/hooks/repo-lock-status.sh
+++ b/hooks/repo-lock-status.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# SessionStart hook (Phase 1, advisory only): if another live Claude session
+# holds the repo lock, surface a notice. Does NOT block. Phase 2 will add
+# claim + heartbeat; Phase 3 will add a PreToolUse guard.
+
+set -u
+
+SCRIPT="$CLAUDE_PROJECT_DIR/scripts/repo-lock.sh"
+[ -x "$SCRIPT" ] || SCRIPT="$HOME/.claude/scripts/repo-lock.sh"
+[ -x "$SCRIPT" ] || exit 0
+
+# Only run inside a git repo
+git -C "$PWD" rev-parse --show-toplevel >/dev/null 2>&1 || exit 0
+
+OUT=$("$SCRIPT" check 2>/dev/null)
+STATUS=$?
+
+if [ $STATUS -eq 1 ]; then
+  PID=$(echo "$OUT" | jq -r '.pid')
+  BRANCH=$(echo "$OUT" | jq -r '.branch')
+  CLAIMED=$(echo "$OUT" | jq -r '.claimed_at')
+  SID=$(echo "$OUT" | jq -r '.session_id')
+  cat <<EOF
+NOTICE: another Claude session is active on this repo.
+  pid=$PID  session=$SID  branch=$BRANCH  claimed_at=$CLAIMED
+Recommend: isolate via worktree before mutating files. Use 'git worktree add ../$(basename "$PWD")-<slug> -b feat/<slug>' or run /user:locks for status.
+EOF
+fi
+
+exit 0

--- a/scripts/repo-lock.sh
+++ b/scripts/repo-lock.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Repo lock manager. Tracks active Claude sessions per repo to prevent
+# cross-session collisions. Locks live at ~/.claude/locks/<sha1>.json.
+# Subcommands: claim, release, check, list, prune.
+# Exit codes: 0 = success, 1 = held by other live session, 2 = bad usage.
+
+set -u
+
+LOCK_DIR="${CLAUDE_LOCK_DIR:-$HOME/.claude/locks}"
+STALE_SECONDS="${CLAUDE_LOCK_STALE:-1800}" # 30 min default
+
+mkdir -p "$LOCK_DIR"
+
+repo_root() {
+  local start="${1:-$PWD}"
+  ( cd "$start" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null )
+}
+
+repo_hash() {
+  printf '%s' "$1" | shasum | awk '{print $1}'
+}
+
+lock_path() {
+  local repo="$1"
+  echo "$LOCK_DIR/$(repo_hash "$repo").json"
+}
+
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+epoch_now() {
+  date -u +%s
+}
+
+iso_to_epoch() {
+  # macOS date - tolerant parser
+  date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$1" +%s 2>/dev/null
+}
+
+is_live() {
+  # Liveness = last_seen within STALE_SECONDS. PID is informational only;
+  # heartbeat (Phase 2) refreshes last_seen via PostToolUse. If PID is
+  # provably dead AND it matches the stored pid, treat as stale early.
+  local file="$1"
+  [ -f "$file" ] || return 1
+  local pid last_seen ts age
+  pid=$(jq -r '.pid // empty' "$file" 2>/dev/null)
+  last_seen=$(jq -r '.last_seen // empty' "$file" 2>/dev/null)
+  [ -z "$last_seen" ] && return 1
+  ts=$(iso_to_epoch "$last_seen") || return 1
+  age=$(( $(epoch_now) - ts ))
+  [ "$age" -ge "$STALE_SECONDS" ] && return 1
+  # Within freshness window. If the stored pid is dead AND last_seen is older
+  # than 60s with no heartbeat catching up, declare stale early.
+  if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null && [ "$age" -gt 60 ]; then
+    return 1
+  fi
+  return 0
+}
+
+build_lock_json() {
+  local repo="$1"
+  local sid="${CLAUDE_SESSION_ID:-$$-$(epoch_now)}"
+  local branch
+  branch=$( cd "$repo" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown" )
+  local in_worktree="false"
+  if [ "$( cd "$repo" && git rev-parse --git-common-dir 2>/dev/null )" != "$( cd "$repo" && git rev-parse --git-dir 2>/dev/null )" ]; then
+    in_worktree="true"
+  fi
+  # Store parent PID - the script subshell dies immediately, so $$ is useless.
+  # PPID is the Claude bash-tool wrapper or shell, which lives longer.
+  local owner_pid="${CLAUDE_PARENT_PID:-$PPID}"
+  jq -n \
+    --arg repo "$repo" \
+    --arg sid "$sid" \
+    --arg branch "$branch" \
+    --argjson pid "$owner_pid" \
+    --argjson worktree "$in_worktree" \
+    --arg now "$(now_iso)" \
+    '{repo_path:$repo, session_id:$sid, pid:$pid, branch:$branch, worktree:$worktree, claimed_at:$now, last_seen:$now}'
+}
+
+cmd_claim() {
+  local repo
+  repo=$(repo_root "${1:-$PWD}") || { echo "not in a git repo" >&2; exit 2; }
+  [ -z "$repo" ] && { echo "not in a git repo" >&2; exit 2; }
+  local lock; lock=$(lock_path "$repo")
+
+  if [ -f "$lock" ] && is_live "$lock"; then
+    local owner_sid; owner_sid=$(jq -r '.session_id' "$lock")
+    if [ "$owner_sid" = "${CLAUDE_SESSION_ID:-}" ]; then
+      # refresh heartbeat
+      jq --arg now "$(now_iso)" '.last_seen=$now' "$lock" > "$lock.tmp" && mv "$lock.tmp" "$lock"
+      cat "$lock"
+      exit 0
+    fi
+    echo "held by another session" >&2
+    cat "$lock" >&2
+    exit 1
+  fi
+
+  build_lock_json "$repo" > "$lock"
+  cat "$lock"
+}
+
+cmd_release() {
+  local repo
+  repo=$(repo_root "${1:-$PWD}") || exit 0
+  [ -z "$repo" ] && exit 0
+  local lock; lock=$(lock_path "$repo")
+  [ -f "$lock" ] || exit 0
+  local owner_sid; owner_sid=$(jq -r '.session_id // empty' "$lock" 2>/dev/null)
+  if [ -n "${CLAUDE_SESSION_ID:-}" ] && [ "$owner_sid" != "$CLAUDE_SESSION_ID" ] && [ "${FORCE:-0}" != "1" ]; then
+    echo "lock owned by $owner_sid - use FORCE=1 to override" >&2
+    exit 1
+  fi
+  rm -f "$lock"
+}
+
+cmd_check() {
+  local repo
+  repo=$(repo_root "${1:-$PWD}") || { echo "not in a git repo" >&2; exit 2; }
+  [ -z "$repo" ] && { echo "not in a git repo" >&2; exit 2; }
+  local lock; lock=$(lock_path "$repo")
+  if [ -f "$lock" ] && is_live "$lock"; then
+    cat "$lock"
+    exit 1
+  fi
+  if [ -f "$lock" ]; then
+    jq '. + {stale:true}' "$lock"
+    exit 0
+  fi
+  echo '{"status":"free"}'
+  exit 0
+}
+
+cmd_list() {
+  shopt -s nullglob 2>/dev/null
+  local any=0
+  for f in "$LOCK_DIR"/*.json; do
+    any=1
+    if is_live "$f"; then
+      jq '. + {live:true}' "$f"
+    else
+      jq '. + {live:false, stale:true}' "$f"
+    fi
+  done
+  [ $any -eq 0 ] && echo '[]'
+}
+
+cmd_prune() {
+  shopt -s nullglob 2>/dev/null
+  local removed=0
+  for f in "$LOCK_DIR"/*.json; do
+    if ! is_live "$f"; then
+      rm -f "$f"
+      removed=$((removed+1))
+    fi
+  done
+  echo "pruned $removed stale locks"
+}
+
+case "${1:-}" in
+  claim)   shift; cmd_claim "$@" ;;
+  release) shift; cmd_release "$@" ;;
+  check)   shift; cmd_check "$@" ;;
+  list)    shift; cmd_list ;;
+  prune)   shift; cmd_prune ;;
+  *) echo "usage: repo-lock.sh {claim|release|check|list|prune} [repo-path]" >&2; exit 2 ;;
+esac

--- a/settings.json
+++ b/settings.json
@@ -181,6 +181,16 @@
             "command": "echo 'Reminder: follow the workflow (Research - Plan - Annotate - Implement - Summarize). Minimal fix first for bugs. Run /user:verify-done before commits. Current year: 2026.'"
           }
         ]
+      },
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/repo-lock-status.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/repo-lock-status.sh\"; [ -x \"$HOOK\" ] && \"$HOOK\" || true",
+            "timeout": 10
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

First layer of the cross-session agent-isolation plan (`~/.claude/plans/2026-04-25-agent-isolation.md`). Goal: when two Claude sessions touch the same repo simultaneously, surface the conflict before they corrupt each other's state. Phase 1 is **advisory only** - no blocking yet. Phases 2-4 (heartbeat, PreToolUse guard, worktree-default rule) follow once we observe collision patterns.

### What's in this PR

- **`scripts/repo-lock.sh`** - lock manager. Subcommands: `claim`, `release`, `check`, `list`, `prune`. Locks at `~/.claude/locks/<sha1-of-repo-path>.json`. Liveness = `last_seen` within 30 min (configurable via `CLAUDE_LOCK_STALE`). PID is informational with an early-stale shortcut when the stored PID is provably dead.
- **`hooks/repo-lock-status.sh`** - SessionStart hook (`startup|resume` matchers). Reads the lock for the current repo; if held by another live session, prints a notice with the offending pid/session/branch/claimed_at and recommends isolating via `git worktree`. Always exits 0 - never blocks.
- **`commands/locks.md`** - `/user:locks` listing, with `--prune` and `--release <hash>` flags for stale-lock cleanup.
- **`settings.json`** - wires the SessionStart hook with the existing project/global fallback pattern.
- **`README.md`** - registers the new script, hook, and command.

### Why advisory first

Locks are easier to debug when nothing is blocked. Run for a few days, see how often `/user:locks` shows multiple live sessions, then decide whether to ship Phase 2 (heartbeat) and Phase 3 (PreToolUse guard).

## Test plan

- [x] `bash -n` syntax check on script + hook
- [x] free repo - `check` returns `{"status":"free"}` exit 0
- [x] A claims, B checks - returns A's lock JSON exit 1
- [x] B claim attempt while A holds - rejected with stderr message exit 1
- [x] SessionStart hook from B's perspective - prints notice (visible in transcript)
- [x] A re-claim refreshes `last_seen` (heartbeat works)
- [x] A release frees the lock; subsequent check is `free`
- [x] `prune` removes stale locks
- [ ] Real two-session test in a real repo (manual, post-merge)

## Plan link

Full design at `~/.claude/plans/2026-04-25-agent-isolation.md` (in your local plans dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)