### PR TITLE
chore(scripts): add setup-symlinks.sh for one-shot device bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,31 +30,24 @@ Symlink the repo contents to `~/.claude/` so changes auto-sync:
 # Clone the repo
 git clone git@github.com:domengabrovsek/claude.git ~/dev/claude
 
-# IMPORTANT: if any of these targets already exist as real files or
-# directories under ~/.claude/, back them up first. The `ln -sf` for
-# directories will fail loudly if the target is a non-empty real dir,
-# but for files it silently overwrites - audit first to avoid losing
-# any local-only rules or settings.
-ls -la ~/.claude/
-
-# Symlink to ~/.claude/
-ln -sf ~/dev/claude/CLAUDE.md ~/.claude/CLAUDE.md
-ln -sf ~/dev/claude/agents ~/.claude/agents
-ln -sf ~/dev/claude/rules ~/.claude/rules
-ln -sf ~/dev/claude/skills ~/.claude/skills
-ln -sf ~/dev/claude/commands ~/.claude/commands
-ln -sf ~/dev/claude/hooks ~/.claude/hooks
-ln -sf ~/dev/claude/scripts ~/.claude/scripts
-ln -sf ~/dev/claude/settings.json ~/.claude/settings.json
-ln -sf ~/dev/claude/RTK.md ~/.claude/RTK.md
-ln -sf ~/dev/claude/scripts/statusline.sh ~/.claude/statusline.sh
+# Bootstrap the symlinks (idempotent, safe to re-run, dry-run via --check)
+bash ~/dev/claude/scripts/setup-symlinks.sh
 
 # Configure smudge/clean filter to strip ephemeral state from settings.json
+cd ~/dev/claude
 git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState)" 2>/dev/null || cat'
 git config filter.strip-ephemeral-state.smudge cat
 ```
 
-**Warning**: `~/.claude/rules/` is the most common collision point. If it already exists as a real directory with files in it, `ln -sf ~/dev/claude/rules ~/.claude/rules` will create the symlink *inside* it (e.g. `~/.claude/rules/rules`) instead of replacing it. Back up the contents into the repo first, then remove the directory before symlinking.
+The setup script handles all 9 expected symlinks (CLAUDE.md, RTK.md, settings.json, agents, commands, hooks, rules, skills, statusline.sh). If something already exists at one of those paths:
+
+- Correctly symlinked already -> skipped.
+- Symlinked to a wrong target -> the wrong link is removed and replaced.
+- A real file or directory -> backed up to `<path>.bak.<timestamp>` before being replaced. Your local-only content is preserved next to the new symlink for you to inspect.
+
+Run `bash ~/dev/claude/scripts/setup-symlinks.sh --check` first if you want a dry-run showing exactly what each step would do.
+
+Once the symlinks are in place, the `symlink-check.sh` SessionStart hook (in `hooks/`) will warn on stderr if any of them drift later.
 
 **Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. The smudge/clean filter in `.gitattributes` automatically strips this before git sees it, so `git status` stays clean.
 

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Bootstrap the symlinks from ~/.claude/ to the dotfiles repo.
+# Idempotent: safe to run multiple times.
+#
+# Per entry:
+#   - If already symlinked to the correct target -> skipped.
+#   - If symlinked to a different target -> the wrong link is removed and
+#     replaced with the correct one (no backup; symlinks have no content).
+#   - If a real file/dir exists at that path -> backed up to
+#     <path>.bak.<timestamp>, then replaced with the symlink.
+#   - If nothing exists at the path -> a new symlink is created.
+#
+# Repo location resolves in this order:
+#   1. $CLAUDE_DOTFILES_REPO if set
+#   2. The script's own directory (../ from scripts/) if it is a git repo
+#   3. ~/dev/claude
+#
+# Usage:
+#   bash scripts/setup-symlinks.sh           # apply
+#   bash scripts/setup-symlinks.sh --check   # dry-run (report only, no changes)
+#
+# Exit 0 on success, 1 if any entry failed.
+
+set -u
+
+MODE="apply"
+case "${1:-}" in
+  --check|-n|--dry-run) MODE="check" ;;
+  --help|-h)
+    sed -n '2,21p' "$0"
+    exit 0
+    ;;
+  "") ;;
+  *)
+    echo "Unknown flag: $1" >&2
+    echo "Usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+# Resolve repo
+if [ -n "${CLAUDE_DOTFILES_REPO:-}" ]; then
+  REPO="$CLAUDE_DOTFILES_REPO"
+else
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+  CANDIDATE=$(cd "$SCRIPT_DIR/.." && pwd)
+  if [ -d "$CANDIDATE/.git" ] || git -C "$CANDIDATE" rev-parse --git-dir >/dev/null 2>&1; then
+    REPO="$CANDIDATE"
+  else
+    REPO="$HOME/dev/claude"
+  fi
+fi
+
+if [ ! -d "$REPO" ]; then
+  echo "Repo not found at $REPO." >&2
+  echo "Set CLAUDE_DOTFILES_REPO to override, or clone the dotfiles repo first." >&2
+  exit 1
+fi
+
+LIVE_DIR="$HOME/.claude"
+mkdir -p "$LIVE_DIR"
+
+# name | repo-side target (relative to $REPO)
+ENTRIES=(
+  "CLAUDE.md|CLAUDE.md"
+  "RTK.md|RTK.md"
+  "settings.json|settings.json"
+  "agents|agents"
+  "commands|commands"
+  "hooks|hooks"
+  "rules|rules"
+  "skills|skills"
+  "statusline.sh|scripts/statusline.sh"
+)
+
+TS=$(date +%Y%m%d-%H%M%S)
+FAILED=0
+
+printf "%-16s %-12s %s\n" "PATH" "STATE" "ACTION"
+printf "%-16s %-12s %s\n" "----" "-----" "------"
+
+for ENTRY in "${ENTRIES[@]}"; do
+  NAME="${ENTRY%%|*}"
+  REL_TARGET="${ENTRY##*|}"
+  TARGET="$REPO/$REL_TARGET"
+  LIVE="$LIVE_DIR/$NAME"
+
+  if [ ! -e "$TARGET" ] && [ ! -L "$TARGET" ]; then
+    printf "%-16s %-12s %s\n" "$NAME" "MISSING-SRC" "skip ($TARGET does not exist in repo)"
+    FAILED=$((FAILED+1))
+    continue
+  fi
+
+  if [ -L "$LIVE" ]; then
+    GOT=$(readlink "$LIVE")
+    if [ "$GOT" = "$TARGET" ]; then
+      printf "%-16s %-12s %s\n" "$NAME" "OK" "already correct"
+      continue
+    fi
+    if [ "$MODE" = "check" ]; then
+      printf "%-16s %-12s %s\n" "$NAME" "WRONG-LINK" "would replace ($GOT -> $TARGET)"
+      continue
+    fi
+    rm "$LIVE" && ln -s "$TARGET" "$LIVE" \
+      && printf "%-16s %-12s %s\n" "$NAME" "RELINKED" "$GOT -> $TARGET" \
+      || { printf "%-16s %-12s %s\n" "$NAME" "FAILED" "could not relink"; FAILED=$((FAILED+1)); }
+    continue
+  fi
+
+  if [ -e "$LIVE" ]; then
+    # Real file or directory
+    if [ "$MODE" = "check" ]; then
+      printf "%-16s %-12s %s\n" "$NAME" "REAL-FILE" "would backup to $LIVE.bak.$TS and link"
+      continue
+    fi
+    BACKUP="$LIVE.bak.$TS"
+    mv "$LIVE" "$BACKUP" \
+      && ln -s "$TARGET" "$LIVE" \
+      && printf "%-16s %-12s %s\n" "$NAME" "REPLACED" "backed up to $(basename "$BACKUP")" \
+      || { printf "%-16s %-12s %s\n" "$NAME" "FAILED" "could not replace"; FAILED=$((FAILED+1)); }
+    continue
+  fi
+
+  # Nothing exists at LIVE
+  if [ "$MODE" = "check" ]; then
+    printf "%-16s %-12s %s\n" "$NAME" "MISSING" "would create symlink"
+    continue
+  fi
+  ln -s "$TARGET" "$LIVE" \
+    && printf "%-16s %-12s %s\n" "$NAME" "CREATED" "$TARGET" \
+    || { printf "%-16s %-12s %s\n" "$NAME" "FAILED" "could not create"; FAILED=$((FAILED+1)); }
+done
+
+echo ""
+if [ "$MODE" = "check" ]; then
+  echo "Dry run complete. Re-run without --check to apply."
+elif [ "$FAILED" -eq 0 ]; then
+  echo "All symlinks in place. Repo: $REPO"
+else
+  echo "$FAILED entr(ies) failed. See output above." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New \`scripts/setup-symlinks.sh\`: idempotent script that creates or restores the 9 expected \`~/.claude/*\` symlinks on a fresh machine.
- README "Setup" section rewritten to call the script; the manual \`ln -sf\` block is removed (it had a documented \`rules/\` collision footgun that the script handles automatically).

## Behavior

| Existing state at \`~/.claude/<path>\` | Action |
|---|---|
| Symlinked to the correct target | Skipped |
| Symlinked to a different target | Removed and re-linked (no backup needed; symlinks have no content) |
| Real file or directory | Backed up to \`<path>.bak.<timestamp>\`, then symlinked |
| Nothing | New symlink created |

## Configuration

- Repo location resolves in order: \`$CLAUDE_DOTFILES_REPO\` -> script-relative detection -> \`~/dev/claude\`.
- \`--check\` (also \`-n\` / \`--dry-run\`): reports what would happen without making changes.
- Exit 1 if any entry failed, 0 otherwise.

## Why

Closes the bootstrap chicken-and-egg the \`symlink-check.sh\` SessionStart hook (#60) cannot solve: on a fresh machine where \`settings.json\` is a real file, the hook registration is not loaded, so the warning never fires. The setup script needs to run once to make subsequent drift detection actually work.

## Test plan

- [x] Dry-run on this machine (everything already correctly symlinked): all 9 entries report \`OK\`, no changes, exit 0.
- [ ] On a clean clone with empty \`~/.claude/\`: all 9 entries report \`CREATED\`, exit 0. Subsequent re-run: all 9 report \`OK\`.
- [ ] Pre-existing real file at \`~/.claude/settings.json\`: entry reports \`REPLACED\`, file moved to \`.bak.<ts>\`, symlink created.
- [ ] Pre-existing wrong-target symlink: entry reports \`RELINKED\`, points to the correct target after.