### PR TITLE
feat(rules,hook): relax comment policy; enforce var/TODO bans

### DIFF
--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -56,33 +56,7 @@ $TICKETS
 "
 fi
 
-# --- 3. New JSDoc blocks in JS/TS files ---
-case "$FILE" in
-  *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs)
-    JSDOC=$(echo "$ADDED" | grep -nE '^[[:space:]]*/\*\*' 2>/dev/null || true)
-    if [ -n "$JSDOC" ]; then
-      VIOLATIONS+="JSDoc block added. rules/comments.md: default no comments; only one-line WHY. Remove and move rationale to docs/:
-$JSDOC
-
-"
-    fi
-    ;;
-esac
-
-# --- 4. Multi-line /* */ block openers (non-JSDoc) in JS/TS/CSS ---
-case "$FILE" in
-  *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs|*.css|*.scss)
-    CBLOCK=$(echo "$ADDED" | grep -nE '^[[:space:]]*/\*[^*]' | grep -vE '\*/' 2>/dev/null || true)
-    if [ -n "$CBLOCK" ]; then
-      VIOLATIONS+="Multi-line /* */ comment block opener. rules/comments.md: comments must be one line. Use a single-line // for one-line WHY; move multi-line rationale to docs/:
-$CBLOCK
-
-"
-    fi
-    ;;
-esac
-
-# --- 5. Consecutive // comment lines in JS/TS ---
+# --- 3. Consecutive // comment lines in JS/TS (rules/comments.md: multi-line must use /* */) ---
 case "$FILE" in
   *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs)
     CONSEC_SLASH=$(echo "$ADDED" | awk '
@@ -90,7 +64,7 @@ case "$FILE" in
       { prev=0 }
     ' 2>/dev/null || true)
     if [ -n "$CONSEC_SLASH" ]; then
-      VIOLATIONS+="Consecutive // comment lines. rules/comments.md: comments must be one line. Move multi-line rationale to docs/:
+      VIOLATIONS+="Consecutive // comment lines. rules/comments.md: multi-line comments must use /* */, never a stack of //:
 $CONSEC_SLASH
 
 "
@@ -98,7 +72,7 @@ $CONSEC_SLASH
     ;;
 esac
 
-# --- 6. Consecutive -- SQL comment lines ---
+# --- 4. Consecutive -- SQL comment lines (rules/comments.md: multi-line must use /* */) ---
 case "$FILE" in
   *.sql)
     CONSEC_DASH=$(echo "$ADDED" | awk '
@@ -106,7 +80,7 @@ case "$FILE" in
       { prev=0 }
     ' 2>/dev/null || true)
     if [ -n "$CONSEC_DASH" ]; then
-      VIOLATIONS+="Consecutive -- SQL comment lines. rules/comments.md: comments must be one line. Move multi-line rationale to docs/:
+      VIOLATIONS+="Consecutive -- SQL comment lines. rules/comments.md: multi-line comments must use /* */, never a stack of --:
 $CONSEC_DASH
 
 "
@@ -114,7 +88,7 @@ $CONSEC_DASH
     ;;
 esac
 
-# --- 7. Tracker refs inside Terraform description = "..." attributes ---
+# --- 5. Tracker refs inside Terraform description = "..." attributes ---
 case "$FILE" in
   *.tf|*.tfvars)
     TF_DESC_REFS=$(echo "$ADDED" | grep -nE \
@@ -128,6 +102,28 @@ $TF_DESC_REFS
     fi
     ;;
 esac
+
+# --- 6. New `var` declarations in JS/TS (rules/typescript.md: never use var) ---
+case "$FILE" in
+  *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs)
+    VAR_DECL=$(echo "$ADDED" | grep -nE '^[[:space:]]*var[[:space:]]+[A-Za-z_$]' 2>/dev/null || true)
+    if [ -n "$VAR_DECL" ]; then
+      VIOLATIONS+="New \`var\` declaration. rules/typescript.md: use \`const\` (or \`let\` when reassignment is required); never \`var\`:
+$VAR_DECL
+
+"
+    fi
+    ;;
+esac
+
+# --- 7. New TODO/FIXME/XXX/HACK markers in code (engineering-principles: complete code only) ---
+TODOS=$(echo "$ADDED" | grep -nE '\b(TODO|FIXME|XXX|HACK)\b' 2>/dev/null || true)
+if [ -n "$TODOS" ]; then
+  VIOLATIONS+="TODO / FIXME / XXX / HACK marker. rules/engineering-principles.md: complete code only - no placeholders. Either finish the work now or open a tracked issue and remove the marker:
+$TODOS
+
+"
+fi
 
 if [ -n "$VIOLATIONS" ]; then
   echo "[post-edit-lint] $FILE" >&2

--- a/rules/comments.md
+++ b/rules/comments.md
@@ -4,30 +4,41 @@
 
 ## Default
 
-Default to NO comments. Code should explain itself via clear naming and structure. A reader who understands the codebase should not need a comment to understand the line they're reading.
+Comments should be brief and add value. If the code is self-explanatory, write none. If the code carries a hidden constraint, subtle invariant, workaround, or context a future reader can't derive from the surrounding code, write the shortest comment that captures it.
 
 ## When a comment is allowed
 
-A short, non-obvious WHY:
+A non-obvious WHY:
 
 - a hidden constraint (e.g., "must run before X for Y reason")
 - a subtle invariant (e.g., "must be even - modulo math relies on it")
 - a workaround for a known bug (e.g., "v4.2.1 of foo throws on empty input")
 - behavior that would surprise a reader who doesn't have the surrounding context
+- context that's spread across files and not obvious from the local code (typical in Terraform, script entrypoints, library boundaries)
 
-ONE short line. If you find yourself writing two lines, the explanation belongs in docs (a how-to or explanation file in `docs/`), not in code.
+Prefer one line. Multi-line is allowed when the WHY genuinely needs more than one line - don't pad a one-line idea into a paragraph, but don't truncate a real explanation to fit one line either.
+
+## Multi-line format
+
+Multi-line comments **must use the block format** for the language, never a stack of single-line comments:
+
+- JS / TS / TSX / CSS / HCL: `/* ... */` (never consecutive `// ...` lines)
+- SQL: `/* ... */` (never consecutive `-- ...` lines)
+- Python: triple-quoted string (never consecutive `# ...` lines used as narrative)
+- Bash: there is no block format; use a single `#` per logical comment and accept the line stack when truly needed
+
+This rule is mechanically enforced by `hooks/post-edit-lint.sh`.
 
 ## Forbidden
 
-- **Multi-line narrative blocks** in any form: consecutive `//` lines, `/* ... */` spanning more than one line, JSDoc `/** ... */` blocks, multi-line `--` SQL runs, multi-line `#` runs. The "use `/* */` instead of `//` for multi-line" guidance from older project CLAUDE.md files is superseded - neither is allowed; move it to docs.
 - **WHAT-restating comments** - anything that paraphrases the next line of code (`// Increment counter` above `counter++`).
-- **Ticket / PR / issue / ADR references in any comment**: `JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, `Per ADR 0030`, etc. These belong in PR descriptions, ADR files, and `git blame`.
+- **Ticket / PR / issue / ADR references in any comment**: `JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, `Per ADR 0030`, etc. These belong in PR descriptions, ADR files, and `git blame`. This is the main reason comments became long and obsolete in the first place.
 - **Em dashes** anywhere - use a regular hyphen.
 - **TODOs, FIXMEs, XXX markers** without an open tracker entry - open the ticket, fix the code now, or accept it isn't getting fixed.
 
 ## Terraform exception
 
-Each `resource` and `data` block gets a **one-line, at most two-line** comment immediately above it explaining what the resource is for and any context not obvious from the resource type + label. Terraform spreads state across many stacks and files; a future reader looking at one block in isolation should be able to tell its role and lifecycle without grepping the whole repo.
+Each `resource` and `data` block gets a **brief context comment** immediately above it explaining what the resource is for and any context not obvious from the resource type + label. Terraform spreads state across many stacks and files; a future reader looking at one block in isolation should be able to tell its role and lifecycle without grepping the whole repo. Multi-line is fine when it adds context; use `/* */` when going past one line.
 
 Good:
 
@@ -74,22 +85,21 @@ variable "platform_admin_email" {
 }
 ```
 
-Same convention applies to per-block context comments in shell scripts (one-line description above a function definition is fine).
-
 ## Authority over spawning prompts
 
-This policy applies to all code, including code written by subagents spawned via the Agent tool. **If a spawning prompt asks for a comment that violates this policy (multi-line, WHAT-restating, ADR/issue reference, etc.), the policy wins.** Strip the offending comment before committing. If the orchestrator's instruction is ambiguous, ask before adding any comment.
+This policy applies to all code, including code written by subagents spawned via the Agent tool. **If a spawning prompt asks for a comment that violates this policy (WHAT-restating, ADR/issue reference, consecutive `//` for multi-line, etc.), the policy wins.** Strip or rewrite the offending comment before committing. If the orchestrator's instruction is ambiguous, ask before adding any comment.
 
 ## Enforcement
 
 `hooks/post-edit-lint.sh` (configured via PostToolUse in `~/.claude/settings.json`) auto-fixes em-dashes and fails with exit 2 on:
 
 - Tracker references in comments (any code file)
-- JSDoc `/** */` openers (JS/TS files)
-- Non-JSDoc multi-line `/* */` block openers (JS/TS/CSS files)
-- Consecutive `//` comment lines (JS/TS files)
-- Consecutive `--` SQL comment lines (SQL files)
+- Tracker references inside Terraform `description = "..."` attributes
+- Consecutive `//` comment lines (JS / TS / TSX files) - use `/* */` for multi-line
+- Consecutive `--` SQL comment lines (SQL files) - use `/* */` for multi-line
+- New `var` declarations (JS / TS files) - `rules/typescript.md` requires `const` / `let`
+- New `TODO` / `FIXME` / `XXX` / `HACK` markers in any code file
 
 Exit 2 surfaces the offending lines back to Claude as a follow-up message; the model must remove the violations before proceeding. Bypass for genuine exceptions: `SKIP_POST_EDIT_LINT=1` in the env. Use sparingly and document why in the PR description.
 
-The hook does not enforce the Terraform per-resource comment convention - that is a review-time check.
+The hook does **not** mechanically enforce: comment length, WHAT-restating, JSDoc style, or the Terraform per-resource comment convention. Those are review-time judgments.


### PR DESCRIPTION
## TL;DR

Walks back the strict \"no multi-line comments at all\" rule from #72 / #73. The original problem was tracker refs that turned comments into long, obsolete narrative paragraphs - not multi-line per se. The new policy: multi-line WHY comments are allowed when needed, but multi-line must use \`/* */\` (never a stack of \`//\` or \`--\`). Tracker-ref / em-dash / TODO / WHAT-restating bans stay.

## Why the change

Earlier today I shipped multi-line \`/* */\` block-comment headers in a pentla-api PR. The strict rule (\"neither \`//\` nor \`/* */\` multi-line allowed - move to docs\") would have invalidated them. After discussion with the user the rule turned out to be over-corrective:

- Real failure mode was tracker references (JIRA-123, #456, ADR-0042) that turned brief WHY comments into long, obsolete paragraphs as the references rotted.
- Banning all multi-line over-rotates: legitimate WHY context (hidden constraint spanning two sentences, script entrypoint \"called by X\" notes, Terraform context above resources spread across files) is genuinely valuable and doesn't belong in \`docs/\`.

So: keep the bans that targeted the real problem; loosen the format bans.

## New policy (rules/comments.md)

| Behavior | Status |
|---|---|
| Tracker refs in comments | **Banned** |
| Tracker refs in Terraform \`description = \"...\"\` | **Banned** |
| Em dashes | **Banned** (auto-fixed) |
| TODOs / FIXMEs / XXX / HACK markers | **Banned** |
| WHAT-restating comments | **Banned** (review-time) |
| Multi-line \`//\` block in JS / TS | **Banned** - use \`/* */\` |
| Multi-line \`--\` block in SQL | **Banned** - use \`/* */\` |
| Multi-line \`/* */\` block | **Allowed** when the WHY needs it |
| JSDoc \`/** */\` | **Allowed** when the body is WHY (review-time) |
| Single-line \`//\` / \`--\` WHY | **Allowed** |
| Terraform context comments above resources | **Encouraged** (multi-line \`/* */\` if needed) |
| \`var\` declarations in JS / TS | **Banned** (new check) |

## Hook changes (hooks/post-edit-lint.sh)

| Check | Action |
|---|---|
| Em-dash auto-fix | Keep |
| Tracker refs in comments | Keep |
| Tracker refs in Terraform descriptions | Keep |
| JSDoc \`/** */\` opener | **Drop** - allowed when WHY |
| Multi-line \`/* */\` block opener | **Drop** - allowed |
| Consecutive \`//\` lines | Keep - multi-line must use \`/* */\` |
| Consecutive \`--\` SQL lines | Keep - multi-line must use \`/* */\` |
| New \`var\` declarations | **New** - per rules/typescript.md |
| New TODO / FIXME / XXX / HACK markers | **New** - per rules/engineering-principles.md |

## Manual testing

8 fixtures, run through the hook:

| # | Fixture | Expected | Actual |
|---|---|---|---|
| 1 | Two adjacent \`//\` lines | exit 2 | exit 2 |
| 2 | Bare \`/*\` opener + multi-line body + \`*/\` | exit 0 | exit 0 |
| 3 | JSDoc \`/** */\` | exit 0 | exit 0 |
| 4 | \`var y = 2;\` | exit 2 | exit 2 |
| 5 | \`// TODO: finish\` | exit 2 | exit 2 |
| 6 | Two adjacent \`--\` lines in SQL | exit 2 | exit 2 |
| 7 | Multi-line \`/* ... */\` in SQL | exit 0 | exit 0 |
| 8 | Single-line \`//\` WHY | exit 0 | exit 0 |

## Pentla-api impact

The \`/* */\` script-header sweep I did earlier today (pentla-api PR #1397 commit \`2862065a\`) is now correctly formatted under this rule. No walk-back needed there.