### PR TITLE
fix(config): reconcile settings.json into single source of truth

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -9,6 +9,8 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
   },
+  "effortLevel": "high",
+  "skipAutoPermissionPrompt": false,
   "permissions": {
     "deny": [
       "Read(**/.env)",
@@ -105,10 +107,10 @@
       "Write(**/pnpm-lock.yaml)",
       "Bash(*DROP TABLE*)",
       "Bash(*DROP DATABASE*)",
-      "Bash(*TRUNCATE TABLE*)"
+      "Bash(*TRUNCATE TABLE*)",
+      "mcp__claude_ai_Atlassian__*"
     ]
   },
-  "effortLevel": "xhigh",
   "hooks": {
     "PreToolUse": [
       {
@@ -146,6 +148,11 @@
             "type": "command",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/post-edit-typecheck.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/post-edit-typecheck.sh\"; if [ -x \"$HOOK\" ]; then \"$HOOK\"; fi",
             "timeout": 60
+          },
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/post-edit-lint.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/post-edit-lint.sh\"; if [ -x \"$HOOK\" ]; then \"$HOOK\"; fi",
+            "timeout": 15
           }
         ]
       },
@@ -190,10 +197,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'Reminder: follow the workflow (Research - Grill - Implement - Summarize). Use /grill-with-docs for alignment. Minimal fix first for bugs. Run /user:verify-done before commits. Current year: 2026.'"
+            "command": "echo 'Reminder: follow the workflow (Research - Grill - Implement - Summarize). Use /grill-with-docs for alignment. Minimal fix first for bugs. Run /verify-done before pushing. Current year: 2026.'"
           }
         ]
-      },
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary

- Fix invalid trailing comma in SessionStart hooks array that was silently making every commit produce an empty blob (the strip-ephemeral-state clean filter falls back to nothing when jq fails on malformed JSON).
- Add post-edit-lint hook registration to PostToolUse Write|Edit so the new lint hook (em-dash auto-fix, ticket-ref-in-comment notifier, JSDoc-block notifier — landing in a follow-up PR) actually fires.
- Add mcp__claude_ai_Atlassian__* to permissions.deny so the Atlassian MCP can't compete with the acli Jira workflow rule.
- Update SessionStart reminder text: /user:verify-done -> /verify-done, before commits -> before pushing.
- Set effortLevel: high and skipAutoPermissionPrompt: false explicitly so per-machine drift can't reintroduce divergent values.
- Preserve repo extras that were already correct: RTK_HOOK_AUDIT env, SessionEnd worktree-cleanup hook, pre-push-gate.sh PreToolUse registration.

## Why now

~/.claude/settings.json and the repo's settings.json had drifted substantially because settings.json is NOT one of the symlinked files in ~/.claude/. This meant: the pre-push-gate hook was registered in the repo but not in live (so "tests before push" never actually fired on this machine), and various other recent changes existed in one place but not the other. Reconciling here so a follow-up step can symlink the live file to this one — same model as CLAUDE.md, rules/, hooks/, skills/.

## Post-merge step (per device)

\`\`\`bash
mv ~/.claude/settings.json ~/.claude/settings.json.bak
ln -s ~/dev/claude/settings.json ~/.claude/settings.json
\`\`\`

## Test plan

- [ ] CI checks pass (jq parse round-trip via clean filter)
- [ ] After merge + symlink: start a fresh Claude Code session, verify SessionStart reminder text matches the new wording
- [ ] After merge + symlink: verify pre-push-gate.sh fires on Bash(git push *) in a node project (it didn't before because the registration was missing in live)
- [ ] After merge + symlink: verify the post-edit-lint hook fires on a Write|Edit (will be more useful once the lint hook is built in a follow-up PR)