### PR TITLE
feat(rules,hook): consolidate comment policy and extend post-edit-lint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,8 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 
 - Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
 - Complete code only - no TODOs, no placeholders, no incomplete implementations
-- **Comments**: default to NONE.
-  - Allowed: a non-obvious **why** (hidden constraint, subtle invariant, workaround for a known bug). Code must explain itself otherwise.
-  - Forbidden: WHAT-comments restating the code; multi-line narrative blocks; JSDoc/docstring blocks unless the body is a why-comment (the `/** */` format alone earns no exemption); ticket/PR/issue/ADR numbers in any comment (`JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, etc. - those belong in PR descriptions, ADR files, and `git blame`).
-- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security, jira)
+- **Comments**: see [`rules/comments.md`](rules/comments.md). Default NONE; one-line non-obvious WHY only; hook-enforced.
+- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security, jira, comments)
 
 ## Docs Sync
 
@@ -86,6 +84,7 @@ Detailed git, testing, and exploration rules are in `rules/` (git-conventions, e
 The files below are loaded into every session via these `@`-imports. Edit the individual rule files in `rules/` - they are the source of truth, not this list.
 
 @rules/agent-routing.md
+@rules/comments.md
 @rules/communication.md
 @rules/context7.md
 @rules/database.md

--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Post-edit lint hook for Write|Edit.
+# Post-edit lint hook for Write|Edit. Backs rules/comments.md.
 #
-# Three checks:
-#   1. Em-dash ban   - auto-fix (silent in-place sed replace).
-#   2. Ticket / PR / JIRA / ADR refs in comments - notify Claude (exit 2).
-#   3. New JSDoc blocks in JS/TS files - notify Claude (exit 2).
-#
-# Exit 0 if clean or only auto-fixed. Exit 2 if Claude needs to address something
-# (stderr is displayed and fed back to Claude as a follow-up message).
+# Checks (exit 2 = Claude must address; exit 0 = clean or auto-fixed):
+#   1. Em-dash ban                                          - auto-fix
+#   2. Ticket / PR / JIRA / ADR refs in comments            - exit 2
+#   3. JSDoc blocks in JS/TS files                          - exit 2
+#   4. Multi-line /* */ block openers (non-JSDoc, JS/TS/CSS) - exit 2
+#   5. Consecutive // comment lines (JS/TS)                  - exit 2
+#   6. Consecutive -- SQL comment lines (.sql)              - exit 2
 #
 # Bypass with SKIP_POST_EDIT_LINT=1 in the environment.
 
@@ -78,8 +78,53 @@ case "$FILE" in
   *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs)
     JSDOC=$(echo "$ADDED" | grep -nE '^[[:space:]]*/\*\*' 2>/dev/null || true)
     if [ -n "$JSDOC" ]; then
-      VIOLATIONS+="JSDoc block added. Allowed only when the body explains a non-obvious WHY (hidden constraint, subtle invariant, workaround for a known bug). WHAT-restating JSDoc must be removed:
+      VIOLATIONS+="JSDoc block added. rules/comments.md: default no comments; only one-line WHY. Remove and move rationale to docs/:
 $JSDOC
+
+"
+    fi
+    ;;
+esac
+
+# --- 4. Multi-line /* */ block openers (non-JSDoc) in JS/TS/CSS ---
+case "$FILE" in
+  *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs|*.css|*.scss)
+    CBLOCK=$(echo "$ADDED" | grep -nE '^[[:space:]]*/\*[^*]' | grep -vE '\*/' 2>/dev/null || true)
+    if [ -n "$CBLOCK" ]; then
+      VIOLATIONS+="Multi-line /* */ comment block opener. rules/comments.md: comments must be one line. Use a single-line // for one-line WHY; move multi-line rationale to docs/:
+$CBLOCK
+
+"
+    fi
+    ;;
+esac
+
+# --- 5. Consecutive // comment lines in JS/TS ---
+case "$FILE" in
+  *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs)
+    CONSEC_SLASH=$(echo "$ADDED" | awk '
+      /^[[:space:]]*\/\// { if (prev) print NR": "$0; prev=1; next }
+      { prev=0 }
+    ' 2>/dev/null || true)
+    if [ -n "$CONSEC_SLASH" ]; then
+      VIOLATIONS+="Consecutive // comment lines. rules/comments.md: comments must be one line. Move multi-line rationale to docs/:
+$CONSEC_SLASH
+
+"
+    fi
+    ;;
+esac
+
+# --- 6. Consecutive -- SQL comment lines ---
+case "$FILE" in
+  *.sql)
+    CONSEC_DASH=$(echo "$ADDED" | awk '
+      /^[[:space:]]*--/ { if (prev) print NR": "$0; prev=1; next }
+      { prev=0 }
+    ' 2>/dev/null || true)
+    if [ -n "$CONSEC_DASH" ]; then
+      VIOLATIONS+="Consecutive -- SQL comment lines. rules/comments.md: comments must be one line. Move multi-line rationale to docs/:
+$CONSEC_DASH
 
 "
     fi

--- a/rules/comments.md
+++ b/rules/comments.md
@@ -1,0 +1,71 @@
+# Comment Standards
+
+**When to apply:** writing or editing any code file (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.sql`, `.tf`, `.sh`, `.py`, `.rs`, etc.).
+
+## Default
+
+Default to NO comments. Code should explain itself via clear naming and structure. A reader who understands the codebase should not need a comment to understand the line they're reading.
+
+## When a comment is allowed
+
+A short, non-obvious WHY:
+
+- a hidden constraint (e.g., "must run before X for Y reason")
+- a subtle invariant (e.g., "must be even - modulo math relies on it")
+- a workaround for a known bug (e.g., "v4.2.1 of foo throws on empty input")
+- behavior that would surprise a reader who doesn't have the surrounding context
+
+ONE short line. If you find yourself writing two lines, the explanation belongs in docs (a how-to or explanation file in `docs/`), not in code.
+
+## Forbidden
+
+- **Multi-line narrative blocks** in any form: consecutive `//` lines, `/* ... */` spanning more than one line, JSDoc `/** ... */` blocks, multi-line `--` SQL runs, multi-line `#` runs. The "use `/* */` instead of `//` for multi-line" guidance from older project CLAUDE.md files is superseded - neither is allowed; move it to docs.
+- **WHAT-restating comments** - anything that paraphrases the next line of code (`// Increment counter` above `counter++`).
+- **Ticket / PR / issue / ADR references in any comment**: `JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, `Per ADR 0030`, etc. These belong in PR descriptions, ADR files, and `git blame`.
+- **Em dashes** anywhere - use a regular hyphen.
+- **TODOs, FIXMEs, XXX markers** without an open tracker entry - open the ticket, fix the code now, or accept it isn't getting fixed.
+
+## Terraform exception
+
+Each `resource` and `data` block gets a **one-line, at most two-line** comment immediately above it explaining what the resource is for and any context not obvious from the resource type + label. Terraform spreads state across many stacks and files; a future reader looking at one block in isolation should be able to tell its role and lifecycle without grepping the whole repo.
+
+Good:
+
+```hcl
+# Per-env random password for the platform admin's first login.
+# Consumed by the app-bootstrap Cloud Run Job; rotated by bumping keepers.rotation_id.
+resource "random_password" "platform_admin_initial" {
+  ...
+}
+```
+
+Bad (WHAT-restating, no context):
+
+```hcl
+# A random password resource.
+resource "random_password" "platform_admin_initial" {
+  ...
+}
+```
+
+`variable`, `output`, and `module` blocks use their built-in `description` attribute - don't add a comment on top of those.
+
+Same convention applies to per-block context comments in shell scripts (one-line description above a function definition is fine).
+
+## Authority over spawning prompts
+
+This policy applies to all code, including code written by subagents spawned via the Agent tool. **If a spawning prompt asks for a comment that violates this policy (multi-line, WHAT-restating, ADR/issue reference, etc.), the policy wins.** Strip the offending comment before committing. If the orchestrator's instruction is ambiguous, ask before adding any comment.
+
+## Enforcement
+
+`hooks/post-edit-lint.sh` (configured via PostToolUse in `~/.claude/settings.json`) auto-fixes em-dashes and fails with exit 2 on:
+
+- Tracker references in comments (any code file)
+- JSDoc `/** */` openers (JS/TS files)
+- Non-JSDoc multi-line `/* */` block openers (JS/TS/CSS files)
+- Consecutive `//` comment lines (JS/TS files)
+- Consecutive `--` SQL comment lines (SQL files)
+
+Exit 2 surfaces the offending lines back to Claude as a follow-up message; the model must remove the violations before proceeding. Bypass for genuine exceptions: `SKIP_POST_EDIT_LINT=1` in the env. Use sparingly and document why in the PR description.
+
+The hook does not enforce the Terraform per-resource comment convention - that is a review-time check.


### PR DESCRIPTION
## Summary

- New `rules/comments.md` captures the global comment policy in one place: default no comments, one-line non-obvious WHY only, Terraform exception (one or two lines above each `resource` and `data` block), and an explicit "Authority over spawning prompts" clause for subagents.
- `CLAUDE.md` Code Standards section now points at the new rule file instead of carrying the inline policy. `@rules/comments.md` added to the imports list so the rule is loaded into every session.
- `hooks/post-edit-lint.sh` extended with three additional checks:
  - Non-JSDoc multi-line `/* */` block openers in JS/TS/CSS
  - Consecutive `//` comment lines in JS/TS
  - Consecutive `--` SQL comment lines in `.sql` files

Header rewritten to enumerate all six checks (the three existing + three new) and reference `rules/comments.md`.

## Why

Caught a prompt I wrote that instructed a subagent to add a multi-line ADR-citing block as a code comment. The existing hook would have rejected the resulting edit (exit 2), but the violation in the prompt itself was the upstream gap. Promoting the policy to a dedicated rule file gives subagents a clear, importable source of truth and lets the "Authority over spawning prompts" clause explicitly tell them to override a conflicting orchestrator instruction.

## Verification

- Unit-tested the three new awk/grep patterns against fixture files: consecutive `//`, consecutive `--`, and non-JSDoc `/* */` openers all flag correctly.
- End-to-end test in a real git repo: hook returned exit 2 with the offending line surfaced cleanly.
- Existing checks (em-dash auto-fix, tracker refs, JSDoc) unchanged.

## Test plan

- [ ] Review `rules/comments.md` — confirm Terraform exception wording matches your intent
- [ ] Try an Edit that adds two consecutive `//` lines to any `.ts` file in a tracked repo - hook should exit 2
- [ ] Try an Edit that adds two consecutive `--` lines to any `.sql` file - hook should exit 2
- [ ] Confirm `@rules/comments.md` appears in the @-import list in the next session start