### PR TITLE
feat(rules,hook): extend comment policy to Terraform description attrs

### DIFF
--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -46,7 +46,7 @@ VIOLATIONS=""
 
 # --- 2. Ticket / PR / JIRA / ADR refs inside comments ---
 TICKETS=$(echo "$ADDED" | grep -nE \
-  '(//|#|/\*|^\s*\*).*(\b[A-Z]{2,}-[0-9]+\b|[[:space:]]#[0-9]+\b|\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+\b|\bADR-[0-9]+\b|\b(Fixes|Closes|Refs|Resolves)[[:space:]]+(#|[A-Z]{2,}-))' \
+  '(//|#|/\*|^\s*\*).*(\b[A-Z]{2,}-[0-9]+\b|[[:space:]]#[0-9]+\b|\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+\b|\b[Aa][Dd][Rr][[:space:]-]+[0-9]+\b|\b(Fixes|Closes|Refs|Resolves)[[:space:]]+(#|[A-Z]{2,}-))' \
   2>/dev/null || true)
 
 if [ -n "$TICKETS" ]; then
@@ -108,6 +108,21 @@ case "$FILE" in
     if [ -n "$CONSEC_DASH" ]; then
       VIOLATIONS+="Consecutive -- SQL comment lines. rules/comments.md: comments must be one line. Move multi-line rationale to docs/:
 $CONSEC_DASH
+
+"
+    fi
+    ;;
+esac
+
+# --- 7. Tracker refs inside Terraform description = "..." attributes ---
+case "$FILE" in
+  *.tf|*.tfvars)
+    TF_DESC_REFS=$(echo "$ADDED" | grep -nE \
+      'description[[:space:]]*=.*(\b[A-Z]{2,}-[0-9]+\b|[[:space:]]#[0-9]+\b|\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+\b|\b[Aa][Dd][Rr][[:space:]-]+[0-9]+\b|\b(Fixes|Closes|Refs|Resolves)[[:space:]]+(#|[A-Z]{2,}-))' \
+      2>/dev/null || true)
+    if [ -n "$TF_DESC_REFS" ]; then
+      VIOLATIONS+="Tracker reference inside Terraform description attribute. rules/comments.md: descriptions surface in terraform-docs and module-consumer docs - tracker refs belong in PR descriptions, ADR files, and git blame:
+$TF_DESC_REFS
 
 "
     fi

--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
-# Post-edit lint hook for Write|Edit. Backs rules/comments.md.
-#
-# Checks (exit 2 = Claude must address; exit 0 = clean or auto-fixed):
-#   1. Em-dash ban                                          - auto-fix
-#   2. Ticket / PR / JIRA / ADR refs in comments            - exit 2
-#   3. JSDoc blocks in JS/TS files                          - exit 2
-#   4. Multi-line /* */ block openers (non-JSDoc, JS/TS/CSS) - exit 2
-#   5. Consecutive // comment lines (JS/TS)                  - exit 2
-#   6. Consecutive -- SQL comment lines (.sql)              - exit 2
-#
-# Bypass with SKIP_POST_EDIT_LINT=1 in the environment.
+# Post-edit lint hook backing rules/comments.md. Bypass: SKIP_POST_EDIT_LINT=1.
 
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -29,26 +19,21 @@ case "$FILE" in
 esac
 
 # --- 1. Em-dash auto-fix (whole file, idempotent, silent) ---
-# Applies to ALL file types. The em-dash ban from CLAUDE.md is universal.
 if LC_ALL=C grep -q $'\xe2\x80\x94' "$FILE" 2>/dev/null; then
-  # macOS sed in-place without backup.
   sed -i '' $'s/\xe2\x80\x94/-/g' "$FILE"
 fi
 
-# --- Comment / JSDoc checks only run on code files in git repos ---
-# Skip docs/text: false positives from markdown headings (# Foo) and prose em-dashes are not relevant here.
+# --- Skip docs/text: prose comment markers cause false positives ---
 case "$FILE" in
   *.md|*.markdown|*.txt|*.rst|*.adoc|*.tex) exit 0 ;;
 esac
 
 FILE_DIR=$(dirname "$FILE")
 if ! git -C "$FILE_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-  # Not in a git repo - skip diff-based checks.
   exit 0
 fi
 
-# Collect lines added by this edit (vs HEAD).
-# If the file is untracked, treat the whole file as added.
+# Untracked file: treat whole file as added.
 if git -C "$FILE_DIR" ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
   ADDED=$(git -C "$FILE_DIR" diff --unified=0 HEAD -- "$FILE" 2>/dev/null | grep -E '^\+[^+]' | sed 's/^\+//')
 else
@@ -60,8 +45,6 @@ fi
 VIOLATIONS=""
 
 # --- 2. Ticket / PR / JIRA / ADR refs inside comments ---
-# Looks for a comment marker (// # /* *) somewhere before a tracker ref on the same line.
-# Tracker refs: UPPERCASE-### (e.g. JIRA-123), #digits, owner/repo#digits, ADR-####, Fixes/Closes/Refs/Resolves <ref>.
 TICKETS=$(echo "$ADDED" | grep -nE \
   '(//|#|/\*|^\s*\*).*(\b[A-Z]{2,}-[0-9]+\b|[[:space:]]#[0-9]+\b|\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+\b|\bADR-[0-9]+\b|\b(Fixes|Closes|Refs|Resolves)[[:space:]]+(#|[A-Z]{2,}-))' \
   2>/dev/null || true)

--- a/rules/comments.md
+++ b/rules/comments.md
@@ -50,6 +50,30 @@ resource "random_password" "platform_admin_initial" {
 
 `variable`, `output`, and `module` blocks use their built-in `description` attribute - don't add a comment on top of those.
 
+### Terraform `description` attributes follow the same tracker-ref rule
+
+The content of any `description = "..."` attribute (on `variable`, `output`, `module`, or `resource` schema attributes) is subject to the same prohibition on ticket / PR / issue / ADR references that applies to comments. These descriptions are surfaced in `terraform-docs`-generated READMEs, `terraform plan` output, and module-consumer documentation - tracker refs there are MORE visible to readers than buried in a code comment, not less.
+
+Multi-line descriptions are fine - they are documentation, not code comments. WHAT-style content is fine - describing what a variable is for is the description's job. Just no tracker refs and no em-dashes.
+
+Good:
+
+```hcl
+variable "platform_admin_email" {
+  description = "Email address for the platform admin account. Used by the app-bootstrap job to seed the initial user."
+  type        = string
+}
+```
+
+Bad:
+
+```hcl
+variable "platform_admin_email" {
+  description = "Per ADR 0031: email for the platform admin. See pentla-api PR #1397."
+  type        = string
+}
+```
+
 Same convention applies to per-block context comments in shell scripts (one-line description above a function definition is fine).
 
 ## Authority over spawning prompts


### PR DESCRIPTION
## Summary

Follow-up to merged PR #72. Two commits pushed after that merge needed their own PR.

1. **`chore(hook): strip multi-line # comment clusters per the rule`** — apply the rule that PR #72 established to `hooks/post-edit-lint.sh` itself: collapse the script's own multi-line `#` header to one line. The enforcer now follows its own rule.
2. **`feat(rules,hook): extend policy to cover Terraform description attrs`** — tracker references inside `description = "..."` attributes are surfaced in `terraform-docs`-generated READMEs, `terraform plan` output, and module-consumer documentation, where they are MORE visible than buried in code comments. Three changes:
   - `rules/comments.md` gains a sub-section under the Terraform exception with examples.
   - `hooks/post-edit-lint.sh` gets check 7: `description = "..."` lines in `.tf` / `.tfvars` files matching tracker patterns trigger exit 2.
   - The existing comment-ref check (check 2) is broadened to also catch space-separated ADR refs like `ADR 0030` (the prior regex only matched `ADR-NNN`).

## Why now

While sweeping pentla-infra PR #229 for the new comment policy, the agent left 8 `ADR` references inside Terraform `description` attributes intact, because the rule said "tracker refs in comments" and those are config attributes. That reading is defensible but wrong in spirit - those refs land in module READMEs and plan output where they are MORE visible than buried in code. Closing the loop.

## Verification

- check 7 fires on a fixture: `description = "Per ADR 0015: a thing. See issue #103."` → exit 2 with the offending line surfaced.
- check 2 (broadened) fires on `# Per ADR 0015 - this is forbidden` → exit 2.
- Clean descriptions don't match: `description = "Email for the platform admin..."` → exit 0.

## Test plan

- [ ] Edit a `.tf` file to add a tracker ref in a `description` attribute and confirm the hook fires exit 2
- [ ] Confirm pentla-infra PR #229 follow-up sweep (already pushed: commit `1631d38`) aligns with the rule this PR establishes