### PR TITLE
docs(rules): add uniform 'When to apply' line + drop stale frontmatter

### DIFF
--- a/rules/agent-routing.md
+++ b/rules/agent-routing.md
@@ -1,5 +1,7 @@
 # Expert Agent Routing
 
+**When to apply:** when a task touches a specialized domain (architecture, frontend, backend, security, infra, etc.). Skip for trivial changes (typos, one-liners, config tweaks).
+
 Specialized agent personas live in `~/.claude/agents/`. Each captures domain expertise plus guardrails and red flags.
 
 ## Loading model

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -1,11 +1,13 @@
 # Communication
 
+**When to apply:** every interaction with the user (grilling, planning, debugging, code review, casual conversation).
+
 ## Asking questions
 
 Ask **one** question at a time. Wait for the answer before asking the next.
 
 - Do not stack multiple questions in a single turn, even closely related ones.
-- Do not bundle a question with "and also confirm X, Y, Z" tacked onto the end — those are separate questions, ask them on later turns.
+- Do not bundle a question with "and also confirm X, Y, Z" tacked onto the end - those are separate questions, ask them on later turns.
 - If you have many things to clarify, pick the single most blocking one and ask only that. The rest go in the next turn.
 - Applies to all interaction (grilling, planning, debugging, code review, casual conversation), not just to the `/grill-with-docs` skill.
 

--- a/rules/context7.md
+++ b/rules/context7.md
@@ -1,4 +1,8 @@
-Use the `ctx7` CLI to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service -- even well-known ones like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This includes API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Use even when you think you know the answer -- your training data may not reflect recent changes. Prefer this over web search for library docs.
+# Library Documentation (ctx7 CLI)
+
+**When to apply:** whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service. Including well-known ones (React, Next.js, Prisma, Tailwind, Django) since your training data may not reflect recent changes.
+
+Use the `ctx7` CLI to fetch current documentation. This covers API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Prefer it over web search for library docs.
 
 Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts.
 

--- a/rules/database.md
+++ b/rules/database.md
@@ -1,9 +1,6 @@
----
-globs: "**/migrations/**,**/*.sql,**/prisma/**,**/drizzle/**,**/knex/**"
-description: "Database conventions and migration safety"
----
-
 # Database Conventions
+
+**When to apply:** editing migrations, SQL files, or any database schema / query code (Prisma, Drizzle, Knex, raw SQL).
 
 - Soft delete only - never hard delete records (use `deleted_at` timestamp)
 - Explicit migrations only - never auto-sync schemas in production

--- a/rules/diagrams.md
+++ b/rules/diagrams.md
@@ -1,5 +1,7 @@
 # Diagram Policy
 
+**When to apply:** creating or updating any diagram in `docs/` (flowchart, sequence, architecture, state machine, etc.).
+
 Two diagram formats are allowed in `docs/`. Pick by complexity, not by aesthetic preference.
 
 ## Mermaid (default)

--- a/rules/engineering-principles.md
+++ b/rules/engineering-principles.md
@@ -1,6 +1,6 @@
 # Engineering Principles
 
-Universal principles that apply to all implementation work, regardless of domain or language.
+**When to apply:** every implementation task, regardless of domain or language.
 
 ## Change Sizing
 

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -1,5 +1,7 @@
 # Git Conventions
 
+**When to apply:** every commit, branch operation, or pull-request action.
+
 ## Commits
 
 - Always use conventional commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, etc.)
@@ -14,7 +16,7 @@
 - NEVER merge PRs automatically - always wait for the user to merge manually
 - After completing any feature implementation, create a PR unless explicitly told otherwise - do not wait to be asked
 - Always rebase onto the target branch (`git fetch origin main && git rebase origin/main`) before creating a PR
-- Always run `/user:verify-done` before pushing any branch - never push without all checks passing
+- Always run `/verify-done` before pushing any branch - never push without all checks passing
 - PR descriptions: always use bullet points in the summary section, not prose paragraphs
 - After pushing new commits to an existing PR, update the PR title and description to reflect all changes - use `gh pr edit` to keep them accurate
 - If the repo has a PR template (`.github/pull_request_template.md`), use it. If not, use `~/.claude/pull_request_template.md`

--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -1,9 +1,6 @@
----
-globs: "**/terraform/**,**/Dockerfile,**/docker-compose*,**/*.tf,**/k8s/**,**/.github/workflows/**"
-description: "Infrastructure and CI/CD conventions"
----
-
 # Infrastructure Conventions
+
+**When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, or CI/CD workflow files.
 
 - Infrastructure as Code only - no manual changes to cloud resources
 - No `latest` tags for Docker images - always use specific version tags

--- a/rules/jira.md
+++ b/rules/jira.md
@@ -1,6 +1,8 @@
 # Jira Access
 
-When the user mentions a Jira ticket, issue, story, bug, or epic, reach for `acli` (Atlassian CLI) before doing anything else.
+**When to apply:** when the user mentions a Jira ticket / issue / story / bug / epic, drops a Jira key (`[A-Z]+-\d+`), or pastes a Jira URL.
+
+Reach for `acli` (Atlassian CLI) before doing anything else.
 
 ## Detection
 
@@ -15,7 +17,7 @@ If the reference is ambiguous (could be GitHub issue vs Jira), ask before assumi
 ## Tool check
 
 1. Run `which acli` to confirm it is installed.
-2. If installed, run `acli jira auth status` (or attempt a read command) to confirm it is authenticated. If unauthenticated, surface that to the user — do not attempt to authenticate on their behalf.
+2. If installed, run `acli jira auth status` (or attempt a read command) to confirm it is authenticated. If unauthenticated, surface that to the user - do not attempt to authenticate on their behalf.
 3. If not installed or not configured, tell the user and fall back to asking them for the ticket contents.
 
 ## Usage
@@ -31,7 +33,7 @@ acli jira workitem comment <KEY> ...    # add comment
 acli jira workitem update <KEY> ...     # update fields / transition
 ```
 
-Run `acli jira workitem --help` for the current command surface — flags change between versions, so do not guess.
+Run `acli jira workitem --help` for the current command surface - flags change between versions, so do not guess.
 
 ## Rules
 
@@ -39,4 +41,4 @@ Run `acli jira workitem --help` for the current command surface — flags change
 - **No silent writes**: never transition, comment on, or update a ticket without explicit user confirmation. Reading is free; writing affects shared state.
 - **Do not invent keys**: only act on keys the user actually provided. Do not guess project prefixes.
 - **Stay scoped**: fetch the specific tickets referenced, not the entire backlog. Avoid broad `--jql` sweeps unless asked.
-- **Surface auth errors**: if `acli` returns an auth or permission error, report it verbatim — do not retry blindly or attempt to re-auth.
+- **Surface auth errors**: if `acli` returns an auth or permission error, report it verbatim - do not retry blindly or attempt to re-auth.

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -1,5 +1,7 @@
 # Parallel Work with Agent Worktrees
 
+**When to apply:** when a task has 2+ independent sub-tasks that touch different files / modules and can run concurrently.
+
 When a task can be split into independent pieces, parallelize by spawning multiple agents in isolated git worktrees. This dramatically reduces wall-clock time for multi-part work.
 
 ## When to Parallelize

--- a/rules/state-persistence.md
+++ b/rules/state-persistence.md
@@ -1,5 +1,7 @@
 # State Persistence
 
+**When to apply:** when saving research artifacts, specs, plans, or session diaries.
+
 All work artifacts must be saved to the project-level `.claude/state/` directory so they persist across sessions and machines.
 
 ## Directories

--- a/rules/tests.md
+++ b/rules/tests.md
@@ -1,9 +1,6 @@
----
-globs: "**/*.test.ts,**/*.spec.ts,**/*.test.tsx,**/*.spec.tsx"
-description: "Testing standards and patterns"
----
-
 # Testing Standards
+
+**When to apply:** editing test files (`*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`).
 
 - Vitest preferred as the test runner
 - Mock external dependencies only (APIs, databases, file system) - not internal modules

--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -1,9 +1,6 @@
----
-globs: "**/*.ts,**/*.tsx"
-description: "TypeScript coding standards"
----
-
 # TypeScript Standards
+
+**When to apply:** editing TypeScript files (`*.ts`, `*.tsx`).
 
 - No `any` or `unknown` - use proper types, generics, or branded types
 - 2-space indentation, single quotes


### PR DESCRIPTION
## Summary

- Add a \`When to apply: ...\` one-liner near the top of all 13 \`rules/*.md\` files so the model can tell in one glance whether the rule is relevant on the current turn.
- Remove the \`globs:\` / \`description:\` frontmatter from \`database.md\`, \`infrastructure.md\`, \`tests.md\`, \`typescript.md\`. Path-scoped loading was the original purpose; since all rules are \`@\`-imported globally (PR #56), the frontmatter is decorative and was misleading the README's claims about which rules are "path-scoped" vs "always-loaded". The same trigger context is now expressed as prose in the When-to-apply line.
- Add a missing H1 title to \`context7.md\` (the only rule file without one).
- Fix one stale \`/user:verify-done\` reference in \`git-conventions.md\` left over from #56's rename pass.

## Side effects

The \`post-edit-lint.sh\` hook (#58) auto-fixed pre-existing em-dashes in \`communication.md\` and \`jira.md\` when those files were touched. First production firing of that hook on a Claude-authored edit, working as designed.

## What this PR does NOT do

Internal shape of each rule file is untouched. Rules vary from 15 to ~100 lines depending on whether they're a short checklist (typescript.md, infrastructure.md) or a longer policy with rationale and examples (parallel-agents.md, diagrams.md, engineering-principles.md). Forcing a uniform internal structure would dilute meaning. The light-touch consistency is the When-to-apply trigger line; everything below it stays content-appropriate.

## Test plan

- [ ] Read any rule file cold. Confirm the When-to-apply line answers "should I care about this rule right now?" in under 10 seconds.
- [ ] Verify no rule file still contains \`globs:\` frontmatter.
- [ ] Verify no rule file still contains \`/user:verify-done\`.
- [ ] Verify \`context7.md\` now has an H1.