### PR TITLE
feat(statusline): show context window usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Utility scripts referenced by skills and hooks.
 | Script | Purpose |
 | --- | --- |
 | `notify.sh` | Send macOS desktop notification unless a terminal or IDE is in the foreground |
-| `statusline.sh` | Status line showing model, repo, branch, and node version. Symlink to `~/.claude/statusline.sh` |
+| `statusline.sh` | Status line showing repo, branch (red if dirty), node version, and context usage (`145.7k (15%)`, color-graded green/yellow/red). Symlink to `~/.claude/statusline.sh` |
 | `repo-lock.sh` | Repo lock manager. `claim/release/check/list/prune` against `~/.claude/locks/<sha1>.json`. Used by isolation hooks. |
 | `worktree-prune.sh` | Identify and (with `--apply`) remove safely-disposable worktrees. Conservative rule: upstream-gone OR merged into default. `audit-all` mode walks `~/dev/`. |
 

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -35,6 +35,25 @@ elif command -v node >/dev/null 2>&1; then
   node_version=$(node -v 2>/dev/null)
 fi
 
+# Context: only present after first API call (current_usage non-null)
+has_usage=$(echo "$input" | jq -r '.context_window.current_usage // empty')
+ctx_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+# Compact a raw token number to e.g. "45.2k" or "999"
+compact_tokens() {
+  echo "$1" | awk '{
+    if ($1 >= 1000) {
+      val = $1 / 1000
+      # One decimal place, strip trailing .0
+      s = sprintf("%.1fk", val)
+      sub(/\.0k$/, "k", s)
+      print s
+    } else {
+      printf "%d", $1
+    }
+  }'
+}
+
 # Build output
 printf "${BOLD}${CYAN}%s${RESET}" "$folder"
 
@@ -44,4 +63,31 @@ fi
 
 if [ -n "$node_version" ]; then
   printf " ${DIM}node${RESET} ${YELLOW}%s${RESET}" "$node_version"
+fi
+
+# Context block: only render when current_usage is available
+if [ -n "$has_usage" ] && [ -n "$ctx_pct" ]; then
+  pct_int=$(echo "$ctx_pct" | awk '{printf "%d", $1}')
+  if [ "$pct_int" -ge 80 ]; then
+    pct_color="$RED"
+  elif [ "$pct_int" -ge 50 ]; then
+    pct_color="$YELLOW"
+  else
+    pct_color="$GREEN"
+  fi
+
+  # Sum context-consuming tokens (output tokens are NOT part of the context window)
+  used_tokens=$(echo "$input" | jq -r '
+    (.context_window.current_usage.input_tokens // 0)
+    + (.context_window.current_usage.cache_read_input_tokens // 0)
+    + (.context_window.current_usage.cache_creation_input_tokens // 0)
+  ')
+
+  # Window size: prefer the reported field, fall back to 200000
+  window_size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+
+  used_label=$(compact_tokens "$used_tokens")
+
+  printf " ${DIM}context${RESET} ${pct_color}%s (%d%%)${RESET}" \
+    "$used_label" "$pct_int"
 fi


### PR DESCRIPTION
## Summary
- Adds a `context 145.7k (15%)` block to the status line so every session (local and cloud) shows live context-window usage.
- Sums input + cache_read + cache_creation tokens; output tokens are excluded since they don't consume the window.
- Color-graded: green <50%, yellow 50-79%, red >=80%. Block is hidden until the first API call populates `context_window`.
- Updates README script table to match.

## Test plan
- [x] Local session renders `context <tokens> (<pct>%)` after first response
- [x] Block is suppressed before any API call (no `current_usage`)
- [x] Color thresholds verified at boundary percentages
- [ ] Confirm cloud session picks it up on next bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)