### PR TITLE
feat: auto-cleanup of safely-disposable worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Slash commands for frequent workflows. Available as `/user:<name>`.
 | `locks` | `/user:locks [--prune\|--release <hash>]` | List active Claude session locks across repos; prune stale; force-release |
 | `worktree` | `/user:worktree <slug>` | Create an isolated git worktree on a fresh branch and switch into it. Resolves cross-session collisions before they happen. |
 | `worktree-merge` | `/user:worktree-merge` | Clean up the current worktree after its branch is merged. Removes worktree dir, deletes local branch, releases lock. |
+| `worktrees-prune` | `/user:worktrees-prune [--apply]` | Per-repo dry-run / apply: remove worktrees whose branch is upstream-gone or merged into default. |
+| `worktrees-audit` | `/user:worktrees-audit [--root <path>] [--apply]` | Cross-repo scan under `~/dev/`, verdict per worktree, optional bulk apply. |
 
 ### Hooks (`hooks/`)
 
@@ -162,6 +164,7 @@ Automation scripts triggered at lifecycle events. Configured in `settings.json` 
 | `repo-lock-status.sh` | SessionStart (startup\|resume) | Claim the repo lock for this session (or notice if held by another live session). Advisory, never blocks. |
 | `repo-lock-heartbeat.sh` | PostToolUse (Write\|Edit\|Bash) | Refresh lock `last_seen` so the session stays alive. Throttled to 60s via lock mtime. Never blocks. |
 | `repo-lock-release.sh` | SessionEnd | Release the repo lock if owned by this session. Idempotent. |
+| `worktree-cleanup.sh` | SessionEnd | Opportunistic safe-prune of the current repo's worktrees. Conservative; never blocks. Disable per-session with `CLAUDE_DISABLE_WORKTREE_CLEANUP=1`. |
 | `repo-lock-guard.sh` | PreToolUse (Write\|Edit\|Bash mutations) | Hard-block mutations when another live session holds the lock and current session is not in a worktree. Bypass with `SKIP_LOCK=1`. |
 | `auto-format.sh` | PostToolUse (Write/Edit) | Auto-format files with project formatter (Biome/Prettier) |
 | `post-edit-typecheck.sh` | PostToolUse (Write/Edit) | Run typecheck and lint on .ts/.tsx files after edits |
@@ -178,6 +181,7 @@ Utility scripts referenced by skills and hooks.
 | `notify.sh` | Send macOS desktop notification unless a terminal or IDE is in the foreground |
 | `statusline.sh` | Status line showing model, repo, branch, and node version. Symlink to `~/.claude/statusline.sh` |
 | `repo-lock.sh` | Repo lock manager. `claim/release/check/list/prune` against `~/.claude/locks/<sha1>.json`. Used by isolation hooks. |
+| `worktree-prune.sh` | Identify and (with `--apply`) remove safely-disposable worktrees. Conservative rule: upstream-gone OR merged into default. `audit-all` mode walks `~/dev/`. |
 
 ### State (`.claude/state/` per project)
 

--- a/commands/summarize.md
+++ b/commands/summarize.md
@@ -30,13 +30,6 @@ Also output the summary to the conversation. Keep it concise - suitable for a st
 
 ## Worktree auto-cleanup
 
-After saving the diary, scan worktrees owned by this repo and remove ones that are safely disposable:
+After saving the diary, run `~/.claude/scripts/worktree-prune.sh --apply` against the current repo. The script applies the conservative rule (upstream-gone OR merged into default) and reports what was removed vs kept. Locked worktrees are auto-unlocked iff safely removable. Anything with unpushed work or open PR is preserved.
 
-1. `git worktree list --porcelain` to list every worktree.
-2. For each non-main worktree, check its branch:
-   - If the branch's upstream is `gone` (remote branch deleted, e.g. PR merged) - safe to remove.
-   - If `git rev-list --count <branch>@{upstream}..<branch>` is 0 (no unpushed commits) - safe to remove.
-   - Otherwise (unpushed work, no upstream, or uncommitted changes) - skip and tell the user the worktree was preserved with a one-line reason.
-3. For each safe worktree: `git worktree remove <path>` and `git branch -d <branch>`. Release the lock with `~/.claude/scripts/repo-lock.sh release <path>` if needed.
-
-Never force-remove. Never delete a branch with unpushed commits. If in doubt, preserve and report.
+The same hook fires automatically at SessionEnd, so this step is mostly for explicit closure and surface visibility.

--- a/commands/worktrees-audit.md
+++ b/commands/worktrees-audit.md
@@ -1,0 +1,26 @@
+---
+description: "Cross-repo worktree audit. Scans ~/dev/ (or --root <path>) for git repos and reports their worktrees with SAFE / KEEP verdicts. With --apply, removes the safe ones across every repo found."
+---
+
+Run a cross-repo worktree audit: $ARGUMENTS
+
+## Behavior
+
+`~/.claude/scripts/worktree-prune.sh audit-all [--root <path>] [--apply]`
+
+- Walks `--root <path>` (default `~/dev/`) up to 4 levels deep, finds every git repo (skipping nested worktree dirs that share their parent's git common dir).
+- For each repo: same dry-run (or apply) report as `/user:worktrees-prune`.
+
+## Use cases
+
+- After a long stretch where multiple repos accumulated stale worktrees.
+- Periodic hygiene pass (run weekly with `--apply` if the dry-run output looks correct).
+- Diagnosing "where did all my worktrees go" - the audit shows you everything in one pass.
+
+## Tip
+
+Run `git fetch --prune origin` in each repo first if you want upstream-gone detection to be current. The script does NOT fetch automatically (network cost across many repos). The `merged-into-default` check works offline.
+
+## Safety
+
+Conservative rule: only worktrees whose branch is **upstream-gone** OR **merged into default** are marked SAFE. Locked ones are unlocked iff safe. Anything with unpushed work or an open PR is preserved.

--- a/commands/worktrees-prune.md
+++ b/commands/worktrees-prune.md
@@ -1,0 +1,32 @@
+---
+description: "Identify and (with --apply) remove safely-disposable git worktrees in the current repo. Conservative: only removes worktrees whose branch is upstream-gone or merged into default."
+---
+
+Run `~/.claude/scripts/worktree-prune.sh` against the current repo: $ARGUMENTS
+
+## Defaults
+
+- Without `--apply`, this is **dry-run**: prints SAFE / KEEP verdicts and exits without changes.
+- With `--apply`, removes safe worktrees and deletes their local branches.
+
+## Flags passed through
+
+- `--apply` - actually remove. Without it, only report.
+- `--repo <path>` - target a different repo than `$PWD`.
+
+## Safety rule
+
+A worktree is "safe to remove" only if its branch is:
+
+- **upstream-gone** (the remote branch was deleted, typically after PR merge), OR
+- **merged into the repo's default branch** (origin/HEAD or main/master).
+
+Locked worktrees are unlocked iff they pass the safety rule. Default-branch checkouts are never removed. Worktrees with unmerged commits or open PRs are kept.
+
+## Tip
+
+Run `git fetch --prune origin` in the repo first to refresh remote-tracking branches. Otherwise `[gone]` detection lags behind the remote.
+
+## Recommendation
+
+If the dry-run output looks right, re-run with `--apply`. The SessionEnd hook does this opportunistically too, so for actively-used repos you rarely need to run it manually.

--- a/hooks/worktree-cleanup.sh
+++ b/hooks/worktree-cleanup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SessionEnd hook: opportunistically prune safely-disposable worktrees in
+# the current repo. Conservative - only removes worktrees whose branch is
+# upstream-gone or merged into default. Always exits 0; never blocks.
+# Disable per-session with CLAUDE_DISABLE_WORKTREE_CLEANUP=1.
+
+set -u
+
+if [ "${CLAUDE_DISABLE_WORKTREE_CLEANUP:-0}" = "1" ]; then
+  exit 0
+fi
+
+SCRIPT="$CLAUDE_PROJECT_DIR/scripts/worktree-prune.sh"
+[ -x "$SCRIPT" ] || SCRIPT="$HOME/.claude/scripts/worktree-prune.sh"
+[ -x "$SCRIPT" ] || exit 0
+
+# Only run inside a git repo
+git -C "$PWD" rev-parse --show-toplevel >/dev/null 2>&1 || exit 0
+
+# Run apply mode silently. The script is conservative; it will skip anything
+# uncertain and only remove obviously-safe entries.
+"$SCRIPT" --apply >/dev/null 2>&1 || true
+exit 0

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -64,6 +64,7 @@ After all agents complete:
 3. After each merge, check for conflicts and resolve immediately
 4. Run the full test suite, typecheck, and lint after all merges are complete
 5. If a merge conflict arises, resolve it manually - do NOT re-spawn an agent for conflict resolution
+6. After all branches are merged into the integration branch, prune the agent worktrees: `~/.claude/scripts/worktree-prune.sh --apply`. The conservative rule will only remove worktrees whose branch is upstream-gone or merged into the default - exactly the post-merge state. Locked worktrees will auto-unlock if safe. Anything still active is preserved.
 
 ## Agent Prompt Quality
 

--- a/scripts/worktree-prune.sh
+++ b/scripts/worktree-prune.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# worktree-prune: identify and (optionally) remove safely-disposable git
+# worktrees. Conservative by default - only removes worktrees whose branch
+# is upstream-gone (PR merged + remote branch deleted) OR merged into the
+# repo's default branch. Locked worktrees are auto-unlocked iff the branch
+# is safely removable.
+#
+# Usage:
+#   worktree-prune.sh [--apply] [--repo <path>]
+#   worktree-prune.sh audit-all [--apply] [--root <path>]   # default root: $HOME/dev
+#
+# Without --apply this is dry-run: prints verdicts and exits without changes.
+# Exit codes: 0 always (audit/prune are advisory, never block).
+
+set -u
+
+APPLY=0
+MODE=prune
+REPO=""
+ROOT="${HOME}/dev"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --repo)  REPO="${2:-}"; shift ;;
+    --root)  ROOT="${2:-}"; shift ;;
+    audit-all) MODE=audit-all ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# Color codes when stdout is a tty
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
+else
+  C_RED=""; C_GREEN=""; C_YELLOW=""; C_DIM=""; C_RESET=""
+fi
+
+# Determine the repo's default branch (origin/HEAD if set, else main, else master)
+default_branch() {
+  local repo="$1"
+  local d
+  d=$(git -C "$repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
+  if [ -n "$d" ]; then echo "$d"; return; fi
+  for cand in main master trunk; do
+    git -C "$repo" rev-parse --verify "refs/heads/$cand" >/dev/null 2>&1 && { echo "$cand"; return; }
+  done
+  echo ""
+}
+
+# Parse `git worktree list --porcelain` into TAB-separated rows:
+#   path \t HEAD \t branch \t locked(0|1) \t prunable(0|1)
+list_worktrees() {
+  local repo="$1"
+  git -C "$repo" worktree list --porcelain 2>/dev/null | awk '
+    /^worktree / { if (path) print path"\t"head"\t"branch"\t"locked"\t"prunable; path=$2; head=""; branch=""; locked=0; prunable=0; next }
+    /^HEAD /     { head=$2; next }
+    /^branch /   { sub(/^branch /,""); sub(/^refs\/heads\//,""); branch=$0; next }
+    /^locked/    { locked=1; next }
+    /^prunable/  { prunable=1; next }
+    END          { if (path) print path"\t"head"\t"branch"\t"locked"\t"prunable }
+  '
+}
+
+is_branch_merged() {
+  local repo="$1" branch="$2" default_br="$3"
+  [ -z "$default_br" ] && return 1
+  git -C "$repo" merge-base --is-ancestor "$branch" "$default_br" 2>/dev/null
+}
+
+upstream_gone() {
+  local repo="$1" branch="$2"
+  local track
+  track=$(git -C "$repo" for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null)
+  [ "$track" = "[gone]" ]
+}
+
+# Verdict per worktree: "safe" or "keep". Echos verdict + reason on stdout.
+verdict() {
+  local repo="$1" path="$2" branch="$3" locked="$4" prunable="$5"
+  local default_br
+  default_br=$(default_branch "$repo")
+
+  if [ "$prunable" = "1" ]; then
+    echo "safe disk-missing-prunable"; return
+  fi
+  if [ -z "$branch" ]; then
+    echo "keep detached-HEAD-no-branch"; return
+  fi
+  if [ "$branch" = "$default_br" ]; then
+    echo "keep default-branch-checkout"; return
+  fi
+  if upstream_gone "$repo" "$branch"; then
+    echo "safe upstream-gone"; return
+  fi
+  if is_branch_merged "$repo" "$branch" "$default_br"; then
+    echo "safe merged-into-$default_br"; return
+  fi
+  if [ "$locked" = "1" ]; then
+    echo "keep locked-and-not-merged"; return
+  fi
+  # Unpushed work or open PR
+  echo "keep unmerged-or-active"
+}
+
+prune_repo() {
+  local repo="$1"
+  local main_path
+  main_path=$(git -C "$repo" rev-parse --show-toplevel 2>/dev/null)
+  [ -z "$main_path" ] && return 0
+
+  # Drop disk-gone entries first
+  git -C "$repo" worktree prune 2>/dev/null
+
+  local total=0 safe=0 kept=0 acted=0
+  local rows
+  rows=$(list_worktrees "$repo")
+  [ -z "$rows" ] && return 0
+
+  printf '%s== %s ==%s\n' "$C_DIM" "$repo" "$C_RESET"
+
+  while IFS=$'\t' read -r path head branch locked prunable; do
+    [ -z "$path" ] && continue
+    total=$((total+1))
+    # Skip the main worktree
+    if [ "$path" = "$main_path" ]; then
+      kept=$((kept+1))
+      continue
+    fi
+
+    local v reason
+    v=$(verdict "$repo" "$path" "$branch" "$locked" "$prunable")
+    reason=${v#* }
+    v=${v%% *}
+
+    if [ "$v" = "safe" ]; then
+      safe=$((safe+1))
+      printf '  %sSAFE%s   %s  branch=%s  reason=%s\n' "$C_GREEN" "$C_RESET" "$path" "${branch:-?}" "$reason"
+      if [ "$APPLY" = "1" ]; then
+        if [ "$locked" = "1" ]; then
+          git -C "$repo" worktree unlock "$path" 2>/dev/null
+        fi
+        if git -C "$repo" worktree remove "$path" 2>/dev/null; then
+          # Delete the local branch too if not the default and it exists
+          if [ -n "$branch" ] && [ "$branch" != "$(default_branch "$repo")" ]; then
+            git -C "$repo" branch -D "$branch" >/dev/null 2>&1 || true
+          fi
+          acted=$((acted+1))
+          printf '         %s-> removed%s\n' "$C_DIM" "$C_RESET"
+        else
+          # Disk-missing, just clean the registry
+          git -C "$repo" worktree prune 2>/dev/null
+          acted=$((acted+1))
+          printf '         %s-> pruned (disk gone)%s\n' "$C_DIM" "$C_RESET"
+        fi
+      fi
+    else
+      kept=$((kept+1))
+      local color="$C_YELLOW"
+      [ "$reason" = "default-branch-checkout" ] && color="$C_DIM"
+      printf '  %sKEEP%s   %s  branch=%s  reason=%s\n' "$color" "$C_RESET" "$path" "${branch:-?}" "$reason"
+    fi
+  done <<< "$rows"
+
+  if [ "$APPLY" = "1" ]; then
+    printf '  %s%d total, %d removed, %d kept%s\n\n' "$C_DIM" "$total" "$acted" "$kept" "$C_RESET"
+  else
+    printf '  %s%d total, %d safe-to-remove, %d kept%s\n\n' "$C_DIM" "$total" "$safe" "$kept" "$C_RESET"
+  fi
+}
+
+case "$MODE" in
+  prune)
+    R="${REPO:-$PWD}"
+    git -C "$R" rev-parse --show-toplevel >/dev/null 2>&1 || { echo "not in a git repo: $R" >&2; exit 0; }
+    prune_repo "$(git -C "$R" rev-parse --show-toplevel)"
+    ;;
+  audit-all)
+    [ -d "$ROOT" ] || { echo "root not found: $ROOT" >&2; exit 0; }
+    # Find repos: any .git directory or file at depth <= 4
+    while IFS= read -r git_path; do
+      repo=$(dirname "$git_path")
+      # Skip nested worktree git dirs (those live inside another repo's tree)
+      gd=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null)
+      td=$(git -C "$repo" rev-parse --git-dir 2>/dev/null)
+      [ "$gd" != "$td" ] && continue
+      prune_repo "$repo"
+    done < <(find "$ROOT" -maxdepth 4 \( -name .git -type d -o -name .git -type f \) 2>/dev/null | sort)
+    ;;
+esac
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -192,6 +192,11 @@
             "type": "command",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/repo-lock-release.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/repo-lock-release.sh\"; [ -x \"$HOOK\" ] && \"$HOOK\" || true",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/worktree-cleanup.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/worktree-cleanup.sh\"; [ -x \"$HOOK\" ] && \"$HOOK\" || true",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
## Summary

Stale worktrees accumulate because nothing automatically prunes them when their branch lifecycle ends. Causes observed across `~/dev/`:

1. **Parallel-agents pattern** spawns `.claude/worktrees/agent-<id>` per Task agent. The Agent tool only auto-cleans worktrees that made *zero changes* - any commit and the worktree persists.
2. **`/user:worktree-merge` is manual** - users (and Claude) forget.
3. **Sessions abort/crash** before `/user:summarize` runs. SessionEnd hook only released the lock; never touched worktrees.
4. **Locked worktrees** (`git worktree lock`) are never auto-unlocked when work ends.

This PR adds a conservative pruner with a SessionEnd trigger and on-demand commands.

### Safety rule (per user choice)

A worktree is "safe to remove" only if its branch is:

- **upstream-gone** (remote branch deleted, typically after PR merge), OR
- **merged into the repo's default branch** (`origin/HEAD` or `main`/`master`).

Locked worktrees are auto-unlocked iff they pass the rule. Default-branch checkouts are never removed. Anything with unpushed work or active state is preserved.

### What's in this PR

- **`scripts/worktree-prune.sh`** - the engine. Subcommands:
  - default: per-repo dry-run / `--apply`. Targets `$PWD` or `--repo <path>`.
  - `audit-all` - walks `--root <path>` (default `~/dev/`) up to depth 4, skipping nested worktree git dirs.
  - Color verdicts when stdout is a TTY (SAFE in green, KEEP in yellow). Always exits 0.
  - Runs `git worktree prune` first to drop disk-gone entries.
- **`hooks/worktree-cleanup.sh`** - SessionEnd hook. Calls the script in `--apply` mode, silently. Disable per-session with `CLAUDE_DISABLE_WORKTREE_CLEANUP=1`. Conservative rule means no surprises.
- **`commands/worktrees-prune.md`** - `/user:worktrees-prune [--apply]` per-repo.
- **`commands/worktrees-audit.md`** - `/user:worktrees-audit [--root <path>] [--apply]` cross-repo.
- **`commands/summarize.md`** - replaces inline cleanup logic with a call to the script (single source of truth).
- **`rules/parallel-agents.md`** - adds step 6 to the Merging Results checklist: run the pruner after integrating parallel-agent branches.
- **`settings.json`** - wires the new SessionEnd hook alongside `repo-lock-release.sh`.
- **`README.md`** - registers script, hook, and two new commands.

### Empirical baseline

Dry-run audit of `~/dev/` at PR-time shows everything correctly classified. The 4 sibling worktrees and 1 nested `.claude/worktrees/migrate-shared` all have unmerged branches and are kept. No false positives.

## Test plan

- [x] Syntax check on script + hook
- [x] Dry-run on the claude repo and audit-all on `~/dev/` - kept everything (correctly, since nothing is merged)
- [x] markdownlint v0.17.2 / 0.37.4 clean across all touched .md files
- [x] SessionEnd hook wired alongside the existing release hook
- [ ] After a PR merges and remote branch is deleted, run `/user:worktrees-prune` - expect SAFE verdict on that worktree (manual, post-merge)
- [ ] After deliberate `git worktree lock` on a merged-branch worktree, run `--apply` - expect auto-unlock + remove (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)