### PR TITLE
chore(skills): drop find-docs and zoom-out, document vendoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ See [Agent Reference](docs/agents.md) for the full listing.
 
 Reusable workflows invoked on-demand. Cost ~200 tokens when idle (metadata only) vs. full cost if in CLAUDE.md.
 
+Skills tagged *(mattpocock)* below are vendored from [mattpocock/skills](https://github.com/mattpocock/skills). They were imported on 2026-05-08 and are not kept in sync upstream - they may diverge over time as they get adapted to this workflow. To pull a newer upstream version, copy it manually and re-review the diff.
+
 | Skill | Trigger | Purpose |
 | --- | --- | --- |
 | `spec` | `/spec <topic>` | Define requirements before planning |
@@ -134,11 +136,10 @@ Reusable workflows invoked on-demand. Cost ~200 tokens when idle (metadata only)
 | `mr` | `/mr` | Create MR/PR with template, conventional commit checks, and stacked MR/PR dependency support |
 | `debug` | `/debug <error\|alert>` | Structured incident investigation: evidence, ranked hypotheses, minimal fix, regression test |
 | `diagram` | `/diagram <topic>` | Pick mermaid vs drawio per `rules/diagrams.md`, write the source, preview via drawio MCP |
-| `grill-with-docs` | `/grill-with-docs` | Default alignment phase. Real-time Q&A walking the decision tree, updating `CONTEXT.md` and writing ADRs inline as decisions land. Replaces the old Plan + Annotate phases. From [mattpocock/skills](https://github.com/mattpocock/skills) |
-| `zoom-out` | `/zoom-out` | Map an unfamiliar code area: surrounding modules, callers, domain glossary terms. From [mattpocock/skills](https://github.com/mattpocock/skills) |
-| `to-issues` | `/to-issues` | Break a plan/PRD into independently-grabbable vertical-slice issues on the project tracker. From [mattpocock/skills](https://github.com/mattpocock/skills) |
-| `improve-codebase-architecture` | `/improve-codebase-architecture` | Surface deepening opportunities (shallow-module refactors) using deletion-test heuristics. From [mattpocock/skills](https://github.com/mattpocock/skills) |
-| `write-a-skill` | `/write-a-skill` | Scaffold a new skill with proper frontmatter, triggers, and progressive disclosure. From [mattpocock/skills](https://github.com/mattpocock/skills) |
+| `grill-with-docs` | `/grill-with-docs` | *(mattpocock)* Default alignment phase. Real-time Q&A walking the decision tree, updating `CONTEXT.md` and writing ADRs inline as decisions land. Replaces the old Plan + Annotate phases. |
+| `to-issues` | `/to-issues` | *(mattpocock)* Break a plan/PRD into independently-grabbable vertical-slice issues on the project tracker. |
+| `improve-codebase-architecture` | `/improve-codebase-architecture` | *(mattpocock)* Surface deepening opportunities (shallow-module refactors) using deletion-test heuristics. |
+| `write-a-skill` | `/write-a-skill` | *(mattpocock)* Scaffold a new skill with proper frontmatter, triggers, and progressive disclosure. |
 
 ### Commands (`commands/`)
 

--- a/skills/zoom-out/SKILL.md
+++ b/skills/zoom-out/SKILL.md
@@ -1,9 +1,0 @@
----
-name: zoom-out
-description: Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.
-disable-model-invocation: true
----
-
-> Source: [mattpocock/skills — engineering/zoom-out](https://github.com/mattpocock/skills/tree/main/skills/engineering/zoom-out)
-
-I don't know this area of code well. Go up a layer of abstraction. Give me a map of all the relevant modules and callers, using the project's domain glossary vocabulary.


### PR DESCRIPTION
## What does this PR do?

Two skill deletions and a vendoring-policy note in the README.

**`find-docs` removed** — overlapped with three other paths to "fetch current library docs": the always-loaded `rules/context7.md` rule that triggers `ctx7` CLI use automatically, and the `mcp__context7__*` MCP tools. Three paths meant two would rot. Picking the always-loaded rule as canonical kills the overlap. `ctx7` CLI works regardless of MCP connectivity; MCP stays as fallback.

**`zoom-out` removed** — overlapped with `/user:research`. Both explore unfamiliar code; research produces an artifact for re-reading, zoom-out was purely conversational. The conversational case is just "ask Claude to give a higher-level view" - no slash command needed.

**Vendoring policy documented** — 4 remaining mattpocock-origin skills are now flagged in the README. They were imported 2026-05-08, are vendored (no automatic upstream sync), and may diverge as they adapt to this workflow.

Net diff: +6 / -14, 2 files. No ADR for this PR; the calls are routing/policy, not architectural reversals like #47 / #48.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follows up #46, #47, #48. Last of three audit PRs (hooks, agents, skills). Discoverability follow-up may or may not yield a PR depending on what the grill turns up.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant