### PR TITLE
feat(rules): make global rule files reach every session

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,6 @@
     "drawio": {
       "command": "npx",
       "args": ["-y", "@drawio/mcp"]
-    },
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,6 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 
 - Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
 - Complete code only - no TODOs, no placeholders, no incomplete implementations
-- Use Context7 MCP to pull latest docs when working with specific technologies (NestJS, PostgreSQL, Drizzle, etc.) - don't rely on potentially outdated training knowledge
 - Default to writing no comments. Prefer readable, explicit code (well-named variables, functions, and types) over commentary. A comment is justified only when it explains a non-obvious WHY: hidden constraint, subtle invariant, workaround for a known bug, or surprising behavior a future reader would otherwise misread. Comments that restate WHAT the code does are forbidden, including multiline narrative blocks. JSDoc/docstring format (`/** */`) is allowed only when its content is WHY - the format alone does not earn an exemption.
 - Never reference issue, PR, ticket, or ADR numbers in code comments (no `owner/repo#535`, `PR #561`, `(#545)`, `Fixes #123`, `JIRA-1234`, `ADR-0042`, etc.). They rot as soon as trackers move or decisions are superseded. The PR description, the ADR document itself, and git blame are the right places for that context. Comments should describe the WHY in self-contained prose.
 - Detailed standards are in rules/ (typescript, tests, database, infrastructure, security, jira)
@@ -59,7 +58,7 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 - **Conciseness**: be direct and terse during implementation - save explanations for when asked
 - **Existing patterns**: follow the conventions already in the codebase - consistency over personal preference
 - **Context first**: before choosing an approach, check how similar problems are already solved in the codebase - grep for existing patterns, read neighboring files, and follow established conventions rather than guessing
-- **Verification**: always run `/user:verify-done` before pushing - never push without all checks passing
+- **Verification**: always run `/verify-done` before pushing - never push without all checks passing
 - **Atomic feature unit**: "implement" means implement + commit on a feature branch + push + open PR. Never stop after the code change. Never commit to `main`/`master` directly. If on a protected branch, create a feature branch first.
 - **Parallelization**: when a task has 2+ independent sub-tasks touching different files, split across multiple agents using git worktrees - see `rules/parallel-agents.md`
 
@@ -79,3 +78,20 @@ Detailed git, testing, and exploration rules are in `rules/` (git-conventions, e
 - Access boundaries: .env files, credentials, and secrets are blocked by deny rules - do not attempt workarounds. For Sentry, staging databases, and external services requiring auth, ask the user for credentials or URLs rather than trying to authenticate
 
 @RTK.md
+
+## Imported rules
+
+The files below are loaded into every session via these `@`-imports. Edit the individual rule files in `rules/` - they are the source of truth, not this list.
+
+@rules/agent-routing.md
+@rules/context7.md
+@rules/database.md
+@rules/diagrams.md
+@rules/engineering-principles.md
+@rules/git-conventions.md
+@rules/infrastructure.md
+@rules/jira.md
+@rules/parallel-agents.md
+@rules/state-persistence.md
+@rules/tests.md
+@rules/typescript.md

--- a/settings.json
+++ b/settings.json
@@ -9,6 +9,8 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
   },
+  "effortLevel": "high",
+  "skipAutoPermissionPrompt": false,
   "permissions": {
     "deny": [
       "Read(**/.env)",
@@ -105,10 +107,10 @@
       "Write(**/pnpm-lock.yaml)",
       "Bash(*DROP TABLE*)",
       "Bash(*DROP DATABASE*)",
-      "Bash(*TRUNCATE TABLE*)"
+      "Bash(*TRUNCATE TABLE*)",
+      "mcp__claude_ai_Atlassian__*"
     ]
   },
-  "effortLevel": "xhigh",
   "hooks": {
     "PreToolUse": [
       {
@@ -146,6 +148,11 @@
             "type": "command",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/post-edit-typecheck.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/post-edit-typecheck.sh\"; if [ -x \"$HOOK\" ]; then \"$HOOK\"; fi",
             "timeout": 60
+          },
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/post-edit-lint.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/post-edit-lint.sh\"; if [ -x \"$HOOK\" ]; then \"$HOOK\"; fi",
+            "timeout": 15
           }
         ]
       },
@@ -190,10 +197,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'Reminder: follow the workflow (Research - Grill - Implement - Summarize). Use /grill-with-docs for alignment. Minimal fix first for bugs. Run /user:verify-done before commits. Current year: 2026.'"
+            "command": "echo 'Reminder: follow the workflow (Research - Grill - Implement - Summarize). Use /grill-with-docs for alignment. Minimal fix first for bugs. Run /verify-done before pushing. Current year: 2026.'"
           }
         ]
-      },
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary

- Add `@`-imports for the 12 files in `rules/` at the end of CLAUDE.md so they load in every session (not just sessions inside this dotfiles repo).
- Remove the contradictory "Use Context7 MCP" bullet from CLAUDE.md Code Standards; `rules/context7.md` (now globally imported) says to use the `ctx7` CLI.
- Remove the `context7` server from `.mcp.json` so the model surface stops competing with the CLI rule.
- Rename `/user:verify-done` -> `/verify-done` in the Verification behavioral rule. The skill is named `verify-done`; the `user:` prefix resolved to nothing.

## Why

In every project I work in (didomi, addingwell, ...) my project-level `CLAUDE.md` files did not `@`-import the global rule files. The global `CLAUDE.md` itself only imported `RTK.md`. So `rules/jira.md`, `rules/tests.md`, `rules/typescript.md`, etc. were on disk but never in the model's context. That explains most rule violations I have noticed (use of MCP for Jira instead of `acli`, missing test patterns, etc.). This PR closes that gap by importing all 12 rule files at the top level.

`rules/communication.md` is intentionally NOT imported here - it lands in the next PR alongside the file itself, so the import line and the file are added in the same commit and never reference a missing path.

## Depends on

- #55 (PR 0, settings.json reconcile) - merge first

## Test plan

- [ ] Start a fresh Claude session in a non-dotfiles repo (e.g. didomi/consents-api). Confirm via session context that the imported rules now appear.
- [ ] Confirm `ctx7` CLI is used for library docs (not Context7 MCP, which is now removed).
- [ ] `/verify-done` resolves to the actual skill on fresh sessions.