### PR TITLE
docs(rules): add jira access rule using acli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 - Use Context7 MCP to pull latest docs when working with specific technologies (NestJS, PostgreSQL, Drizzle, etc.) - don't rely on potentially outdated training knowledge
 - Default to writing no comments. Prefer readable, explicit code (well-named variables, functions, and types) over commentary. A comment is justified only when it explains a non-obvious WHY: hidden constraint, subtle invariant, workaround for a known bug, or surprising behavior a future reader would otherwise misread. Comments that restate WHAT the code does are forbidden, including multiline narrative blocks. JSDoc/docstring format (`/** */`) is allowed only when its content is WHY - the format alone does not earn an exemption.
 - Never reference issue, PR, ticket, or ADR numbers in code comments (no `owner/repo#535`, `PR #561`, `(#545)`, `Fixes #123`, `JIRA-1234`, `ADR-0042`, etc.). They rot as soon as trackers move or decisions are superseded. The PR description, the ADR document itself, and git blame are the right places for that context. Comments should describe the WHY in self-contained prose.
-- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security)
+- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security, jira)
 
 ## Docs Sync
 

--- a/rules/jira.md
+++ b/rules/jira.md
@@ -1,0 +1,42 @@
+# Jira Access
+
+When the user mentions a Jira ticket, issue, story, bug, or epic, reach for `acli` (Atlassian CLI) before doing anything else.
+
+## Detection
+
+Trigger this rule when any of the following appears in the user's message:
+
+- A Jira-style key matching `[A-Z]+-\d+`
+- The words "Jira", "ticket", "issue", "story", "epic", "bug" used in a tracker sense (not a generic "there's an issue with X")
+- A Jira URL (`*.atlassian.net/browse/KEY-123`)
+
+If the reference is ambiguous (could be GitHub issue vs Jira), ask before assuming.
+
+## Tool check
+
+1. Run `which acli` to confirm it is installed.
+2. If installed, run `acli jira auth status` (or attempt a read command) to confirm it is authenticated. If unauthenticated, surface that to the user — do not attempt to authenticate on their behalf.
+3. If not installed or not configured, tell the user and fall back to asking them for the ticket contents.
+
+## Usage
+
+Prefer `acli` over web fetches or asking the user to paste ticket content.
+
+Common commands:
+
+```bash
+acli jira workitem view <KEY>           # read a ticket
+acli jira workitem search --jql "..."   # search
+acli jira workitem comment <KEY> ...    # add comment
+acli jira workitem update <KEY> ...     # update fields / transition
+```
+
+Run `acli jira workitem --help` for the current command surface — flags change between versions, so do not guess.
+
+## Rules
+
+- **Read first**: when a ticket is referenced, fetch it before asking the user what it says. Do not make the user paste content `acli` could have retrieved.
+- **No silent writes**: never transition, comment on, or update a ticket without explicit user confirmation. Reading is free; writing affects shared state.
+- **Do not invent keys**: only act on keys the user actually provided. Do not guess project prefixes.
+- **Stay scoped**: fetch the specific tickets referenced, not the entire backlog. Avoid broad `--jql` sweeps unless asked.
+- **Surface auth errors**: if `acli` returns an auth or permission error, report it verbatim — do not retry blindly or attempt to re-auth.


### PR DESCRIPTION
## What does this PR do?

Adds a new rule file (`rules/jira.md`) instructing agents to use `acli` (Atlassian CLI) when the user references a Jira ticket, issue, story, bug, or epic.

- Detection triggers: Jira-style keys matching `[A-Z]+-\d+`, tracker terms ("Jira", "ticket", "issue", "story", "epic", "bug"), and Jira URLs
- Tool check: verify `acli` is installed and authenticated; surface auth errors verbatim; never auto-authenticate
- Usage: prefer `acli jira workitem view/search/comment/update` over web fetches or asking the user to paste ticket content
- Guardrails: reads are free, but transitions/comments/updates require explicit user confirmation; do not invent project keys or run broad JQL sweeps

Also adds `jira` to the rules index line in `CLAUDE.md`.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant