### PR TITLE
feat(skills): add drive-fleet workflow skill

### DIFF
--- a/docs/adr/0004-drive-fleet.md
+++ b/docs/adr/0004-drive-fleet.md
@@ -1,0 +1,37 @@
+# Drive-fleet: a manager-only loop that drives a fleet of MRs/PRs to done
+
+## Status
+
+Accepted - 2026-06-02
+
+## Context
+
+Multi-MR / multi-lane work (often spanning sibling repos) was being driven ad hoc: the main session edited, reviewed, and rebased branches itself while holding the whole fleet's state in one context. That context fills fast, edits in one lane stomp another, and CI polling blocks the turn. The subagent-spawn model (ADR 0003) and worktree isolation (`rules/parallel-agents.md`) already exist to avoid this, but nothing tied them into a repeatable end-to-end workflow with a stop condition.
+
+Claude Code's built-in `/goal` command supplies the missing piece: a plain-English completion condition that keeps a session working across turns and auto-clears when met. That makes a hands-off "drive the fleet to done" loop possible without any custom Stop-hook machinery.
+
+Two existing skills create tension with a hands-off loop. `/mr` enforces a human approval gate at MR/PR creation "even when auto mode is active", and `/ci` requires proposing fixes to the user and flagging flaky/infra failures rather than auto-fixing. A fully autonomous loop would contradict gates that were built deliberately.
+
+## Decision
+
+Introduce a `drive-fleet` skill encoding a two-phase workflow:
+
+1. **Plan via grills** (`/grill-with-docs`) - pressure-test the approach, emit CONTEXT.md + ADRs inline, and write an execution plan to `.claude/state/plans/` that proves the lanes are file-isolated.
+2. **Drive with `/goal`** - the operator opens a fresh manager session and sets a `/goal` (the agent cannot start its own session or set its own goal). That single session then runs an orchestration loop that delegates ALL edit / review / rebase / conflict work to worktree-isolated domain-expert subagents. It never mutates a working tree and never spawns nested sessions; `/goal` plus context compaction sustain the one loop until the condition holds.
+
+The skill is platform-neutral: all VCS/CI mechanics delegate to `/mr` and `/ci`. Repo-specifics (target branch, verification command, any post-completion job such as `notify_reviewers`) live in a per-repo block, not in the skill body.
+
+Authorization is reconciled with the existing gates by **batching, not bypassing**: the human approves the fleet's MRs once - preserving `/mr`'s outward-facing, memory-valued create gate - and setting the `/goal` pre-authorizes in-scope downstream iteration (auto-fix, flaky-retry, rebase, review fixes). Three conditions always hard-stop and escalate instead of plowing ahead: a plan-invalidating conflict, a structural CI failure (3x the same issue), and the outward `post_completion_action`.
+
+## Consequences
+
+- Multi-MR work runs hands-off after a single batched approval, with the manager's context staying small (state lives in subagents and worktrees).
+- The deviation from `/mr`'s per-MR gate and `/ci`'s per-fix gate is deliberate and scoped: the gate is batched to MR creation, and autonomy is bounded by the approved plan plus the three escalation carve-outs.
+- The workflow depends on `/goal` (built into Claude Code) and on the lanes being genuinely file-isolated; a plan that fails the isolation proof is not safe to run.
+- Cross-repo runs under a non-git parent require manual per-repo worktree management.
+
+## Considered alternatives
+
+- **Preserve every gate** (surface each MR-create and each fix for approval). Rejected: it defeats the hands-off premise; `/goal` would just keep the session alive across a wall of checkpoints.
+- **Full blanket pre-authorization** (no gate at all). Rejected: MR creation is outward-facing and the standing preference is to always route through `/mr`'s gate. Batching the gate keeps one human checkpoint where it matters without serializing the rest.
+- **Build a custom `/goal` command + Stop hook.** Rejected: `/goal` already ships in Claude Code and does exactly this; custom machinery would be redundant.

--- a/skills/drive-fleet/SKILL.md
+++ b/skills/drive-fleet/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: drive-fleet
+description: "Drive a fleet of MRs/PRs to done with a manager loop plus the built-in /goal command. Use for multi-lane / multi-MR work (often spanning sibling repos) where one session plans file-isolated lanes and a fresh manager session sets a /goal, then delegates ALL edit / review / rebase / conflict work to worktree-isolated domain-expert subagents. Use when the user says 'drive fleet' / 'drive the fleet', has 2+ independent lanes to drive in parallel, or wants a hands-off manager that stops only when the whole fleet is green, reviewed, and rebased."
+---
+
+# Drive Fleet
+
+A two-phase workflow for driving a fleet of MRs/PRs to done in parallel with a manager that never touches a working tree. Platform-neutral: all VCS/CI mechanics delegate to `/mr` and `/ci`.
+
+## When to use
+
+- 2+ independent lanes / multiple MRs, often across sibling repos
+- You want a hands-off MANAGER that delegates every edit and only stops when the whole fleet is done
+- Not for single-MR work - use `/build` + `/mr` directly
+
+## The goal condition
+
+The built-in `/goal` command keeps the session working across turns until the condition holds, then auto-clears. Set it once, in the MANAGER session - it is session-scoped and resets on resume, so a re-planned session re-sets it.
+
+Template (fill the `{knobs}`):
+
+> Every open MR/PR from `{plan}` is CI-green, reviewed (`{review_depth}` applied via review-pr), and rebased on `{target_branch}`. `{post_completion_action}`
+
+| Knob | Default |
+| --- | --- |
+| `target_branch` | `main` |
+| `review_depth` | blockers + majors + one-line fixes |
+| `post_completion_action` | none (repo-specific; e.g. "Once all hold simultaneously, trigger the `notify_reviewers` job on each") |
+
+## Phase 1 - Plan via grills
+
+1. Run `/grill-with-docs` (add `grill-me` if you have it installed) to pressure-test the approach against the existing domain model, sharpen terminology, and emit CONTEXT.md + ADRs inline.
+2. Output: an execution plan in `.claude/state/plans/` that defines the lanes / MRs and **proves they are file-isolated** - no two lanes touch the same file.
+
+The plan is the contract. Approving it and setting the `/goal` is your batched authorization for the fleet (see [orchestration.md](orchestration.md)).
+
+## Phase 2 - Drive with /goal (manager-only)
+
+Phase 2 is started by **you, the operator** - the agent cannot open its own session or set its own goal:
+
+1. Open a **fresh** Claude Code session. The plan on disk is the whole handoff; nothing from the grill carries over. This boundary is also a deliberate gate - a long autonomous run should not start as a side effect of planning.
+2. Type `/goal <condition>` (built into Claude Code). With auto mode on, `/goal` is what keeps the **one** manager session working turn after turn until the fleet meets the condition, then auto-clears.
+3. Invoke this skill and run the manager loop (see [orchestration.md](orchestration.md)).
+
+This stays a **single, thin manager session** the whole time - it never spawns nested sessions. Its context stays small because all editing / review / rebase / conflict work goes to subagents (each with its own context window) and worktrees; the harness compacts the manager's context as it grows. The main loop manages and nothing else - it never edits, reviews, rebases, or resolves conflicts.
+
+> If this skill is invoked with no `/goal` set, stop and ask the operator to set one (ideally in a fresh session) before running the loop.
+
+## Example - a fleet spanning three repos
+
+**Phase 1** (planning session) - describe the work; the agent grills and plans:
+
+```text
+/drive-fleet
+Add a feature-flag system end-to-end: the evaluation service in the api repo,
+the React hook + toggle UI in the web repo, and the shared flag schema in the
+shared-types repo. Plan file-isolated lanes across the three repos.
+```
+
+The agent runs `/grill-with-docs`, proves the lanes share no files, writes the plan to `.claude/state/plans/`, and hands back the `/goal` line to use next.
+
+**Phase 2** (fresh session) - set the goal, turn on auto mode, start the loop:
+
+```text
+/goal Every open MR/PR from the feature-flags plan is CI-green, reviewed
+(blockers + majors + one-line fixes via review-pr), and rebased on main.
+```
+
+```text
+/drive-fleet
+Execute the plan at .claude/state/plans/2026-06-02-feature-flags.md
+```
+
+The manager builds the three lanes in parallel worktrees, opens the MRs (you approve the batch once), then drives CI-fix / review / rebase per repo until the goal clears. Your only inputs after that are the batch approval and any escalation.
+
+## Details
+
+Manager orchestration loop, authorization model, guardrails, and the per-repo block: see [orchestration.md](orchestration.md).
+
+## Delegates to
+
+`/grill-with-docs`, `/mr`, `/ci`, `/review-pr`, `/worktree`; agent personas Frontend Staff Engineer, Backend Staff Engineer, and PR Reviewer (via Agent `subagent_type`).

--- a/skills/drive-fleet/orchestration.md
+++ b/skills/drive-fleet/orchestration.md
@@ -1,0 +1,43 @@
+# Drive Fleet - Orchestration
+
+The manager loop for Phase 2. The main loop is a MANAGER: it polls CI, dispatches subagents, tracks tasks, retargets/closes MRs, and triggers CI jobs. It NEVER mutates a working tree - no edits, reviews, rebases, or conflict resolution. All of that is delegated to background subagents, each in its own git worktree.
+
+## Authorization model
+
+Setting the `/goal` is a one-time human decision. It pre-authorizes the in-scope downstream work, with exactly one outward checkpoint:
+
+- **One batched MR gate.** You approve the fleet's MRs in a single batch. This honors `/mr`'s create-time gate (which holds even in auto mode) without serializing the rest of the run.
+- **Hands-off after the gate.** Auto-fix red, retry infra-flake jobs, rebase, and apply review fixes within the plan's lanes - no per-action approval.
+- **Always hard-stop and escalate (never plow ahead) on:**
+  - a plan-invalidating conflict (e.g. `main` diverged and broke file-isolation)
+  - a structural CI failure (the same issue fails 3x - per `/ci`)
+  - the outward `post_completion_action`
+
+## The loop
+
+1. **Build lanes in parallel.** One subagent per lane, each in its own git worktree, file-isolated, <=4-5 concurrent. Route by domain: Frontend Staff Engineer / Backend Staff Engineer (Agent `subagent_type`, `run_in_background: true`, `isolation: "worktree"`). Sequential sub-tickets that share files stay inside ONE agent.
+2. **Open MRs (the batched gate).** Once lanes are pushed, open MRs via `/mr` - conventional commits, no co-author trailers, stacked-MR dependencies and retargeting. Approve the batch once.
+3. **Poll CI in the background.** One Monitor per branch via `/ci` (emits only on status change, zero cost while running). React on Monitor notifications and agent-completion events - never block the manager turn polling.
+4. **Per red MR - fix subagent.** Spawn a domain-expert subagent in that lane's worktree to diagnose and fix. Infra-flake or clearly-unrelated failure -> retry the job (`glab ci retry` / `gh run rerun`); real failure -> fix and push. Same issue 3x -> escalate to the user.
+5. **Per green MR - review subagent.** Spawn a PR Reviewer subagent that applies `/review-pr` and fixes blockers + majors + one-line fixes in the worktree.
+6. **Rebase + retarget.** Per branch, a subagent rebases onto latest `{target_branch}` (`--force-with-lease`, resolving conflicts). Retarget stacked MRs to `{target_branch}` as their bases merge.
+7. **Close out.** When the WHOLE fleet meets the condition simultaneously, run the `post_completion_action` (if any) on each MR. Only then does the `/goal` clear.
+
+## Guardrails - never violate
+
+- **Manager-only.** The main loop never edits, reviews, rebases, or resolves conflicts. It polls CI, dispatches agents, tracks tasks, retargets/closes MRs, and triggers CI jobs - nothing that mutates a working tree.
+- **One worktree per lane per repo.** Never two concurrent agents in the same worktree. Sequential file-sharing sub-tickets stay in one agent.
+- **CI polling is backgrounded.** Pollers run as Monitors (per `/ci`), not in the manager turn. React on agent-completion and pipeline-terminal events.
+- **Surface genuine conflicts.** If `main` diverges mid-session and invalidates the plan, stop and re-plan the affected MRs with the user. Do not plow ahead.
+- **Hold the post-action.** Trigger `post_completion_action` only when the full condition holds across the whole fleet.
+- **Cross-repo worktrees are manual.** When lanes span sibling repos under a non-git parent (e.g. `~/code/<project>/` holding several repos), there is no repo at the parent - manage each repo's worktrees individually (see `/worktree`).
+
+## Per-repo block (fill in before running)
+
+| Field | Example |
+| --- | --- |
+| `target_branch` | `main` (GitLab) / `develop` (GitHub) |
+| verification cmd | `npm run lint:fix && npm run typecheck && npm test && npm run build` |
+| CI tool | glab / gh (auto-detected by `/ci`) |
+| `post_completion_action` | trigger the `notify_reviewers` job / none |
+| worktree root | per repo; the parent dir is NOT a git repo for multi-repo work |


### PR DESCRIPTION
## What does this PR do?

Adds a `drive-fleet` skill encoding a two-phase workflow for driving a fleet of MRs/PRs to done:

- **Phase 1 - plan via grills:** `/grill-with-docs` pressure-tests the approach and writes a file-isolated execution plan.
- **Phase 2 - drive with `/goal`:** a thin manager session sets a `/goal` and delegates all edit/review/rebase/conflict work to worktree-isolated domain-expert subagents, stopping only when the whole fleet is CI-green, reviewed, and rebased.

Platform-neutral (delegates VCS/CI mechanics to `/mr` and `/ci`); repo-specifics live in a per-repo block. Includes `docs/adr/0004-drive-fleet.md` recording the manager-only, batched-MR-gate authorization decision (one human checkpoint at MR creation, then hands-off, with hard-stops on plan-invalidating conflicts, 3x structural CI failures, and any outward post-completion action).

Files: `skills/drive-fleet/SKILL.md`, `skills/drive-fleet/orchestration.md`, `docs/adr/0004-drive-fleet.md`. Verified locally with `markdownlint-cli2` (CI's lint gate): 0 errors.

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [ ] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant