### PR TITLE
feat: Phase 4 repo isolation - worktree-default rule + helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 - **Verification**: always run `/user:verify-done` before pushing - never push without all checks passing
 - **Atomic feature unit**: "implement" means implement + commit on a feature branch + push + open PR. Never stop after the code change. Never commit to `main`/`master` directly. If on a protected branch, create a feature branch first.
 - **Parallelization**: when a task has 2+ independent sub-tasks touching different files, split across multiple agents using git worktrees - see `rules/parallel-agents.md`
+- **Cross-session isolation**: before non-trivial work, isolate this session in a git worktree to avoid colliding with other Claude sessions on the same repo. See `rules/isolation.md`. The `/user:worktree <slug>` command does this. The PreToolUse guard will block mutations if another live session holds the lock and you are not in a worktree.
 
 Detailed git, testing, and exploration rules are in `rules/` (git-conventions, engineering-principles).
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Modular instruction files. **Always-loaded** rules have no frontmatter. **Path-s
 | `tests.md` | `**/*.test.ts,**/*.spec.ts` | Editing test files |
 | `database.md` | `**/migrations/**,**/*.sql` | Editing database/migration files |
 | `infrastructure.md` | `**/Dockerfile,**/*.tf` | Editing infrastructure files |
+| `isolation.md` | Always | Every session (cross-session repo isolation, worktree decision tree) |
+| `parallel-agents.md` | Always | Every session (worktree pattern for self-spawned parallel agents) |
 
 ### Agents (`agents/`)
 
@@ -144,6 +146,8 @@ Slash commands for frequent workflows. Available as `/user:<name>`.
 | `typecheck` | `/user:typecheck` | Run tsc and fix all type errors |
 | `verify-done` | `/user:verify-done` | Full quality gate before declaring work done (lint + typecheck + test + build + git status) |
 | `locks` | `/user:locks [--prune\|--release <hash>]` | List active Claude session locks across repos; prune stale; force-release |
+| `worktree` | `/user:worktree <slug>` | Create an isolated git worktree on a fresh branch and switch into it. Resolves cross-session collisions before they happen. |
+| `worktree-merge` | `/user:worktree-merge` | Clean up the current worktree after its branch is merged. Removes worktree dir, deletes local branch, releases lock. |
 
 ### Hooks (`hooks/`)
 

--- a/commands/summarize.md
+++ b/commands/summarize.md
@@ -27,3 +27,16 @@ Format the file as:
 ```
 
 Also output the summary to the conversation. Keep it concise - suitable for a standup update or handoff to another session.
+
+## Worktree auto-cleanup
+
+After saving the diary, scan worktrees owned by this repo and remove ones that are safely disposable:
+
+1. `git worktree list --porcelain` to list every worktree.
+2. For each non-main worktree, check its branch:
+   - If the branch's upstream is `gone` (remote branch deleted, e.g. PR merged) - safe to remove.
+   - If `git rev-list --count <branch>@{upstream}..<branch>` is 0 (no unpushed commits) - safe to remove.
+   - Otherwise (unpushed work, no upstream, or uncommitted changes) - skip and tell the user the worktree was preserved with a one-line reason.
+3. For each safe worktree: `git worktree remove <path>` and `git branch -d <branch>`. Release the lock with `~/.claude/scripts/repo-lock.sh release <path>` if needed.
+
+Never force-remove. Never delete a branch with unpushed commits. If in doubt, preserve and report.

--- a/commands/worktree-merge.md
+++ b/commands/worktree-merge.md
@@ -14,10 +14,12 @@ If the branch is not safe to remove, stop and explain what's still pending (unpu
 ## Steps
 
 1. Capture worktree path and branch name:
+
    ```bash
    WORKTREE=$(git rev-parse --show-toplevel)
    BRANCH=$(git rev-parse --abbrev-ref HEAD)
    ```
+
 2. Move out of the worktree to the main checkout (`cd "$(git rev-parse --git-common-dir)/.."`).
 3. Release the lock for the worktree path: `~/.claude/scripts/repo-lock.sh release "$WORKTREE"` (the SessionEnd hook will also do this; explicit release here is for the immediate cleanup).
 4. Remove the worktree: `git worktree remove "$WORKTREE"`. If it has uncommitted changes and `--force` was passed, use `git worktree remove --force "$WORKTREE"`.

--- a/commands/worktree-merge.md
+++ b/commands/worktree-merge.md
@@ -1,0 +1,29 @@
+---
+description: "Clean up a worktree after its branch has been merged. Removes the worktree dir, deletes the local branch, releases the lock."
+---
+
+Clean up the current worktree: $ARGUMENTS
+
+## Preconditions
+
+- Current `$PWD` must be inside a worktree (not the main checkout). Verify with `git rev-parse --git-dir != --git-common-dir`.
+- The worktree's branch must be safely removable: either merged into the default branch upstream, or its upstream is `gone` (PR was merged and remote branch deleted), or the user explicitly passes `--force`.
+
+If the branch is not safe to remove, stop and explain what's still pending (unpushed commits, open PR, etc.). Never auto-delete unmerged work.
+
+## Steps
+
+1. Capture worktree path and branch name:
+   ```bash
+   WORKTREE=$(git rev-parse --show-toplevel)
+   BRANCH=$(git rev-parse --abbrev-ref HEAD)
+   ```
+2. Move out of the worktree to the main checkout (`cd "$(git rev-parse --git-common-dir)/.."`).
+3. Release the lock for the worktree path: `~/.claude/scripts/repo-lock.sh release "$WORKTREE"` (the SessionEnd hook will also do this; explicit release here is for the immediate cleanup).
+4. Remove the worktree: `git worktree remove "$WORKTREE"`. If it has uncommitted changes and `--force` was passed, use `git worktree remove --force "$WORKTREE"`.
+5. Delete the local branch: `git branch -d "$BRANCH"` (or `-D` with `--force`).
+6. Report what was cleaned up.
+
+## After cleanup
+
+The next session can claim the lock on the main checkout cleanly. If the user has more work, suggest `/user:worktree <new-slug>` for the next task rather than mutating the main checkout.

--- a/commands/worktree.md
+++ b/commands/worktree.md
@@ -1,0 +1,40 @@
+---
+description: "Create an isolated git worktree for the current task and switch into it. Resolves cross-session collisions before they happen."
+---
+
+Create a worktree for: $ARGUMENTS
+
+## Slug
+
+If $ARGUMENTS is non-empty, treat the first argument as the slug.
+
+If $ARGUMENTS is empty:
+
+- If a plan file exists at `~/.claude/plans/<latest>.md`, derive slug from its basename (strip date prefix and `.md` extension).
+- Else generate `<topic>-<6char-hex>` and ask the user to confirm.
+
+The slug must be lowercase, hyphen-separated, no spaces.
+
+## Branch type
+
+Default to `feat/<slug>`. If the user's request looks like a bug fix, use `fix/<slug>`. For cleanups, `chore/<slug>`.
+
+## Steps
+
+1. Find the repo root: `git rev-parse --show-toplevel`. Refuse if not inside a git repo.
+2. Compute target dir: `<repo-parent>/<repo-basename>-<slug>`. Refuse if it already exists (offer to `cd` into the existing one instead).
+3. Create the worktree on a new branch:
+   ```bash
+   git worktree add "<target>" -b "<branch>"
+   ```
+4. `cd` into the worktree dir for all subsequent operations.
+5. Show the user the new working dir, branch name, and confirm next steps.
+
+## After creation
+
+The worktree is its own working tree - the PreToolUse guard auto-bypasses inside it. The session can continue mutating files freely without colliding with the main checkout's session.
+
+When work is done:
+
+- Open a PR from the worktree's branch as normal.
+- After merge, run `/user:worktree-merge` to clean up the worktree and remove the local branch.

--- a/commands/worktree.md
+++ b/commands/worktree.md
@@ -24,9 +24,11 @@ Default to `feat/<slug>`. If the user's request looks like a bug fix, use `fix/<
 1. Find the repo root: `git rev-parse --show-toplevel`. Refuse if not inside a git repo.
 2. Compute target dir: `<repo-parent>/<repo-basename>-<slug>`. Refuse if it already exists (offer to `cd` into the existing one instead).
 3. Create the worktree on a new branch:
+
    ```bash
    git worktree add "<target>" -b "<branch>"
    ```
+
 4. `cd` into the worktree dir for all subsequent operations.
 5. Show the user the new working dir, branch name, and confirm next steps.
 

--- a/rules/isolation.md
+++ b/rules/isolation.md
@@ -1,0 +1,38 @@
+# Cross-Session Repo Isolation
+
+Concurrent Claude sessions on the same repo collide on working tree state, branch checkout, and partial edits. The repo-lock system (Phases 1-3) and this rule together prevent that.
+
+## Decision Tree (apply at session start, before first mutation)
+
+1. **Read-only session** (only Read / Grep / Glob, no Edit / Write / git mutation): no action. Skip the rest.
+2. **Light edit** (1-2 files, <5 min expected, no plan file): SessionStart hook already claims the lock. If it printed a `NOTICE: another Claude session is active` message, **stop and ask the user** whether to wait, share the existing session, or isolate via worktree. Do not start mutating.
+3. **Non-trivial work** (plan file exists, multi-file changes, branch+commit+push expected): always isolate via worktree before the first mutation. Run `/user:worktree <slug>`.
+
+## Slug Convention
+
+- Branch name, worktree dir basename, and lock id share one slug.
+- Source the slug from the plan filename if a plan exists (e.g. `2026-04-25-agent-isolation.md` → slug `agent-isolation`).
+- Otherwise: `<topic>-<6char-hex>`.
+- Branch: `feat/<slug>` (or `fix/<slug>` for bug fixes, `chore/<slug>` for cleanups).
+- Worktree dir: `../<repo-basename>-<slug>` (sibling of main checkout).
+
+## When the Guard Blocks You
+
+The PreToolUse guard refuses mutating Edit / Write / Bash when another live session holds the lock and you are not in a worktree. Remediation in priority order:
+
+1. **`/user:worktree <slug>`** - the right answer almost always. Isolates this session, no race risk.
+2. **`/user:locks --prune`** - if the other session is genuinely dead (machine crashed, process killed, last_seen >30 min old).
+3. **`SKIP_LOCK=1 <command>`** - one-shot bypass. Use only when you know the other session is in a different part of the repo and won't collide. Risky.
+
+Never silently retry past the guard. Never instruct the user to disable the hooks.
+
+## Worktree Lifecycle
+
+- Create: `/user:worktree <slug>` (which runs `git worktree add ../<repo>-<slug> -b <slug>` and `cd`s into it).
+- Work: commit + push from the worktree as normal. The branch lives upstream.
+- Merge back: open a PR from the worktree's branch. Once merged, run `/user:worktree-merge` to remove the worktree and release its lock.
+- Auto-cleanup on `/user:summarize`: removes worktrees whose branch is `gone` upstream or has zero unpushed commits. Worktrees with unpushed work persist.
+
+## Why Worktrees Over Locks Alone
+
+Locks are advisory - races and stale locks happen. Worktrees physically isolate working trees. Cost: one disk-clone of the repo + per-worktree `node_modules`. For non-trivial work this cost is trivial vs. the cost of a corrupted main checkout mid-session.


### PR DESCRIPTION
## Summary

Final layer of the cross-session agent-isolation plan. Phases 1-3 (#34, #35, #36) shipped the lock system: SessionStart claim, heartbeat refresh, SessionEnd release, and PreToolUse hard-block guard. Phase 4 makes the **worktree** path frictionless and teaches every session to use it.

### What's in this PR

- **`rules/isolation.md`** (new, always-loaded) - decision tree:
  - **Read-only session** (Read/Grep/Glob only): no action.
  - **Light edit** (1-2 files, <5 min, no plan): honor the SessionStart notice. If held, ask the user before mutating.
  - **Non-trivial work** (plan exists, multi-file, branch+commit+push expected): always worktree first via `/user:worktree`.
  - Slug convention (shared across branch / dir / lock id), escape hatches, worktree lifecycle.
- **`commands/worktree.md`** - `/user:worktree <slug>`. Derives slug from arg, or from latest plan filename, or generates `<topic>-<6char-hex>`. Creates `<repo-parent>/<repo-basename>-<slug>` on `feat/<slug>` (or `fix/`/`chore/` based on intent). `cd`s into it.
- **`commands/worktree-merge.md`** - `/user:worktree-merge`. Tears down the current worktree once its branch is safely merged. Refuses if the branch has unpushed commits or no upstream and `--force` was not passed. Releases the lock and deletes the local branch.
- **`commands/summarize.md`** - extended to scan worktrees and remove ones whose upstream is `gone` or which have 0 unpushed commits. Never force-removes. Preserves anything with pending work and reports it.
- **`CLAUDE.md`** - new behavioral rule under **Behavioral Rules** pointing at `rules/isolation.md` and `/user:worktree`. Restates that the PreToolUse guard will block if you skip isolation when another session holds the lock.
- **`README.md`** - registers `isolation.md` rule, `parallel-agents.md` rule (was missing from the table), and the two worktree commands.

### How the four phases interact

| Layer | Trigger | Role |
|---|---|---|
| Phase 1: `repo-lock.sh` | direct CLI | claim/release/check/list/prune |
| Phase 2: SessionStart + heartbeat + SessionEnd | hooks | self-maintaining lock state |
| Phase 3: PreToolUse guard | hook | hard-block when held + not isolated |
| Phase 4: rule + worktree commands | rule + commands | teach Claude to isolate first, make it cheap |

Together they implement: deterministic mechanism (worktree), graceful default (lock + advisory), enforceable boundary (guard), with three escape hatches (`SKIP_LOCK=1`, `/user:locks --prune`, `/user:locks --release`).

## Test plan

- [x] `rules/isolation.md` content is coherent (decision tree, slug conv, lifecycle, escape hatches)
- [x] `/user:worktree` instructions cover slug derivation, dir naming, branch type
- [x] `/user:worktree-merge` refuses unmerged work, releases lock, deletes branch
- [x] `summarize` extended logic preserves worktrees with unpushed commits
- [x] CLAUDE.md rule references the right files
- [x] README rules + commands tables include the new entries
- [ ] End-to-end: open 2 sessions on same repo, second runs `/user:worktree foo`, both work concurrently without collision (manual, post-merge)
- [ ] Run `/user:summarize` in a stale-branch worktree - confirm cleanup vs preservation logic (manual, post-merge)

## Plan link

`~/.claude/plans/2026-04-25-agent-isolation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)