### PR TITLE
fix(rtk): raise hook adoption + scoped proxy guidance

### DIFF
--- a/RTK.md
+++ b/RTK.md
@@ -27,3 +27,19 @@ All other commands are automatically rewritten by the Claude Code hook.
 Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
 
 Refer to CLAUDE.md for full command reference.
+
+## Hook Bailouts to Avoid
+
+The RTK hook silently falls back to raw output when a command contains shell
+operators it cannot parse cleanly. To keep adoption high:
+
+- **Do not append `2>&1`** — RTK filters already surface stderr usefully; the
+  redirect suppresses the rewrite and loses the savings. Let failure output
+  flow through naturally.
+- Avoid command substitution (`$(...)`), pipes into interpreters
+  (`| python -c`, `| node -e`), and compound commands (`&&`, `;`) when a
+  simpler single-command form exists.
+
+**Exception: `glab`** — RTK has no `glab` filter yet (tracked upstream at
+rtk-ai/rtk#1085). Until that ships, `glab` commands bypass RTK regardless of
+redirects, so `2>&1` is harmless there.

--- a/RTK.md
+++ b/RTK.md
@@ -43,3 +43,26 @@ operators it cannot parse cleanly. To keep adoption high:
 **Exception: `glab`** — RTK has no `glab` filter yet (tracked upstream at
 rtk-ai/rtk#1085). Until that ships, `glab` commands bypass RTK regardless of
 redirects, so `2>&1` is harmless there.
+
+## When NOT to reach for `rtk proxy`
+
+`rtk proxy <cmd>` strips all RTK filtering, including adapter-specific
+summaries (vitest failures, tsc error grouping, lint diagnostics). That
+makes it a scalpel, not a session-wide shield. Reach for it only when an
+rtk adapter is provably broken for one specific command.
+
+- **Default**: bare `npm` / bare tool invocation. Trust RTK filters to
+  surface failures. Do not prefix `rtk proxy` out of habit.
+- **When one adapter misbehaves** (e.g. the lint adapter on a Biome
+  project emitting `ESLint output (JSON parse failed: EOF ...)`), scope
+  `rtk proxy` to just that one command (`rtk proxy npm run lint`). Leave
+  every other command on bare invocation so their adapters keep working.
+- **A quiet proxied run is not a validated run**. `rtk proxy` shows raw
+  end-of-stream output, which can look like success even when a coverage
+  gate, typecheck, or integration assertion failed mid-stream. If you
+  used `rtk proxy`, re-read the raw output yourself; do not trust the
+  tail.
+- **Before reaching for proxy, dry-run the rewrite**: `rtk hook check
+  "<cmd>"` prints what rtk will rewrite the command to. If it routes to
+  an adapter that does not match the actual tool (`biome check` ->
+  `rtk lint check`), that is the collision to scope a proxy around.

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "RTK_HOOK_AUDIT": "1"
   },
   "autoUpdatesChannel": "stable",
   "minimumVersion": "2.1.92",


### PR DESCRIPTION
## What does this PR do?

Improves RTK hook diagnosability and clarifies when bare invocation beats
`rtk proxy`.

- Add `RTK_HOOK_AUDIT=1` env so `rtk hook-audit` can show which Bash
  commands the PreToolUse hook rewrote vs. skipped and why - without it,
  hook adoption gaps are undiagnosable.
- New `Hook Bailouts to Avoid` section in `RTK.md` warning sessions not
  to append `2>&1` (suppresses the rewrite) or use compound shell forms;
  flags `glab` as the current exception.
- New `When NOT to reach for rtk proxy` section explaining that proxy
  strips adapter-specific filtering (vitest summaries, tsc grouping,
  lint diagnostics), so it should be scoped to one misbehaving adapter
  rather than blanket-prefixed across a session. Recommends
  `rtk hook check "<cmd>"` to dry-run rewrites.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant