### PR TITLE
docs(readme): trim landing page and merge intro paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ The whole config is symlinked into `~/.claude/`, so edits to this repo apply to 
 ## Quick start
 
 ```bash
-git clone git@github.com:domengabrovsek/claude.git ~/dev/claude
-cd ~/dev/claude
+# Clone the repo wherever you keep dotfiles - the setup script auto-detects its own location
+git clone git@github.com:domengabrovsek/claude.git
+cd claude
 
-# Dry-run first, then apply
+# Dry-run first to see what would change, then apply
 bash scripts/setup-symlinks.sh --check
 bash scripts/setup-symlinks.sh
 
-# Strip ephemeral state Claude Code writes to settings.json
+# Strip ephemeral state Claude Code writes to settings.json at runtime
 git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState)" 2>/dev/null || cat'
 git config filter.strip-ephemeral-state.smudge cat
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The whole config is symlinked into `~/.claude/`, so edits to this repo apply to 
 ## Quick start
 
 ```bash
-# Clone the repo wherever you keep dotfiles - the setup script auto-detects its own location
+# Clone the repo - the setup script auto-detects its own location
 git clone git@github.com:domengabrovsek/claude.git
 cd claude
 

--- a/README.md
+++ b/README.md
@@ -2,119 +2,42 @@
 
 Custom configuration for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) that turns it into a disciplined engineering partner with structured workflows, strict guardrails, and domain-specific expertise.
 
-## Why
+Out of the box, Claude Code is capable but generic. This repo adds opinionated defaults: a research -> grill -> build -> ship workflow, security boundaries, code standards, and 16 expert subagents that spawn based on task context. The result is more consistent, reviewable, and safe output.
 
-Out of the box, Claude Code is capable but generic. This configuration adds opinionated defaults - a mandatory research-plan-implement workflow, security boundaries, code standards, and 16 expert agents that activate automatically based on task context. The result is more consistent, reviewable, and safe output.
+The whole config is symlinked into `~/.claude/`, so edits to this repo apply to every Claude Code session. It contains global rules (`CLAUDE.md`, `rules/`), automation hooks, slash commands, subagent personas, and reusable workflow skills.
 
-## Repository Structure
-
-```text
-CLAUDE.md                      # Core rules (workflow, security, behavioral constraints)
-settings.json                  # Global settings (hooks, deny list, permissions)
-agents/                        # 16 expert agent personas
-commands/                      # Slash commands for frequent workflows
-hooks/                         # Automation scripts (formatting, typechecking)
-rules/                         # Modular instruction files (always-loaded + path-scoped)
-scripts/                       # Utility scripts (notifications)
-skills/                        # Reusable workflows with supporting files
-docs/                          # Reference documentation
-.github/pull_request_template.md   # Default PR template (GitHub convention)
-.github/workflows/             # CI (markdown linting)
-```
-
-## Setup
-
-Symlink the repo contents to `~/.claude/` so changes auto-sync:
+## Quick start
 
 ```bash
-# Clone the repo
 git clone git@github.com:domengabrovsek/claude.git ~/dev/claude
-
-# Bootstrap the symlinks (idempotent, safe to re-run, dry-run via --check)
-bash ~/dev/claude/scripts/setup-symlinks.sh
-
-# Configure smudge/clean filter to strip ephemeral state from settings.json
 cd ~/dev/claude
+
+# Dry-run first, then apply
+bash scripts/setup-symlinks.sh --check
+bash scripts/setup-symlinks.sh
+
+# Strip ephemeral state Claude Code writes to settings.json
 git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState)" 2>/dev/null || cat'
 git config filter.strip-ephemeral-state.smudge cat
 ```
 
-The setup script handles all 10 expected symlinks (CLAUDE.md, RTK.md, settings.json, agents, commands, hooks, rules, skills, statusline.sh, pull_request_template.md). If something already exists at one of those paths:
+Re-runs are safe: existing files are backed up to `<path>.bak.<timestamp>` before being replaced. A `SessionStart` hook warns if a symlink drifts later.
 
-- Correctly symlinked already -> skipped.
-- Symlinked to a wrong target -> the wrong link is removed and replaced.
-- A real file or directory -> backed up to `<path>.bak.<timestamp>` before being replaced. Your local-only content is preserved next to the new symlink for you to inspect.
+## What's inside
 
-Run `bash ~/dev/claude/scripts/setup-symlinks.sh --check` first if you want a dry-run showing exactly what each step would do.
-
-Once the symlinks are in place, the `symlink-check.sh` SessionStart hook (in `hooks/`) will warn on stderr if any of them drift later.
-
-**Note**: Claude Code writes ephemeral state (e.g. `feedbackSurveyState`) to `settings.json` at runtime. The smudge/clean filter in `.gitattributes` automatically strips this before git sees it, so `git status` stays clean.
-
-## RTK (Token Optimization)
-
-[RTK](https://github.com/rtk-ai/rtk) is a CLI proxy written in Rust that sits between Claude Code and the shell. It intercepts common commands (`git status`, `npm test`, `grep`, `docker`, etc.), strips noise the model doesn't need (passing tests, progress bars, ASCII borders), and returns a compressed version. Reported savings are 60-90% tokens on typical dev operations, which translates to more exchanges per session before hitting rate limits.
-
-The integration lives in this repo:
-
-- `RTK.md` - meta-command reference, imported into every session via `@RTK.md` in `CLAUDE.md`
-- `rtk/config.toml` - tracked config with tee mode on (`failures`), telemetry off, default exclusions
-- `settings.json` - `PreToolUse` Bash hook that rewrites commands transparently
-
-### Installing RTK
-
-```bash
-# Install the binary and initialize the Claude Code hook
-brew install rtk
-rtk init -g --hook-only   # hook-only: the repo provides RTK.md
-
-# Symlink the tracked config (macOS)
-mkdir -p ~/Library/Application\ Support/rtk
-ln -sf ~/dev/claude/rtk/config.toml ~/Library/Application\ Support/rtk/config.toml
-
-# Verify
-rtk --version
-rtk config          # should print the symlinked config
-rtk gain            # token savings analytics
-```
-
-### Safety note
-
-RTK filters what the model sees. During complex debugging (e.g. correlating timeouts across services), compression can hide patterns that matter. Two mitigations are configured:
-
-- **Tee mode** (`failures`) preserves the full unfiltered output whenever a command fails, so raw data is always recoverable.
-- **`exclude_commands`** in `rtk/config.toml` lets you bypass filtering for specific commands when raw output is non-negotiable (prod DB sessions, incident log tailing).
-
-Use `rtk proxy <cmd>` for a one-shot unfiltered run without editing config.
-
-## Components
-
-Each top-level directory is the canonical source for what it contains. Edit the source files; this README only points.
-
-- **`CLAUDE.md`** - core rules loaded every session: priority order, workflow, security boundaries, code standards, behavioral constraints. See [ADR 0001](docs/adr/0001-grill-driven-workflow.md) for the workflow rationale.
-- **`rules/`** - 13 modular rule files (agent-routing, communication, context7, database, diagrams, engineering-principles, git-conventions, infrastructure, jira, parallel-agents, state-persistence, tests, typescript). All `@`-imported into `CLAUDE.md` so they load in every session.
-- **`agents/`** - 16 expert subagent personas (Staff Engineer, PR Reviewer, PostgreSQL Expert, ...). Spawned via the Agent tool; routing in [`rules/agent-routing.md`](rules/agent-routing.md). Full grouped listing in [`docs/agents.md`](docs/agents.md). See [ADR 0003](docs/adr/0003-agents-via-subagent-spawn.md) for the loading model.
-- **`skills/`** - reusable workflows invoked as `/<skill>` (`/grill-with-docs`, `/build`, `/ship`, `/debug`, ...). Each lives in `skills/<name>/SKILL.md`. Skills marked `(mattpocock)` in their description are vendored from [mattpocock/skills](https://github.com/mattpocock/skills) and may diverge from upstream.
-- **`commands/`** - thin slash invocations for one-shot operations: `/research`, `/summarize`, `/verify-done`, `/worktree`, `/worktree-merge`, `/worktrees`. Anything more substantive than a thin invocation belongs in `skills/`.
-- **`hooks/`** - shell scripts wired into `settings.json` for `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd` events (pre-pr-test-gate, pre-push-gate, pre-commit-branch-gate, auto-format, post-edit-typecheck, post-edit-lint, watch-pr-checks, worktree-cleanup, symlink-check).
-- **`scripts/`** - utilities referenced by hooks and skills: `setup-symlinks.sh` (bootstrap), `statusline.sh`, `notify.sh`, `worktree-prune.sh`.
+- **`CLAUDE.md`** - core rules loaded every session (workflow, security, code standards). See [ADR 0001](docs/adr/0001-grill-driven-workflow.md).
+- **`rules/`** - modular instruction files `@`-imported into `CLAUDE.md`.
+- **`agents/`** - expert subagent personas spawned via the Agent tool. Routing in [`rules/agent-routing.md`](rules/agent-routing.md); full list in [`docs/agents.md`](docs/agents.md). See [ADR 0003](docs/adr/0003-agents-via-subagent-spawn.md).
+- **`skills/`** - reusable `/<skill>` workflows (`/grill-with-docs`, `/build`, `/ship`, `/debug`, …). Skills marked `(mattpocock)` are vendored from [mattpocock/skills](https://github.com/mattpocock/skills).
+- **`commands/`** - thin slash invocations (`/research`, `/verify-done`, `/worktree`, …).
+- **`hooks/`** - shell scripts wired into `settings.json` for `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd` events.
+- **`scripts/`** - utilities used by hooks and skills (`setup-symlinks.sh`, `statusline.sh`, `notify.sh`, `worktree-prune.sh`).
 - **`docs/adr/`** - Architecture Decision Records.
-- **`references/`** - longer-form checklists (security, testing patterns) referenced by skills and agents.
+- **`references/`** - long-form checklists (security, testing) loaded by skills on demand.
 - **`templates/`** - boilerplate for new ADRs and docs.
 
-For a quick "is there a slash for X?" lookup, see [CHEATSHEET.md](CHEATSHEET.md).
+## More
 
-Per-project session state (not in this repo) lives under each consuming project's `.claude/state/{research,specs,plans,sessions}/`. Conventions in [`rules/state-persistence.md`](rules/state-persistence.md).
-
-## Security
-
-- Comprehensive deny list in `settings.json` blocking 35+ sensitive file patterns (env files, SSH/GPG keys, credentials, cloud configs, shell history)
-- Bash command restrictions blocking destructive operations (`rm -rf`, `git push --force`, `sudo`, `DROP TABLE`)
-- Lock file protection prevents edits to `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
-- PreToolUse gate blocks PR creation when tests fail
-- PostToolUse formatting hook validates files before processing
-- Agent guardrails enforce security checks across all domains
-
-## CI
-
-Markdown linting runs on every push and PR via GitHub Actions.
+- **Token optimization** - RTK proxies common commands and strips noise. See [`RTK.md`](RTK.md).
+- **Security boundaries** - deny list, Bash restrictions, and lock-file protection live in [`settings.json`](settings.json).
+- **CI** - markdown linting on push/PR (`.github/workflows/`).


### PR DESCRIPTION
## What does this PR do?

Slims the repo's README from 120 to 43 lines so first-time readers can grok what the repo is and how to use it without scrolling. Detail moved to (or already living in) canonical sources.

- Drop redundant Repository Structure tree; the labelled **What's inside** list now does both jobs
- Move RTK install/usage detail out to `RTK.md` (already the canonical reference loaded into every session)
- Drop standalone Security and CI sections; point to `settings.json` and `.github/workflows/`
- Shorten Setup to a single bash block; link out to `setup-symlinks.sh --check` for the long-form walkthrough
- Merge the original intro with the `## Why` paragraph so the pitch reads as one flow instead of two stacked headings

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant