### PR TITLE
chore(hooks): warn on session start when ~/.claude symlinks have drifted

### DIFF
--- a/hooks/symlink-check.sh
+++ b/hooks/symlink-check.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# SessionStart hook (matcher: startup).
+# Warns to stderr when expected ~/.claude/* symlinks to the dotfiles repo are
+# missing, replaced by a real file, or pointing to the wrong target. Non-blocking.
+# Bypass with SKIP_SYMLINK_CHECK=1 in the environment.
+
+[ "$SKIP_SYMLINK_CHECK" = "1" ] && exit 0
+
+REPO="${CLAUDE_DOTFILES_REPO:-$HOME/dev/claude}"
+[ -d "$REPO" ] || exit 0
+
+EXPECTED=(
+  "CLAUDE.md|$REPO/CLAUDE.md"
+  "RTK.md|$REPO/RTK.md"
+  "settings.json|$REPO/settings.json"
+  "agents|$REPO/agents"
+  "commands|$REPO/commands"
+  "hooks|$REPO/hooks"
+  "rules|$REPO/rules"
+  "skills|$REPO/skills"
+  "statusline.sh|$REPO/scripts/statusline.sh"
+)
+
+ISSUES=()
+for ENTRY in "${EXPECTED[@]}"; do
+  NAME="${ENTRY%%|*}"
+  WANT="${ENTRY##*|}"
+  LIVE="$HOME/.claude/$NAME"
+
+  if [ ! -e "$LIVE" ] && [ ! -L "$LIVE" ]; then
+    ISSUES+=("MISSING:       $LIVE  (expected -> $WANT)")
+  elif [ ! -L "$LIVE" ]; then
+    ISSUES+=("NOT-A-SYMLINK: $LIVE  is a real file (expected -> $WANT)")
+  else
+    GOT=$(readlink "$LIVE")
+    if [ "$GOT" != "$WANT" ]; then
+      ISSUES+=("WRONG-TARGET:  $LIVE -> $GOT  (expected -> $WANT)")
+    fi
+  fi
+done
+
+if [ ${#ISSUES[@]} -gt 0 ]; then
+  echo "[symlink-check] dotfiles symlinks have drifted from $REPO:" >&2
+  for ISSUE in "${ISSUES[@]}"; do echo "  - $ISSUE" >&2; done
+  echo "" >&2
+  echo "Fix each path with:" >&2
+  echo "  unlink <path> 2>/dev/null; rm -rf <path> 2>/dev/null; ln -s <expected-target> <path>" >&2
+  echo "" >&2
+  echo "(Override repo location: CLAUDE_DOTFILES_REPO=/path/to/repo. Bypass this check: SKIP_SYMLINK_CHECK=1.)" >&2
+fi
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -206,6 +206,16 @@
             "command": "echo 'Reminder: follow the workflow (Research - Grill - Implement - Summarize). Use /grill-with-docs for alignment. Minimal fix first for bugs. Run /verify-done before pushing. Current year: 2026.'"
           }
         ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/symlink-check.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/symlink-check.sh\"; [ -x \"$HOOK\" ] && \"$HOOK\" || true",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- New \`hooks/symlink-check.sh\`. Verifies that \`~/.claude/CLAUDE.md\`, \`RTK.md\`, \`settings.json\`, \`agents\`, \`commands\`, \`hooks\`, \`rules\`, \`skills\`, and \`statusline.sh\` are symlinked to the matching paths in the dotfiles repo.
- Three failure modes detected: **missing**, **real file instead of symlink**, **symlink pointing somewhere unexpected**.
- Non-blocking: prints a warning block to stderr listing each drifted path and the fix command, then exits 0.
- Registered in \`settings.json\` under \`SessionStart\` with \`matcher: "startup"\` so it fires once per fresh session (not on resume / compact).

## Why

Earlier in setup we found out the hard way that \`~/.claude/settings.json\` and \`~/.claude/RTK.md\` were real files in \`~/.claude/\` instead of symlinks to the dotfiles repo, while everything else (CLAUDE.md, rules/, hooks/, skills/) was symlinked. That mismatch caused settings drift between machines and made several rules effectively unenforced (e.g. \`pre-push-gate.sh\` was registered in the repo but not in live). This hook surfaces that kind of drift on the next session start so it gets noticed and fixed instead of silently rotting.

## Known limitations

- **Bootstrap chicken-and-egg**: on a fresh machine where \`settings.json\` itself isn't symlinked, the hook registration isn't loaded either, so the check can't fire. This is for catching **partial drift** on machines that are mostly set up, not for first-time bootstrap. The bootstrap problem needs a separate setup script (not in this PR).
- Hook warns only; it does not auto-fix. Fixing a drifted entry requires \`rm\` + \`ln -s\`, which can lose user work if the wrong file is removed. The fix command is printed for manual application.

## Configuration

- \`CLAUDE_DOTFILES_REPO=/path/to/repo\` to override the assumed repo location (\`~/dev/claude\`).
- \`SKIP_SYMLINK_CHECK=1\` to bypass entirely.

## Test plan

- [ ] On this machine (already correctly symlinked): confirm a fresh session shows **no warning**.
- [ ] Temporarily rename one symlink (e.g. \`mv ~/.claude/RTK.md ~/.claude/RTK.md.test\`), start a fresh session, confirm the **MISSING** warning surfaces. Restore.
- [ ] Replace one symlink with a real file copy, start a fresh session, confirm the **NOT-A-SYMLINK** warning surfaces.
- [ ] \`SKIP_SYMLINK_CHECK=1\` suppresses the warning.