### PR TITLE
feat(hooks): block direct commits to main/master

### DIFF
--- a/hooks/pre-commit-branch-gate.sh
+++ b/hooks/pre-commit-branch-gate.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Pre-commit branch gate.
+# Blocks `git commit` when HEAD is on main or master.
+# PreToolUse hook for Bash(git commit *). Exit 2 blocks the action and feeds the
+# message back to Claude as a tool result.
+# Bypass with SKIP_COMMIT_BRANCH_GATE=1 in the environment.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+case "$COMMAND" in
+  *"git commit --help"*|*"git commit -h"*) exit 0 ;;
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+[ "$SKIP_COMMIT_BRANCH_GATE" = "1" ] && exit 0
+
+DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+BRANCH=$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Not in a git repo, or detached HEAD - let it through. Caller handles their own state.
+[ -z "$BRANCH" ] && exit 0
+[ "$BRANCH" = "HEAD" ] && exit 0
+
+case "$BRANCH" in
+  main|master)
+    echo "[pre-commit-branch-gate] Refusing to commit directly to '$BRANCH'." >&2
+    echo "Create a feature branch first, e.g.:" >&2
+    echo "  git checkout -b <type>/<short-description>" >&2
+    echo "(Bypass: SKIP_COMMIT_BRANCH_GATE=1)" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -130,6 +130,12 @@
           },
           {
             "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-branch-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-branch-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "command -v rtk >/dev/null 2>&1 && rtk hook claude || true"
           }
         ]


### PR DESCRIPTION
## Summary

- New \`hooks/pre-commit-branch-gate.sh\` - PreToolUse hook on \`Bash(git commit *)\`. If HEAD is on \`main\` or \`master\`, the hook exits 2 with a message instructing Claude (and surfacing to the user via stderr) to create a feature branch first.
- Register the hook in \`settings.json\` under the PreToolUse Bash matcher, alongside the existing \`pre-pr-test-gate\` and \`pre-push-gate\`.
- Bypass with \`SKIP_COMMIT_BRANCH_GATE=1\` in the environment.

## Why

The existing deny rules block \`git push\` to main/master, but the \`git commit\` itself was unguarded. The rule "never commit to main directly" lived only in CLAUDE.md prose. This closes the mechanical-enforcement gap.

## Test plan

- [ ] On master/main: have Claude run \`git commit -m "test"\`. Confirm the commit is blocked with the hook's message.
- [ ] On a feature branch: have Claude run \`git commit\` normally. Confirm it works.
- [ ] On master with \`SKIP_COMMIT_BRANCH_GATE=1 git commit ...\`: confirm bypass works.