### PR TITLE
chore(agents): spawn agents as subagents instead of reading into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Modular instruction files. **Always-loaded** rules have no frontmatter. **Path-s
 
 | Rule | Scope | Loads when... |
 | --- | --- | --- |
-| `agent-routing.md` | Always | Every session (agent selection table) |
+| `agent-routing.md` | Always | Every session (subagent_type lookup + cross-domain combinations) |
 | `git-conventions.md` | Always | Every session (commits, PRs, semver) |
 | `engineering-principles.md` | Always | Every session (sizing, slicing, exploration) |
 | `state-persistence.md` | Always | Every session (artifact saving, naming) |
@@ -114,7 +114,7 @@ Modular instruction files. **Always-loaded** rules have no frontmatter. **Path-s
 
 ### Agents (`agents/`)
 
-16 expert agent personas across 5 categories. Each follows a 9-section structure with strict guardrails, review checklists, and red-flag detection. Loaded automatically via the routing table in `rules/agent-routing.md`.
+16 expert agent personas across 5 categories. Each follows a 9-section structure with strict guardrails, review checklists, and red-flag detection. Spawned as subagents via the Agent tool when a task touches a specialized domain. The routing table in `rules/agent-routing.md` maps domain triggers to `subagent_type` values. See [ADR 0003](docs/adr/0003-agents-via-subagent-spawn.md) for the loading model.
 
 See [Agent Reference](docs/agents.md) for the full listing.
 

--- a/docs/adr/0003-agents-via-subagent-spawn.md
+++ b/docs/adr/0003-agents-via-subagent-spawn.md
@@ -1,0 +1,36 @@
+# Agents are spawned as subagents, not read into the main conversation
+
+## Status
+
+Accepted - 2026-05-09
+
+## Context
+
+The original `rules/agent-routing.md` instructed Claude to *"Always load agents before research phase - read the files before forming opinions"*. In practice that meant 3-4K tokens of agent persona content was injected into the main conversation any time a task touched a specialized domain. Cross-domain work loaded multiple agents into the same thread, often 12-15K tokens of guardrails, biases, and frame-of-reference for one phase of work that would persist for the rest of the session.
+
+The Agent tool's `subagent_type` parameter exposes the same agent personas as full subagents with their own context window. The parent receives the subagent's summary, not the agent's full guidance. This is structurally cheaper and cleaner: the Postgres expert's biases live in a Postgres-shaped subagent and don't bleed into the frontend work an hour later.
+
+The cost driver is also the routing table itself. The previous version had 27 rows mapping topic triggers to agent files, with redundant "Domain trigger" and "Load when..." columns - ~3.5K tokens always-loaded.
+
+## Decision
+
+Two structural changes:
+
+1. **Loading model.** When a task touches a specialized domain, spawn a subagent via the Agent tool with the matching `subagent_type`. Do not read agent files into the main conversation. The subagent's summary is what the parent acts on.
+
+2. **Routing table slimmed.** Collapsed from 27 trigger-keyed rows to 16 agent-keyed rows (one per agent), with one combined trigger column instead of two. Cross-domain combinations (UI work, perf work, EU data handling, etc.) moved to a separate, smaller section. Net: ~50% reduction in always-loaded routing tokens.
+
+Trivial changes still skip subagent spawning entirely.
+
+## Consequences
+
+- Cost in the main conversation drops to ~0 per agent invocation. Cost moves into the subagent's bounded context.
+- Cleaner separation of concerns: agent guardrails apply in the subagent, not as an indelible bias on the parent thread.
+- Multiple agents on one task become cheap: spawn them in parallel via a single message with multiple Agent tool calls.
+- Sub-agents see none of the parent conversation, so the parent must write self-contained prompts (goal, file paths, constraints, verification command). This is already covered in `rules/parallel-agents.md`.
+
+## Considered alternatives
+
+- **Keep the read-into-main pattern but slim the agent files.** Rejected: the structural problem is loading specialist content into a generalist context, not file size. Slimming files is a separate, lower-leverage optimization that is now mostly moot under subagent loading.
+- **Drop agents entirely and rely on `CLAUDE.md` + `rules/`.** Rejected: the user values having 16 specialized personas available situationally. The agent files are not dead weight; the dead weight was loading them eagerly.
+- **Auto-spawn subagents based on keyword detection.** Rejected: speculative routing would over-trigger. The model deciding when a task is specialized enough to warrant a subagent is the right judgment call.

--- a/rules/agent-routing.md
+++ b/rules/agent-routing.md
@@ -1,43 +1,49 @@
 # Expert Agent Routing
 
-Before starting any non-trivial task, determine which expert agents are relevant based on the task context. Read the matching agent files from `~/.claude/agents/` and follow their guardrails, checklists, and red flags throughout the task. Load multiple agents when the task spans domains.
+Specialized agent personas live in `~/.claude/agents/`. Each captures domain expertise plus guardrails and red flags.
 
-## Routing Table
+## Loading model
 
-| Domain trigger | Agent file | Load when the task involves... |
-| --- | --- | --- |
-| System design, architecture, DDD, module boundaries | `staff-engineer.md` | Code architecture, design patterns, system-level decisions |
-| React, components, CSS, browser, frontend, UI rendering | `frontend-staff-engineer.md` | Frontend code, components, styling, client-side performance |
-| API, database, backend, queues, caching, Node.js server | `backend-staff-engineer.md` | Backend code, APIs, database queries, server-side logic |
-| CI/CD, Docker, Kubernetes, Terraform, infrastructure, GitOps | `devops-engineer.md` | Deployment, pipelines, containers, infrastructure changes |
-| Tests, QA, coverage, flaky, E2E, Playwright, Vitest | `qa-expert.md` | Writing tests, test strategy, test infrastructure |
-| AWS, S3, Lambda, EC2, CloudFront, DynamoDB | `aws-expert.md` | AWS services and infrastructure |
-| GCP, Cloud Run, BigQuery, Pub/Sub, Cloud Functions | `gcp-expert.md` | GCP services and infrastructure |
-| ArgoCD, GitOps, ApplicationSet, sync policy, Argo Rollouts | `argocd-expert.md` | ArgoCD configuration, GitOps workflows, progressive delivery |
-| PostgreSQL, SQL, queries, indexes, migrations | `postgresql-expert.md` | Database schema, queries, migrations, performance |
-| Networking, DNS, TCP, load balancer, CDN, VPN | `networking-expert.md` | Network configuration, DNS, connectivity |
-| Security, auth, OWASP, XSS, injection, encryption | `cybersecurity-expert.md` | Security review, auth flows, vulnerability assessment |
-| GDPR, privacy, consent, DPIA, data subject rights, PII | `gdpr-expert.md` | Data protection, privacy, personal data handling |
-| GTM, tags, server-side tagging, data layer, GA4, CAPI | `gtm-expert.md` | Tag management, analytics, tracking, consent mode |
-| Product, user story, prioritization, roadmap, metrics | `product-manager.md` | Feature planning, requirements, success criteria |
-| UX, usability, accessibility, WCAG, design, interaction | `ux-expert.md` | UI/UX design, accessibility, user experience |
-| Error handling, resilience, circuit breaker, retry, timeout | `backend-staff-engineer.md` | Designing failure modes, degradation patterns |
-| API design, REST, GraphQL, schema, contracts | `backend-staff-engineer.md` | Designing APIs, versioning, breaking changes |
-| Data model, schema design, normalization, ERD | `postgresql-expert.md` | Designing database structure from scratch |
-| Test strategy, test architecture, test pyramid, coverage | `qa-expert.md` | Planning test approach before implementation |
-| Performance, profiling, latency, p99, load testing | `backend-staff-engineer.md` + `frontend-staff-engineer.md` | Performance work (load both for full-stack) |
-| PR review, code review | `pr-reviewer.md` | Reviewing pull requests or code changes |
-| Observability, monitoring, logging, traces, metrics, alerts, OpenTelemetry | `devops-engineer.md` | Instrumentation, monitoring setup, alerting, SLO/SLI |
-| Caching, Redis, cache invalidation, CDN cache, application cache | `backend-staff-engineer.md` | Cache architecture, invalidation strategies, multi-layer caching |
-| Rate limiting, throttling, API quotas, backpressure, DDoS | `backend-staff-engineer.md` + `networking-expert.md` | Rate limiting design, throttling strategies |
-| ETL, data pipeline, stream processing, Pub/Sub, batch jobs, data flow | `backend-staff-engineer.md` | Data pipeline architecture, processing patterns |
+When a task touches a specialized domain, **spawn a subagent** via the Agent tool with the matching `subagent_type`. The subagent loads the agent file in its own context, runs the work, and returns a summary to the parent.
+
+Do NOT read agent files into the main conversation. That pollutes context and bleeds biases across unrelated work later in the session. The agent file is for the subagent; you act on the subagent's summary.
+
+Skip subagent spawning for trivial changes (typos, one-liner fixes, config tweaks).
+
+## Agents
+
+| `subagent_type` | Spawn when the task touches... |
+| --- | --- |
+| `Staff Engineer` | Architecture, DDD, module boundaries, system-level design |
+| `Backend Staff Engineer` | Node.js APIs, server logic, data pipelines, caching, rate limiting, error handling |
+| `Frontend Staff Engineer` | React, components, CSS, browser, client-side performance |
+| `DevOps Engineer` | CI/CD, Docker, Kubernetes, Terraform, observability, GitOps, monitoring |
+| `QA Expert` | Test strategy, test architecture, flaky tests, E2E, coverage |
+| `PR Reviewer` | Pull request review, code review |
+| `Cybersecurity Expert` | Security review, OWASP, auth flows, vulnerability assessment |
+| `PostgreSQL Expert` | SQL, indexes, query plans, migrations, schema design |
+| `AWS Expert` | AWS services and infrastructure |
+| `GCP Expert` | GCP services and infrastructure |
+| `Networking Expert` | DNS, TCP, load balancers, CDN, VPN |
+| `ArgoCD Expert` | ArgoCD, ApplicationSet, sync policy, Argo Rollouts |
+| `GDPR Expert` | Privacy, consent, DPIA, PII handling for EU subjects |
+| `GTM Expert` | Google Tag Manager, server-side tagging, GA4, CAPI |
+| `Product Manager` | Feature planning, user stories, success criteria, roadmap |
+| `UX Expert` | Usability, accessibility, WCAG, interaction design |
+
+## Cross-domain combinations
+
+- **UI work** -> `Frontend Staff Engineer` + `UX Expert` + `QA Expert` (accessibility)
+- **Feature planning** -> `Product Manager` + the relevant technical agents
+- **Performance work** -> `Backend Staff Engineer` + `Frontend Staff Engineer`
+- **Rate limiting / throttling / DDoS** -> `Backend Staff Engineer` + `Networking Expert`
+- **Data handling for EU subjects** -> include `GDPR Expert`
+- **PR with security implications** -> `PR Reviewer` + `Cybersecurity Expert`
+
+When a task crosses domains, spawn multiple subagents in **parallel** - send a single message with multiple Agent tool calls so they run concurrently.
 
 ## Rules
 
-- **Always load agents before research phase** - read the files before forming opinions
-- **Load multiple agents** when the task crosses domains (e.g., a new API endpoint -> backend + security + QA)
-- **Feature planning** should always include: product-manager + the relevant technical agents
-- **UI work** should always include: frontend + ux + qa (accessibility)
-- **Any data handling** in EU context should include: gdpr
-- **Guardrails from all loaded agents apply simultaneously** - a violation in any agent is a blocker
-- **Skip agent loading for trivial changes** (typos, one-liner fixes, config tweaks)
+- Subagent guardrails apply within their context. Act on the subagent's summary, not the agent file
+- Multiple subagents may produce conflicting recommendations - surface conflicts to the user, do not silently pick a side
+- Subagents see none of the parent conversation - brief them with self-contained prompts (goal, file paths, constraints, verification command)


### PR DESCRIPTION
## What does this PR do?

Changes how agent personas are loaded. Previously the routing rule told Claude to read agent files into the main conversation any time a task touched a specialized domain - 3-4K tokens per agent, bleeding specialist biases across the rest of the session. Cross-domain work compounded this to 12-15K tokens of agent frame in a single thread.

New rule: spawn a subagent via the Agent tool with the matching `subagent_type`. The agent file is loaded in the subagent's bounded context. The parent acts on the subagent's summary, not the agent file.

Also slimmed the routing table itself: 27 trigger-keyed rows -> 16 agent-keyed rows, one combined trigger column instead of two. Cross-domain combinations (UI work, performance work, EU data handling, etc.) moved to a separate, smaller section. Net always-loaded routing tokens drop ~50%.

All 16 agents are kept. They earn their place situationally; the problem was the loading model, not the count. Net diff: +82 / -40.

Rationale and rejected alternatives in `docs/adr/0003-agents-via-subagent-spawn.md`.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follows up #46 (grill-driven workflow) and #47 (drop lock machinery). Part of a multi-PR audit walking the deferred branches: hooks (#47), agents (this PR), skills, discoverability.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant