### PR TITLE
fix(ci): use Pipeline state line as source of truth in glab-ci-monitor

### DIFF
--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -15,6 +15,10 @@
    - **Pipeline passes** (`completed|success`):
      - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"`
      - Report success
+   - **Pipeline awaiting manual action** (`completed|manual`, GitLab only):
+     - All automatic jobs completed; the pipeline is paused on a manual gate and will not progress without user action
+     - Run `~/.claude/scripts/notify.sh "CI awaiting manual action - <branch-name>"`
+     - Report status and stop watching - do NOT trigger the manual job automatically
    - **Pipeline fails** (`completed|failure` or any non-success conclusion):
      a. Fetch the job log:
         - GitLab: `glab ci trace <job-id>`

--- a/skills/ci/scripts/glab-ci-monitor.sh
+++ b/skills/ci/scripts/glab-ci-monitor.sh
@@ -4,30 +4,53 @@
 # Exits when the pipeline reaches a terminal state.
 set -euo pipefail
 
-prev=""
+prev_state=""
+prev_first=""
 error_count=0
 
 while true; do
-  raw=$(glab ci status 2>/dev/null) || raw="error|unknown"
-  cur="${raw%%$'\n'*}"
+  raw=$(glab ci status 2>/dev/null) || raw=""
 
-  # Track consecutive errors
-  if [[ "$cur" == error* ]]; then
+  if [ -z "$raw" ]; then
     error_count=$((error_count + 1))
     if [ "$error_count" -ge 5 ]; then
       echo "error|persistent-failure"
       exit 1
     fi
-  else
-    error_count=0
+    sleep 30
+    continue
+  fi
+  error_count=0
+
+  # Source of truth: the trailing "Pipeline state: <state>" line.
+  # `glab ci status` lists jobs above it; the first job line can be a
+  # `manual`/`skipped` outlier that does not reflect overall progress.
+  # Take the LAST match via awk's END block (no SIGPIPE risk under
+  # pipefail) and strip the label prefix so we tolerate extra fields.
+  state_line=$(awk '/^Pipeline state:/ { line = $0 } END { print line }' <<<"$raw")
+  state="${state_line##*: }"
+  first="${raw%%$'\n'*}"
+
+  if [ "$first" != "$prev_first" ]; then
+    echo "$first"
+    prev_first="$first"
   fi
 
-  if [ "$cur" != "$prev" ]; then
-    echo "$cur"
-    prev="$cur"
-    case "$cur" in
-      *passed*|*failed*|*canceled*|*skipped*) exit 0 ;;
+  if [ "$state" != "$prev_state" ] && [ -n "$state" ]; then
+    case "$state" in
+      success|failed|canceled|skipped|manual)
+        # Terminal from the monitor's POV: nothing more will happen
+        # automatically. `manual` means all automatic jobs completed and
+        # the pipeline is paused on a manual gate awaiting human action,
+        # so treat it as semi-done and stop watching.
+        # Emit a structured marker so the consumer can branch on outcome
+        # without re-parsing glab's free-form job lines. Mirrors the
+        # `completed|<conclusion>` contract of gh-ci-monitor.sh.
+        echo "completed|$state"
+        exit 0
+        ;;
     esac
+    prev_state="$state"
   fi
 
   sleep 30


### PR DESCRIPTION
## What does this PR do?

Fixes a premature-exit bug in `skills/ci/scripts/glab-ci-monitor.sh`,
aligns its output contract with the gh sibling, and hardens the parse.

The monitor was matching against the **first** line of `glab ci status`
(a job line) and exiting on `passed|failed|canceled|skipped`. If an
early job came back `manual` or `skipped` while later stages were still
running, the script terminated and `/ci` stopped reporting progress.

- Parse the trailing `Pipeline state: <state>` line from `glab ci status`
  as the source of truth. Exit only when that state is terminal:
  `success | failed | canceled | skipped | manual`. `manual` is treated
  as terminal (semi-done) - all automatic jobs are complete, the
  pipeline is paused on a human gate, nothing more will happen without
  user action.
- Emit `completed|<state>` before exit so `/ci` can branch on outcome
  without re-parsing glab's free-form output. Matches the structured
  contract already produced by `gh-ci-monitor.sh`. `SKILL.md` documents
  the `completed|manual` reaction: notify, report, do NOT auto-trigger
  the manual job.
- Still echo the first job line on change so per-stage progress remains
  visible during the run.

Smaller hardening:
- Switch the consecutive-error counter to a clean empty-output check
  instead of a fragile string match against the synthetic `error|unknown`
  placeholder.
- Replace `printf | awk | tail -1` with awk's `END` block to avoid the
  SIGPIPE-under-pipefail hazard.
- Extract the state via `${line##*: }` instead of positional `$3` so
  trailing fields in the glab output do not break the parse.

## Category

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant