### PR TITLE
feat(rules): add communication rule (one question per turn)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 - **Verification**: always run `/verify-done` before pushing - never push without all checks passing
 - **Atomic feature unit**: "implement" means implement + commit on a feature branch + push + open PR. Never stop after the code change. Never commit to `main`/`master` directly. If on a protected branch, create a feature branch first.
 - **Parallelization**: when a task has 2+ independent sub-tasks touching different files, split across multiple agents using git worktrees - see `rules/parallel-agents.md`
+- **One question at a time**: when asking the user a clarifying question, ask only one per turn and wait for the answer before asking the next - no stacked or bundled questions, even closely related ones. See `rules/communication.md`
 
 Detailed git, testing, and exploration rules are in `rules/` (git-conventions, engineering-principles).
 
@@ -84,6 +85,7 @@ Detailed git, testing, and exploration rules are in `rules/` (git-conventions, e
 The files below are loaded into every session via these `@`-imports. Edit the individual rule files in `rules/` - they are the source of truth, not this list.
 
 @rules/agent-routing.md
+@rules/communication.md
 @rules/context7.md
 @rules/database.md
 @rules/diagrams.md

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -1,0 +1,21 @@
+# Communication
+
+## Asking questions
+
+Ask **one** question at a time. Wait for the answer before asking the next.
+
+- Do not stack multiple questions in a single turn, even closely related ones.
+- Do not bundle a question with "and also confirm X, Y, Z" tacked onto the end — those are separate questions, ask them on later turns.
+- If you have many things to clarify, pick the single most blocking one and ask only that. The rest go in the next turn.
+- Applies to all interaction (grilling, planning, debugging, code review, casual conversation), not just to the `/grill-with-docs` skill.
+
+Long multi-question turns are hard to answer clearly. One question per turn keeps the back-and-forth legible and lets each answer actually shape the next question instead of being lost in a wall of text.
+
+## Phrasing
+
+- Keep the question itself short. Context above the question is fine; the question line itself should be one sentence.
+- Lead with your recommendation when you have one, then ask for confirmation or pushback. Open-ended "what do you think?" without a recommendation wastes a turn.
+
+## Skill-level overrides
+
+If a skill explicitly instructs a different cadence (e.g. "ask all questions at once"), this global rule wins. Update the skill to align rather than following the skill's contradictory instruction.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -13,7 +13,7 @@ Follow this workflow:
    - **Why** - what problem does it solve? What is the success metric?
    - **Constraints** - what technical, time, or scope constraints exist?
    - **Boundaries** - what is explicitly out of scope?
-   - Ask all questions at once. Wait for answers before proceeding.
+   - Ask **one question at a time**, waiting for the answer before asking the next. The list above is the topic checklist to cover across the discovery phase, not a batch to dump in one turn. See `rules/communication.md`.
 
 2. **Draft the spec**: based on the answers, write a specification with these sections:
 


### PR DESCRIPTION
## Summary

- Add `rules/communication.md` establishing one question per turn as a global rule (applies across all interaction, not just /grill-with-docs).
- Add `@rules/communication.md` to the global imports list in CLAUDE.md so the rule actually loads.
- Add a "One question at a time" bullet to CLAUDE.md Behavioral Rules so the rule is also visible inline.
- Fix `skills/spec/SKILL.md` line 16 which previously said "Ask all questions at once" - directly contradicting the new global rule.

## Why

I kept stacking multiple questions in single turns even after being asked not to. Long multi-question turns are hard to answer cleanly. Making this a top-level rule (with both the import and the inline bullet) plus aligning the contradicting `/spec` skill closes the loop.

## Depends on

- #56 (PR 1, global rule loading) - base of this PR. Merge that first; this PR's base will then resolve to master cleanly.

## Test plan

- [ ] Future grill / spec / general clarification turns ask exactly one question per turn.
- [ ] `/spec` no longer dumps all discovery questions at once.