### PR TITLE
feat: add /document command for engineering docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,13 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 
 ## Docs Sync
 
-- When code changes affect behavior documented in `.claude/docs/`, update the relevant docs in the same PR
+- Engineering docs live in each repo's `/docs/` tree, organized by [Diataxis](https://diataxis.fr/) (explanation, reference, how-to, tutorials) plus an `adr/` folder for Architecture Decision Records
+- When code changes affect behavior documented in `docs/`, update the relevant docs in the same PR
+- Use the `/document` slash command to create or refresh docs - it embeds the quality rules and Diataxis routing
 - Never let docs drift from implementation - if you change it, document it
 - Only update docs that describe behavior actually changed in this session - no forward-looking references, planned features, or speculative content
+- Diagrams are Mermaid only (text-based, GitHub-rendered, AI-readable). No draw.io, no PNGs
+- ADRs are immutable once Accepted - a reversed decision creates a new ADR that supersedes the old one
 
 ## Behavioral Rules
 

--- a/commands/document.md
+++ b/commands/document.md
@@ -1,0 +1,116 @@
+---
+description: "Create or refresh technical engineering docs in the current repo's /docs/ tree. Diataxis layout, mermaid diagrams, ADR support, drift audit."
+---
+
+Generate or update engineering documentation for: $ARGUMENTS
+
+This command writes docs that are dual-audience: engineers reading on GitHub AND Claude agents reading the repo. Apply the rules below without exception.
+
+## Subcommands
+
+Parse the first word of `$ARGUMENTS` as the subcommand:
+
+- `explain <topic>` - create/update `docs/explanation/<topic>.md` (the *why* and *how it fits together*)
+- `reference <topic>` - create/update `docs/reference/<topic>.md` (lookup tables, env vars, schemas, enums)
+- `how-to <task>` - create/update `docs/how-to/<task>.md` (a recipe to do one thing)
+- `tutorial <topic>` - create/update `docs/tutorials/<topic>.md` (learning path, onboarding)
+- `adr "<title>"` - draft the next-numbered ADR in `docs/adr/`
+- `diagram <type> <topic>` - add or update a mermaid diagram inside the matching doc
+- `audit` - read every `docs/**/*.md`, compare against current code, produce a drift report (read-only, no edits)
+- `bootstrap` - create the full `docs/` skeleton in a repo that has none yet (uses `~/.claude/templates/docs-readme.md` and `~/.claude/templates/adr.md`)
+
+If no subcommand matches, ask the user which one they meant before writing anything.
+
+## Diataxis routing
+
+If a topic does not clearly fit one quadrant, ask. Do not split a single topic across quadrants.
+
+| Quadrant | Use when... | Don't use when... |
+|----------|-------------|-------------------|
+| explanation | Reader asks *why does this exist* or *how does this fit together* | They want to do a concrete task |
+| reference | Reader needs to look up an exact value, name, or signature | They want narrative context |
+| how-to | Reader has a goal and needs steps | They are still trying to understand the concept |
+| tutorial | Reader is new and learning end-to-end | They already know the system |
+
+## Quality rules (apply to every doc you write)
+
+1. **One topic per file.** If two H1-worthy ideas appear, split into two files.
+2. **Lead with TL;DR** in 3 sentences or fewer, before any heading. Body expands.
+3. **Cite source files** with backticked relative paths (`src/foo/bar.ts`). Link, do not paste. Inline code blocks longer than 15 lines are forbidden - link to the file instead.
+4. **Tables over prose** for any list of more than 3 parallel items.
+5. **Diagrams for relationships only.** No diagram if a 3-row table conveys it. Mermaid only - no draw.io, no PNGs.
+6. **Why before how.** Every explanation doc opens with the problem the thing solves.
+7. **No forward-looking content.** Document only behavior that exists now. No "we plan to", no "in the future".
+8. **No issue/PR/ticket numbers.** They rot. Put them in PR descriptions and git history, not docs.
+9. **ADRs are immutable once Accepted.** A new decision = a new ADR with `Status: Supersedes NNNN`. Never edit the body of an Accepted ADR.
+10. **Max 300 lines per doc.** If longer, split by sub-topic.
+11. **No emoji** unless the user explicitly asked for them.
+12. **No em dashes.** Use a regular hyphen.
+
+## Mermaid conventions
+
+- Use ` ```mermaid ` fenced blocks. GitHub renders them natively.
+- Diagram type by purpose:
+  - `flowchart TD` for high-level architecture and decision trees
+  - `sequenceDiagram` for request flows, auth flows, async messaging
+  - `erDiagram` for data models
+  - `stateDiagram-v2` for state machines (order status, sync status)
+  - `flowchart LR` with subgraphs for C4-context (services, queues, datastores)
+- Keep node labels short. Put long descriptions in adjacent prose, not in the diagram.
+- One diagram per doc maximum, unless the doc is explicitly an architecture doc.
+
+## File layout the command produces or expects
+
+```
+<repo>/
+  docs/
+    README.md             # index grouped by Diataxis quadrant
+    explanation/
+    reference/
+    how-to/
+    tutorials/
+    adr/
+      README.md           # ADR index, table of {NNNN, title, status, date}
+      NNNN-<slug>.md
+    diagrams/             # optional shared .mmd snippets, only if reused
+```
+
+## ADR procedure
+
+When `adr "<title>"`:
+
+1. Scan `docs/adr/` for highest existing number. New file = `NNNN-<kebab-title>.md`, zero-padded to 4 digits.
+2. Use `~/.claude/templates/adr.md` as the body. Fill `<Title>`, today's date, status `Proposed`.
+3. Append a row to `docs/adr/README.md` table.
+4. Ask the user for Context, Decision, Consequences before finalizing - never invent a decision.
+
+## Audit procedure
+
+When `audit`:
+
+1. Walk `docs/**/*.md`.
+2. For each doc, extract source-file citations (backticked paths). Verify they exist with `Glob`/`Read`. Report missing files.
+3. For each ADR, verify `Status` is one of {Proposed, Accepted, Superseded by NNNN, Deprecated}. Flag malformed ADRs.
+4. For each `docs/reference/*.md`, scan referenced enums/configs (e.g. `src/**/enums/*.ts`) and report mismatches between doc tables and code.
+5. Report doc files exceeding 300 lines.
+6. Report any `docs/**/*.md` not linked from `docs/README.md`.
+7. Output a report only - do NOT edit files. The user runs targeted subcommands afterward to fix drift.
+
+## CLAUDE.md integration
+
+After bootstrapping or significant doc changes, update the repo's `CLAUDE.md` so it points to `docs/README.md` in its Documentation section. This keeps Claude's auto-discovery working.
+
+## Verification before finishing
+
+- `markdownlint-cli2 docs/**/*.md` if the repo has it configured (check for `.markdownlint*` files).
+- All mermaid blocks are syntactically valid (rough check: balanced fences, recognized diagram type).
+- All source-file citations resolve.
+- The doc fits the quality rules above.
+
+If any check fails, fix it before reporting done.
+
+## Out of scope for this command
+
+- Generated API references (Swagger/OpenAPI, TypeDoc) - separate tooling.
+- Product specs - those live in `pentla-specs`.
+- Anything outside `docs/` in the current repo.

--- a/commands/document.md
+++ b/commands/document.md
@@ -61,7 +61,7 @@ If a topic does not clearly fit one quadrant, ask. Do not split a single topic a
 
 ## File layout the command produces or expects
 
-```
+```text
 <repo>/
   docs/
     README.md             # index grouped by Diataxis quadrant

--- a/templates/adr-readme.md
+++ b/templates/adr-readme.md
@@ -10,7 +10,7 @@ ADRs capture significant technical decisions: what we chose, why, and what it co
 
 ## How to add one
 
-```
+```text
 /document adr "<short title>"
 ```
 

--- a/templates/adr-readme.md
+++ b/templates/adr-readme.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+ADRs capture significant technical decisions: what we chose, why, and what it commits us to. Once Accepted, an ADR is immutable; a reversed decision creates a new ADR that supersedes the old one.
+
+## Index
+
+| NNNN | Title | Status | Date |
+|------|-------|--------|------|
+<!-- append rows here, newest first -->
+
+## How to add one
+
+```
+/document adr "<short title>"
+```
+
+Fill in Context, Decision, Consequences, Alternatives Considered. Keep each section tight. Status starts as `Proposed`; flip to `Accepted` once the team agrees.
+
+## Status values
+
+- **Proposed** - written but not adopted.
+- **Accepted** - in force.
+- **Superseded by NNNN** - replaced; file stays in place.
+- **Deprecated** - no longer applies, no replacement.

--- a/templates/adr.md
+++ b/templates/adr.md
@@ -1,0 +1,32 @@
+# ADR NNNN: <Title>
+
+- **Status**: Proposed
+- **Date**: YYYY-MM-DD
+- **Deciders**: <names>
+
+## Context
+
+What problem forced the decision. Constraints that shaped it. What was tried before, if anything. Keep to one or two paragraphs.
+
+## Decision
+
+The chosen option, stated plainly in one or two sentences. No hedging.
+
+## Consequences
+
+What this commits us to. Group as Positive / Negative / Neutral if it helps. Be honest about the downsides.
+
+## Alternatives Considered
+
+Each alternative in one short paragraph: what it was, why it was rejected. Keep this section tight - the goal is to show the decision was not accidental, not to write a survey.
+
+---
+
+## Status values
+
+- **Proposed** - written but not yet adopted.
+- **Accepted** - adopted and in force. Body is now immutable; revise only typos.
+- **Superseded by NNNN** - replaced by a later ADR. Keep the file in place; do not delete.
+- **Deprecated** - no longer applies, no replacement. Rare.
+
+A new decision that reverses an Accepted ADR creates a new ADR; the old one's status flips to `Superseded by <new NNNN>` and nothing else in its body changes.

--- a/templates/docs-readme.md
+++ b/templates/docs-readme.md
@@ -1,0 +1,57 @@
+# Documentation
+
+> Engineering docs for `<repo-name>`. Written for engineers reading on GitHub and for Claude agents working in the repo.
+
+## How this is organized
+
+Docs follow [Diataxis](https://diataxis.fr/). Each doc has exactly one job:
+
+| Quadrant | When you're... | Where to look |
+|----------|----------------|---------------|
+| **Explanation** | Trying to understand *why* or *how it fits together* | [explanation/](explanation/) |
+| **Reference** | Looking up an exact value, name, or signature | [reference/](reference/) |
+| **How-to** | Doing a concrete task | [how-to/](how-to/) |
+| **Tutorial** | Learning the system end-to-end | [tutorials/](tutorials/) |
+| **Decisions** | Asking *why did we choose X* | [adr/](adr/) |
+
+## Conventions
+
+- Markdown only. Diagrams are [Mermaid](https://mermaid.js.org/) in fenced blocks - GitHub renders them natively.
+- Each doc opens with a 3-sentence TL;DR before any heading.
+- Source files are cited with backticked relative paths: `src/foo/bar.ts`.
+- Max 300 lines per doc. Split if longer.
+- ADRs are immutable once Accepted. A new decision creates a new ADR.
+
+## Index
+
+### Explanation
+
+<!-- list explanation/*.md here -->
+
+### Reference
+
+<!-- list reference/*.md here -->
+
+### How-to
+
+<!-- list how-to/*.md here -->
+
+### Tutorials
+
+<!-- list tutorials/*.md here -->
+
+### Architecture Decision Records
+
+See [adr/README.md](adr/README.md).
+
+## Maintaining these docs
+
+Use the `/document` slash command in Claude Code:
+
+- `/document explain <topic>` - new explanation doc
+- `/document reference <topic>` - new reference doc
+- `/document how-to <task>` - new recipe
+- `/document adr "<title>"` - new ADR
+- `/document audit` - drift report against current code
+
+Every code change that affects documented behavior should update the relevant doc in the same PR.


### PR DESCRIPTION
## Summary

- Adds the `/document` slash command that creates and refreshes engineering docs in any repo's `/docs/` tree
- Layout follows [Diataxis](https://diataxis.fr/) (explanation, reference, how-to, tutorials) plus an `adr/` folder for Architecture Decision Records
- Mermaid is the only diagram format - text-based, GitHub-rendered, AI-readable
- Quality rules (TL;DR, source citations, no forward-looking content, max 300 lines per doc, no PR/issue numbers, etc.) are embedded in the command body so Claude applies them consistently across repos
- Templates for ADR body, ADR index, and docs README live alongside the command

## Subcommands

- ``/document explain <topic>`` - new or refreshed explanation doc
- ``/document reference <topic>`` - new or refreshed reference doc
- ``/document how-to <task>`` - new or refreshed how-to recipe
- ``/document tutorial <topic>`` - new or refreshed tutorial
- ``/document adr "<title>"`` - draft next-numbered ADR
- ``/document diagram <type> <topic>`` - add or update a mermaid diagram
- ``/document audit`` - drift report comparing docs vs current code (read-only)
- ``/document bootstrap`` - scaffold the full ``docs/`` skeleton in a repo with none

## Test plan

- [ ] `/document bootstrap` in a scratch repo produces the expected folder layout
- [ ] `/document explain auth` writes to `docs/explanation/auth.md` with TL;DR and source citations
- [ ] `/document adr "Use Postgres RLS"` produces a numbered file using the template
- [ ] `/document audit` against pentla-api flags real drift but does not edit files
- [ ] `markdownlint-cli2` passes on docs the command produces