### PR TITLE
fix(rules): track context7.md, warn about symlink collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Symlink the repo contents to `~/.claude/` so changes auto-sync:
 # Clone the repo
 git clone git@github.com:domengabrovsek/claude.git ~/dev/claude
 
+# IMPORTANT: if any of these targets already exist as real files or
+# directories under ~/.claude/, back them up first. The `ln -sf` for
+# directories will fail loudly if the target is a non-empty real dir,
+# but for files it silently overwrites - audit first to avoid losing
+# any local-only rules or settings.
+ls -la ~/.claude/
+
 # Symlink to ~/.claude/
 ln -sf ~/dev/claude/CLAUDE.md ~/.claude/CLAUDE.md
 ln -sf ~/dev/claude/agents ~/.claude/agents
@@ -47,7 +54,9 @@ git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState)" 2>
 git config filter.strip-ephemeral-state.smudge cat
 ```
 
-> **Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. The smudge/clean filter in `.gitattributes` automatically strips this before git sees it, so `git status` stays clean.
+**Warning**: `~/.claude/rules/` is the most common collision point. If it already exists as a real directory with files in it, `ln -sf ~/dev/claude/rules ~/.claude/rules` will create the symlink *inside* it (e.g. `~/.claude/rules/rules`) instead of replacing it. Back up the contents into the repo first, then remove the directory before symlinking.
+
+**Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. The smudge/clean filter in `.gitattributes` automatically strips this before git sees it, so `git status` stays clean.
 
 ## RTK (Token Optimization)
 

--- a/rules/context7.md
+++ b/rules/context7.md
@@ -1,0 +1,16 @@
+Use the `ctx7` CLI to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service -- even well-known ones like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This includes API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Use even when you think you know the answer -- your training data may not reflect recent changes. Prefer this over web search for library docs.
+
+Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts.
+
+## Steps
+
+1. Resolve library: `npx ctx7@latest library <name> "<user's question>"`
+2. Pick the best match (ID format: `/org/project`) by: exact name match, description relevance, code snippet count, source reputation (High/Medium preferred), and benchmark score (higher is better). If results don't look right, try alternate names or queries (e.g., "next.js" not "nextjs", or rephrase the question)
+3. Fetch docs: `npx ctx7@latest docs <libraryId> "<user's question>"`
+4. Answer using the fetched documentation
+
+You MUST call `library` first to get a valid ID unless the user provides one directly in `/org/project` format. Use the user's full question as the query -- specific and detailed queries return better results than vague single words. Do not run more than 3 commands per question. Do not include sensitive information (API keys, passwords, credentials) in queries.
+
+For version-specific docs, use `/org/project/version` from the `library` output (e.g., `/vercel/next.js/v14.3.0`).
+
+If a command fails with a quota error, inform the user and suggest `npx ctx7@latest login` or setting `CONTEXT7_API_KEY` env var for higher limits. Do not silently fall back to training data.


### PR DESCRIPTION
## What does this PR do?

Lands `rules/context7.md` in the repo and adds a setup-warning to the README about a symlink-collision trap.

## Background

While auditing skills, I noticed `~/.claude/rules/` existed as a **real directory** with two files - `context7.md` and `parallel-agents.md` - and was *not* a symlink to the repo. The README's setup instruction (`ln -sf ~/dev/claude/rules ~/.claude/rules`) was never run, which had two consequences:

1. `context7.md` lived only in the live config and was never version-controlled.
2. `parallel-agents.md` had been edited in the repo over time but the live `~/.claude/rules/parallel-agents.md` was the older copy. Claude Code was loading the stale version on every session.
3. Every other rule in the repo's `rules/` directory (`agent-routing.md`, `engineering-principles.md`, `tests.md`, `typescript.md`, etc.) was authored with `globs:` frontmatter for Claude Code's auto-loading mechanism but was never actually loaded - they were documentation-only despite their design intent.

## What this PR does

- Copies `context7.md` from `~/.claude/rules/` into `rules/context7.md` so it can survive the symlink swap.
- Updates the README setup section with a warning about `~/.claude/rules/` being a common collision point: `ln -sf` against a non-empty real dir creates the link *inside* it (`~/.claude/rules/rules`) instead of replacing it.

## What the user does

The actual symlink swap touches `~/.claude/` and can't be done from a PR. After merge, locally:

```bash
# Verify everything is in the repo (this PR ensures it is)
ls ~/dev/claude/rules/

# Remove the stale live dir
rm -rf ~/.claude/rules

# Symlink to the repo
ln -s ~/dev/claude/rules ~/.claude/rules

# Confirm
ls -la ~/.claude/rules
```

After that, all the repo's path-scoped rules (`typescript.md`, `tests.md`, `database.md`, `infrastructure.md`) will auto-load when editing matching files, and the always-loaded ones (`agent-routing.md`, `engineering-principles.md`, `git-conventions.md`, `state-persistence.md`, `diagrams.md`, `parallel-agents.md`) will inject globally.

## Category

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follows up the audit series (#46-#50). This was the deferred-from-skills-audit fix.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant