### PR TITLE
docs(skills): finish the /user:verify-done -> /verify-done rename

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -24,7 +24,7 @@ For each task in the plan:
 4. **Compile continuously**: the project must build after every increment. Run typecheck after each file change.
 5. **Test alongside**: write tests as part of the increment, not as a separate step afterward
 6. **Checkpoint**: after completing each task:
-   - Run `/user:verify-done` (typecheck + lint + tests + build) - do not rely on post-edit hooks alone
+   - Run `/verify-done` (typecheck + lint + tests + build) - do not rely on post-edit hooks alone
    - If all pass, commit with a conventional commit message
    - If any fail, fix before moving to the next task - never accumulate errors across tasks
 
@@ -40,6 +40,6 @@ If the feature is large and will take multiple sessions:
 
 After all tasks are done:
 
-- Run `/user:verify-done` one final time
+- Run `/verify-done` one final time
 - Summarize what was built and what changed
 - Flag any deferred items or follow-up work as issues

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -34,7 +34,7 @@ Pick the top candidate. If two are tied or the user has a strong prior, ask the 
 
 - Minimal change first per CLAUDE.md (1-5 lines, ideally). State the change before applying it.
 - Add a regression test that reproduces the original failure and now passes.
-- Run `/user:verify-done` (lint + typecheck + test + build).
+- Run `/verify-done` (lint + typecheck + test + build).
 - Commit on a feature branch with a conventional message that names the root cause.
 - Open a PR per `mr` skill. PR body: link to the alert/log, root cause statement with evidence, and why this fix is correct.
 

--- a/skills/mr/SKILL.md
+++ b/skills/mr/SKILL.md
@@ -2,7 +2,7 @@
 
 ## Workflow
 
-1. **Run `/user:verify-done` first**: hard-fail on any failure. Do not proceed to push, title generation, or PR ceremony if lint, typecheck, test, or build is broken. This pre-empts the most common CI failures (lint, format, typecheck) before they cost a CI run.
+1. **Run `/verify-done` first**: hard-fail on any failure. Do not proceed to push, title generation, or PR ceremony if lint, typecheck, test, or build is broken. This pre-empts the most common CI failures (lint, format, typecheck) before they cost a CI run.
 2. **Detect VCS platform**: check for `.gitlab-ci.yml` (-> glab) or `.github/` (-> gh)
 3. **Determine base branch**:
    - Default for GitLab repos: `main`
@@ -19,7 +19,7 @@
 9. **Preview and wait for approval**:
    - Print the validated MR/PR title, the fully filled-in description body, and the target branch to the chat
    - Explicitly stop and wait for the user to confirm in a subsequent turn (e.g. "go", "create it", "lgtm")
-   - Ambiguous or non-committal replies do not count as approval — ask again rather than proceed
+   - Ambiguous or non-committal replies do not count as approval - ask again rather than proceed
    - Do NOT call `gh pr create` / `glab mr create` until that explicit confirmation arrives
 10. **Create MR/PR using the template**:
     - If `.github/pull_request_template.md` or `.gitlab/merge_request_templates/` exists, use that template
@@ -61,7 +61,7 @@
 - Pass the body via HEREDOC for correct formatting
 - If auth fails, stop and ask the user to authenticate - do not retry
 - If the repo has a specific MR template, prefer it over the default
-- Never reference local Claude artifacts (research notes, plans, session summaries under `.claude/state/`, etc.) in the MR/PR description — they only have value locally and mean nothing to reviewers
+- Never reference local Claude artifacts (research notes, plans, session summaries under `.claude/state/`, etc.) in the MR/PR description - they only have value locally and mean nothing to reviewers
 - Never pass `--yes` or any other non-interactive auto-accept flag to `glab mr create` / `gh pr create`
-- This approval gate applies even when auto mode is active — auto mode is not a license to open MRs/PRs without a human checkpoint
-- **Scope of the approval gate**: the gate is specifically on the `glab mr create` / `gh pr create` invocation. Related operations that happen before it — pushing the branch, drafting the body, transitioning the Jira ticket — do not need a separate prompt once MR creation itself has been approved in the same turn
+- This approval gate applies even when auto mode is active - auto mode is not a license to open MRs/PRs without a human checkpoint
+- **Scope of the approval gate**: the gate is specifically on the `glab mr create` / `gh pr create` invocation. Related operations that happen before it - pushing the branch, drafting the body, transitioning the Jira ticket - do not need a separate prompt once MR creation itself has been approved in the same turn

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -11,7 +11,7 @@ Run these checks in order. Stop at the first failure.
 
 ### 1. Code Quality
 
-- [ ] Run `/user:verify-done` - stop on first failure (typecheck + lint + tests + build)
+- [ ] Run `/verify-done` - stop on first failure (typecheck + lint + tests + build)
 - [ ] No debugging artifacts (`console.log`, `debugger`, `.only()`, `TODO` without issue link)
 
 ### 2. Git Hygiene


### PR DESCRIPTION
## Summary

Catch the last 9 stale \`/user:verify-done\` references in active skill files. The earlier rename pass (#56) caught the references in CLAUDE.md and the SessionStart hook string, but missed these because they were embedded inside skill prose / checklists rather than command tables:

- \`skills/mr/SKILL.md\` - 5 references
- \`skills/build/SKILL.md\` - 2 references (lines 27 + 43)
- \`skills/ship/SKILL.md\` - 1 reference
- \`skills/debug/SKILL.md\` - 1 reference

After this PR: no \`/user:\` prefixes remain anywhere in active files. The only mentions left are inside \`docs/adr/0001-\` and \`docs/adr/0002-\`, which stay unchanged because ADRs are immutable historical record (per \`rules/diagrams.md\` and \`/document\` skill convention).

## Test plan

- [ ] \`grep -rn "/user:" --include="*.md" skills/ commands/ rules/ hooks/ scripts/\` returns nothing outside \`docs/adr/\`.