### PR TITLE
feat: add drawio for complex diagrams; mermaid stays default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ For trivial changes (typos, one-liner fixes, config tweaks): skip straight to im
 - Use the `/document` slash command to create or refresh docs - it embeds the quality rules and Diataxis routing
 - Never let docs drift from implementation - if you change it, document it
 - Only update docs that describe behavior actually changed in this session - no forward-looking references, planned features, or speculative content
-- Diagrams are Mermaid only (text-based, GitHub-rendered, AI-readable). No draw.io, no PNGs
+- Diagrams default to Mermaid (text-based, GitHub-rendered, AI-readable). Use drawio when the diagram needs custom shapes, multi-layer architecture, >2 swimlanes, or precise layout - see `rules/diagrams.md` for the policy and `/diagram` skill for the workflow
 - ADRs are immutable once Accepted - a reversed decision creates a new ADR that supersedes the old one
 
 ## Behavioral Rules

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Modular instruction files. **Always-loaded** rules have no frontmatter. **Path-s
 | `database.md` | `**/migrations/**,**/*.sql` | Editing database/migration files |
 | `infrastructure.md` | `**/Dockerfile,**/*.tf` | Editing infrastructure files |
 | `isolation.md` | Always | Every session (cross-session repo isolation, worktree decision tree) |
+| `diagrams.md` | Always | Every session (mermaid-default + drawio-for-complex policy, file convention, MCP usage) |
 | `parallel-agents.md` | Always | Every session (worktree pattern for self-spawned parallel agents) |
 
 ### Agents (`agents/`)
@@ -133,6 +134,7 @@ Reusable workflows invoked on-demand. Cost ~200 tokens when idle (metadata only)
 | `ci` | `/ci` | Monitor CI pipeline status, analyze failures, propose fixes. Use with `/loop 2m /ci` for auto-polling |
 | `mr` | `/mr` | Create MR/PR with template, conventional commit checks, and stacked MR/PR dependency support |
 | `debug` | `/debug <error\|alert>` | Structured incident investigation: evidence, ranked hypotheses, minimal fix, regression test |
+| `diagram` | `/diagram <topic>` | Pick mermaid vs drawio per `rules/diagrams.md`, write the source, preview via drawio MCP |
 
 ### Commands (`commands/`)
 

--- a/commands/document.md
+++ b/commands/document.md
@@ -38,7 +38,7 @@ If a topic does not clearly fit one quadrant, ask. Do not split a single topic a
 2. **Lead with TL;DR** in 3 sentences or fewer, before any heading. Body expands.
 3. **Cite source files** with backticked relative paths (`src/foo/bar.ts`). Link, do not paste. Inline code blocks longer than 15 lines are forbidden - link to the file instead.
 4. **Tables over prose** for any list of more than 3 parallel items.
-5. **Diagrams for relationships only.** No diagram if a 3-row table conveys it. Mermaid only - no draw.io, no PNGs.
+5. **Diagrams for relationships only.** No diagram if a 3-row table conveys it. Mermaid by default; drawio for complex per `rules/diagrams.md`. The `/diagram` skill picks format and writes the source.
 6. **Why before how.** Every explanation doc opens with the problem the thing solves.
 7. **No forward-looking content.** Document only behavior that exists now. No "we plan to", no "in the future".
 8. **No issue/PR/ticket numbers.** They rot. Put them in PR descriptions and git history, not docs.
@@ -47,17 +47,26 @@ If a topic does not clearly fit one quadrant, ask. Do not split a single topic a
 11. **No emoji** unless the user explicitly asked for them.
 12. **No em dashes.** Use a regular hyphen.
 
-## Mermaid conventions
+## Diagram conventions
 
-- Use ` ```mermaid ` fenced blocks. GitHub renders them natively.
-- Diagram type by purpose:
-  - `flowchart TD` for high-level architecture and decision trees
-  - `sequenceDiagram` for request flows, auth flows, async messaging
-  - `erDiagram` for data models
-  - `stateDiagram-v2` for state machines (order status, sync status)
-  - `flowchart LR` with subgraphs for C4-context (services, queues, datastores)
-- Keep node labels short. Put long descriptions in adjacent prose, not in the diagram.
-- One diagram per doc maximum, unless the doc is explicitly an architecture doc.
+Mermaid is the default. Use ` ```mermaid ` fenced blocks - GitHub renders natively. Diagram type by purpose:
+
+- `flowchart TD` for high-level architecture and decision trees
+- `sequenceDiagram` for request flows, auth flows, async messaging
+- `erDiagram` for data models
+- `stateDiagram-v2` for state machines (order status, sync status)
+- `flowchart LR` with subgraphs for C4-context (services, queues, datastores)
+
+Keep node labels short. Long descriptions go in adjacent prose. One diagram per doc maximum unless the doc is explicitly an architecture overview.
+
+Switch to drawio when the diagram needs custom shapes, cloud icons, >2 swimlanes, multi-layer architecture, or precise layout. Source lives at `docs/diagrams/<topic>.drawio` with a committed PNG at `docs/diagrams/<topic>.png` (GitHub previews need the PNG; maintainers need the source). Embed via:
+
+```markdown
+![<topic>](diagrams/<topic>.png)
+*Source: [`<topic>.drawio`](diagrams/<topic>.drawio)*
+```
+
+Use the `/diagram` skill (or `mcp__drawio__*` tools directly) to author drawio diagrams. Full policy in `rules/diagrams.md`.
 
 ## File layout the command produces or expects
 

--- a/rules/diagrams.md
+++ b/rules/diagrams.md
@@ -1,0 +1,77 @@
+# Diagram Policy
+
+Two diagram formats are allowed in `docs/`. Pick by complexity, not by aesthetic preference.
+
+## Mermaid (default)
+
+Use mermaid for diagrams whose value is the **logical structure**, where a clean text representation suffices and reviewers benefit from GitHub's native rendering.
+
+Mermaid is correct when:
+
+- Sequence flows (request lifecycle, auth, async messaging)
+- State machines (order status, sync status)
+- ER diagrams (data models)
+- Class diagrams
+- Simple flowcharts and decision trees
+- Graph/topology with <15 nodes and standard shapes
+- gitGraph, journey, gantt, pie
+
+How:
+
+- Write inline in the doc using ```` ```mermaid ```` fenced blocks. GitHub renders natively.
+- One diagram per doc maximum, unless it is an architecture doc.
+- Keep labels short - long descriptions go in adjacent prose.
+
+## Drawio (for complex)
+
+Use drawio when mermaid genuinely fails the diagram. Reach for drawio when:
+
+- Precise grid / column layout matters (network topology, rack diagrams)
+- Custom shapes / icons / cloud provider symbols are required
+- Swimlanes with >2 lanes or nested swimlanes
+- Multi-layer architecture (data plane + control plane stacked)
+- Color and styling carry semantic weight that mermaid styling cannot express cleanly
+- Interactive editing is expected post-merge (cross-team architecture review)
+
+If you find yourself fighting mermaid syntax for layout reasons, switch to drawio - that's the signal.
+
+### File convention
+
+For each drawio diagram:
+
+- Source: `docs/diagrams/<topic>.drawio` (XML, the source of truth, committed)
+- Render: `docs/diagrams/<topic>.png` (committed alongside so GitHub previews work)
+- Reference from docs: embed the PNG with a markdown image link, then a one-line caption naming the source file.
+
+```markdown
+![Order Lifecycle](diagrams/order-lifecycle.png)
+*Source: [`order-lifecycle.drawio`](diagrams/order-lifecycle.drawio)*
+```
+
+### Authoring via MCP
+
+The `drawio` MCP server is configured in `.mcp.json`. Three tools are exposed:
+
+- `mcp__drawio__open_drawio_xml` - paste raw drawio XML, opens in the editor
+- `mcp__drawio__open_drawio_csv` - tabular import (org charts, lists)
+- `mcp__drawio__open_drawio_mermaid` - mermaid input rendered through drawio (useful when you want a richer-styled version of an existing mermaid diagram)
+
+Workflow:
+
+1. Generate the diagram source as XML / CSV / mermaid.
+2. Write it to `docs/diagrams/<topic>.drawio` (or `.csv` / `.mmd` for the latter two formats - then convert).
+3. Call the matching MCP tool to preview in the browser editor.
+4. Export PNG from the drawio editor (`File > Export As > PNG`) and save next to the source as `docs/diagrams/<topic>.png`. Commit both.
+
+The `/diagram` skill automates steps 1-3.
+
+## Forbidden
+
+- Hand-drawn / scanned diagrams (illegible, undiffable, accessibility-hostile).
+- ASCII art for anything more than a 4-node flow (use mermaid).
+- Embedded screenshots of UML tools other than drawio.
+- Diagrams without a captioned source link in the surrounding doc.
+
+## Drift
+
+If a diagram references code paths or APIs that have changed, update the diagram in the same PR as the code. The `/document` workflow handles drift detection for mermaid diagrams; drawio diagrams need manual review since the editor pipeline is offline.

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: diagram
+description: "Create or update a diagram. Picks mermaid vs drawio per rules/diagrams.md, writes the source file, previews via MCP. Use when the user says 'diagram', '/diagram', or asks for a flowchart/architecture/sequence/state diagram."
+---
+
+Create or update the diagram for: $ARGUMENTS
+
+## Step 1 - Pick the format
+
+Read `rules/diagrams.md` if uncertain. Default to **mermaid** unless one of these triggers fires - then use **drawio**:
+
+- Custom shapes, icons, or cloud provider symbols requested
+- Precise grid / column layout (network topology, rack diagrams)
+- More than 2 swimlanes, or nested swimlanes
+- Multi-layer architecture (stacked data/control planes)
+- Color or styling carries semantic weight that mermaid cannot express
+- The user explicitly says "drawio" or "complex"
+
+If the diagram is borderline, ask the user before committing to drawio.
+
+## Step 2 - Locate the doc
+
+- Identify the doc this diagram belongs to. If `docs/` does not exist, ask the user where to put it.
+- Slug the topic from $ARGUMENTS or the parent doc's filename.
+
+## Step 3 - Mermaid path
+
+1. Write the mermaid source inline in the target doc using ```` ```mermaid ```` fenced blocks (one block per diagram).
+2. Match diagram type to purpose: `flowchart` / `sequenceDiagram` / `stateDiagram-v2` / `erDiagram` / `classDiagram` / `gitGraph` / `journey`.
+3. Keep node labels short. Long descriptions go in adjacent prose.
+4. Verify with `mcp__drawio__open_drawio_mermaid` if you want a quick render check (optional).
+5. Commit the doc.
+
+## Step 4 - Drawio path
+
+1. Generate drawio XML for the diagram. Use `mcp__drawio__open_drawio_xml` reference (in the tool description) for shape catalogue, edge routing, swimlanes, containers.
+2. Write the source to `docs/diagrams/<slug>.drawio`.
+3. Call `mcp__drawio__open_drawio_xml` with the XML content - opens in the browser editor for the user to review and export PNG.
+4. Instruct the user: `File > Export As > PNG > save to docs/diagrams/<slug>.png`. They commit both files.
+5. In the consuming doc, embed:
+
+   ```markdown
+   ![<topic>](diagrams/<slug>.png)
+   *Source: [`<slug>.drawio`](diagrams/<slug>.drawio)*
+   ```
+
+## Step 5 - Drift / update
+
+If updating an existing diagram:
+
+- For mermaid: edit the inline block, keep the same diagram type unless the change requires a different one.
+- For drawio: edit the `.drawio` source, re-open via MCP, re-export PNG, replace both files. Same commit.
+
+## Anti-patterns
+
+- Do not generate ASCII art instead of a real diagram.
+- Do not write more than one mermaid block per doc unless the doc is explicitly an architecture overview.
+- Do not commit a `.drawio` file without its `.png` (GitHub reviewers need the preview).
+- Do not ship a `.png` without its `.drawio` source (next maintainer needs to edit it).
+- Do not invent layout coordinates manually for drawio - rely on its auto-layout. Set node ids, labels, edges, lanes; let drawio route.


### PR DESCRIPTION
## Summary

Mermaid stays the default for simple diagrams (sequence, state, ER, class, basic flowchart). Drawio is now allowed for the complex cases mermaid handles poorly (custom shapes, network topology, multi-layer architecture, >2 swimlanes, precise layout). The drawio MCP server was already wired in `.mcp.json` - this PR codifies when to reach for it and adds tooling to make it cheap.

### What's in this PR

- **`rules/diagrams.md`** (new, always-loaded) - decision rule, file convention, MCP tool inventory, anti-patterns. Mermaid by default; drawio when triggered. Drawio diagrams live at `docs/diagrams/<topic>.drawio` (XML source) with `docs/diagrams/<topic>.png` (committed export so GitHub previews work). Embed pattern documented.
- **`skills/diagram/SKILL.md`** (new) - `/diagram <topic>` workflow: pick format by trigger list, write source, call MCP for preview, instruct user to export PNG. Anti-patterns covered (no orphan source, no orphan PNG, no manual layout coords).
- **`CLAUDE.md`** - docs-sync rule relaxed from `Mermaid only - no draw.io, no PNGs` to `Mermaid default, drawio for complex per rules/diagrams.md`.
- **`commands/document.md`** - same relaxation. The "Mermaid conventions" section is renamed to "Diagram conventions" and now covers both formats with the drawio embedding pattern.
- **`README.md`** - registers the new rule and skill.

### Why drawio now

`/insights` showed prior MCP setup friction (3 sessions burned). Existing config in `.mcp.json` already lists `@drawio/mcp` - smoke-tested `mcp__drawio__open_drawio_mermaid` in this branch and got back a valid `app.diagrams.net` editor URL. The pipeline works.

### Tradeoffs

- **PNG bloat**: drawio diagrams ship with a committed PNG. Cost is repo size; benefit is GitHub preview in PR review without anyone needing the drawio app.
- **Manual PNG export**: drawio MCP opens the editor in the browser; export is `File > Export As > PNG`. Could be automated with `drawio-desktop` CLI later if it becomes a friction point.
- **Two source-of-truth files per drawio diagram** (`.drawio` + `.png`): explicit anti-pattern in the skill prevents orphan commits.

## Test plan

- [x] markdownlint clean against the CI version (v0.17.2 / markdownlint v0.37.4)
- [x] `mcp__drawio__open_drawio_mermaid` smoke test - returns a valid editor URL
- [ ] End-to-end `/diagram` invocation in a real repo (manual, post-merge)
- [ ] Generate one drawio source + PNG and confirm GitHub preview renders (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)