### PR TITLE
feat(skills): add handoff skill from mattpocock/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills tagged *(mattpocock)* below are vendored from [mattpocock/skills](https:/
 | `to-issues` | `/to-issues` | *(mattpocock)* Break a plan/PRD into independently-grabbable vertical-slice issues on the project tracker. |
 | `improve-codebase-architecture` | `/improve-codebase-architecture` | *(mattpocock)* Surface deepening opportunities (shallow-module refactors) using deletion-test heuristics. |
 | `write-a-skill` | `/write-a-skill` | *(mattpocock)* Scaffold a new skill with proper frontmatter, triggers, and progressive disclosure. |
+| `handoff` | `/handoff <focus>` | *(mattpocock)* Compact the current conversation into a handoff document so a fresh agent can pick up the work. |
 
 ### Commands (`commands/`)
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+> Source: [mattpocock/skills — productivity/handoff](https://github.com/mattpocock/skills/tree/main/skills/productivity/handoff)
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.


### PR DESCRIPTION
## What does this PR do?

Adds the `handoff` skill, vendored from [`mattpocock/skills` → `productivity/handoff`](https://github.com/mattpocock/skills/tree/main/skills/productivity/handoff). The skill writes a compacted handoff document (via `mktemp -t handoff-XXXXXX.md`) so a fresh agent can pick up an in-flight conversation without re-deriving context.

Attribution follows the same pattern as the other vendored mattpocock skills:

- `> Source: [...]` line at the top of `SKILL.md`
- `*(mattpocock)*` tag in the skills table in `README.md`, placed in the vendored-skills block at the bottom of the table

No changes to existing skills.

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

> None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant