### PR TITLE
feat: Phase 3 repo lock - PreToolUse hard-block guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Automation scripts triggered at lifecycle events. Configured in `settings.json` 
 | `repo-lock-status.sh` | SessionStart (startup\|resume) | Claim the repo lock for this session (or notice if held by another live session). Advisory, never blocks. |
 | `repo-lock-heartbeat.sh` | PostToolUse (Write\|Edit\|Bash) | Refresh lock `last_seen` so the session stays alive. Throttled to 60s via lock mtime. Never blocks. |
 | `repo-lock-release.sh` | SessionEnd | Release the repo lock if owned by this session. Idempotent. |
+| `repo-lock-guard.sh` | PreToolUse (Write\|Edit\|Bash mutations) | Hard-block mutations when another live session holds the lock and current session is not in a worktree. Bypass with `SKIP_LOCK=1`. |
 | `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
 | `post-edit-typecheck.sh` | PostToolUse (Write/Edit) | Run typecheck and lint on .ts/.tsx files after edits |
 | `watch-pr-checks.sh` | PostToolUse (gh pr create) | Poll CI checks in background, notify on pass/fail |

--- a/hooks/repo-lock-guard.sh
+++ b/hooks/repo-lock-guard.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# PreToolUse guard: refuse mutating actions when another live Claude session
+# holds the repo lock and the current session is NOT working in a worktree.
+# Exit code 2 blocks the action and surfaces the message to Claude.
+# Bypass with SKIP_LOCK=1 in the environment.
+
+set -u
+
+SCRIPT="$CLAUDE_PROJECT_DIR/scripts/repo-lock.sh"
+[ -x "$SCRIPT" ] || SCRIPT="$HOME/.claude/scripts/repo-lock.sh"
+[ -x "$SCRIPT" ] || exit 0
+
+# Escape hatch
+if [ "${SKIP_LOCK:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Pull stdin payload once
+INPUT=$(cat 2>/dev/null || true)
+
+# Extract session_id from stdin (PreToolUse payload includes it)
+SID_FROM_STDIN=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -n "$SID_FROM_STDIN" ]; then
+  export CLAUDE_SESSION_ID="$SID_FROM_STDIN"
+fi
+
+# For Bash tools, only gate the dangerous-mutation subset. Reads, lints,
+# tests, etc. don't need the guard.
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [ "$TOOL_NAME" = "Bash" ]; then
+  case "$COMMAND" in
+    *"git commit"*|*"git push"*|*"git checkout"*|*"git switch"*|\
+    *"git rebase"*|*"git merge"*|*"git reset"*|*"git cherry-pick"*|\
+    *"git stash"*|*"git restore"*|*"git apply"*|*"git am"*|\
+    *"git tag"*|*"git branch -D"*|*"git branch -d"*|*"gh pr merge"*) ;;
+    *) exit 0 ;;
+  esac
+fi
+
+# Only run inside a git repo
+REPO=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -z "$REPO" ] && exit 0
+
+# Are we currently in a worktree (not the main checkout)? If so, allow.
+GIT_DIR=$(git -C "$REPO" rev-parse --git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(git -C "$REPO" rev-parse --git-common-dir 2>/dev/null)
+if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
+  exit 0
+fi
+
+# Check lock state
+OUT=$("$SCRIPT" check 2>/dev/null)
+STATUS=$?
+
+# Free or stale - allow (Phase 2 SessionStart should have claimed already)
+[ $STATUS -eq 0 ] && exit 0
+
+# Held - allow only if owned by this session
+OWNER=$(echo "$OUT" | jq -r '.session_id // empty' 2>/dev/null)
+if [ "$OWNER" = "${CLAUDE_SESSION_ID:-}" ]; then
+  exit 0
+fi
+
+# Held by another live session - block
+PID=$(echo "$OUT" | jq -r '.pid')
+BRANCH=$(echo "$OUT" | jq -r '.branch')
+CLAIMED=$(echo "$OUT" | jq -r '.claimed_at')
+LAST_SEEN=$(echo "$OUT" | jq -r '.last_seen')
+
+cat >&2 <<EOF
+[repo-lock-guard] BLOCKED: another live Claude session holds this repo.
+  pid=$PID  session=$OWNER  branch=$BRANCH
+  claimed_at=$CLAIMED  last_seen=$LAST_SEEN
+
+To proceed, isolate yourself in a worktree:
+  git worktree add ../$(basename "$REPO")-<slug> -b feat/<slug>
+  cd ../$(basename "$REPO")-<slug>
+
+Or one-shot bypass:
+  SKIP_LOCK=1 <command>
+
+Or, if the other session is genuinely dead:
+  /user:locks --prune
+EOF
+
+exit 2

--- a/settings.json
+++ b/settings.json
@@ -115,6 +115,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/repo-lock-guard.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/repo-lock-guard.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr create *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 120
@@ -128,6 +133,16 @@
           {
             "type": "command",
             "command": "command -v rtk >/dev/null 2>&1 && rtk hook claude || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/repo-lock-guard.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/repo-lock-guard.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

Phase 3 of the cross-session agent-isolation plan. Phases 1-2 (#34, #35) gave us self-maintaining advisory locks. Phase 3 makes them **enforceable**: when another live Claude session holds the lock and you are not isolated in a worktree, mutations are blocked.

### What's gated

- **Edit, Write** - always.
- **Bash** - only when the command is a real mutation: `git commit/push/checkout/switch/rebase/merge/reset/cherry-pick/stash/restore/apply/am/tag/branch -d/-D`, `gh pr merge`. Reads, lints, tests, `gh pr view`, etc. pass through with zero overhead.

### What auto-bypasses

- Current session owns the lock (via `session_id` from stdin payload).
- Current working tree is a git worktree (`git rev-parse --git-dir != --git-common-dir`). Worktrees can't collide with the main checkout - each has its own branch.
- `SKIP_LOCK=1` env var.

### Block message

When blocked, the guard writes remediation steps to stderr (Claude sees them):

```
[repo-lock-guard] BLOCKED: another live Claude session holds this repo.
  pid=...  session=...  branch=...
  claimed_at=...  last_seen=...

To proceed, isolate yourself in a worktree:
  git worktree add ../<repo>-<slug> -b feat/<slug>
  cd ../<repo>-<slug>

Or one-shot bypass:
  SKIP_LOCK=1 <command>

Or, if the other session is genuinely dead:
  /user:locks --prune
```

### Wiring

Guard runs first in `PreToolUse[Bash]` (before the existing pre-pr-test-gate, pre-push-gate, rtk hook), and is added as a new `PreToolUse[Write|Edit]` entry. 5s timeout. No latency on the read-only path - the case statement returns exit 0 before any lock IO.

## Test plan

- [x] Syntax check
- [x] Owner Edit allowed
- [x] Foreign Edit blocked (exit 2 + message)
- [x] Foreign read-only Bash (`ls -la`) allowed
- [x] Foreign mutating Bash (`git commit`) blocked
- [x] `SKIP_LOCK=1` bypass works
- [x] Worktree bypass works (foreign session inside `git worktree add`-created tree allowed)
- [ ] Real two-session test in a real repo (manual, post-merge)

## Plan link

`~/.claude/plans/2026-04-25-agent-isolation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)