### PR TITLE
feat(rules): rule-enforcement architecture - meta-policy + marker pass (alpha1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ The files below are loaded into every session via these `@`-imports. Edit the in
 @rules/agent-routing.md
 @rules/comments.md
 @rules/communication.md
+@rules/comments.md
 @rules/context7.md
+@rules/rule-authoring.md
 @rules/database.md
 @rules/diagrams.md
 @rules/engineering-principles.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,61 +21,61 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 
 ## Security
 
-- NEVER read or process files containing secrets, credentials, API keys, or private keys
-- Sensitive file patterns: `.env*`, `*.pem`, `*.key`, `credentials.json`, `service-account*.json`
-- Home directory secrets (`~/.aws`, `~/.ssh`, `~/.config/gcloud`, `~/.kube`) are off-limits
-- If you need config values for debugging, ask the user to provide only the non-sensitive parts
+- NEVER read or process files containing secrets, credentials, API keys, or private keys `(review-time: backed by permissions.deny in settings.json which blocks the path patterns below)`
+- Sensitive file patterns: `.env*`, `*.pem`, `*.key`, `credentials.json`, `service-account*.json` `(review-time: descriptive list, blocked by permissions.deny)`
+- Home directory secrets (`~/.aws`, `~/.ssh`, `~/.config/gcloud`, `~/.kube`) are off-limits `(review-time: blocked by permissions.deny)`
+- If you need config values for debugging, ask the user to provide only the non-sensitive parts `(review-time: conversational pattern)`
 
 ## Formatting
 
-- Never use em dashes (-) anywhere - in code, text, translations, or documentation. Use a regular hyphen/dash (-) instead.
+- Never use em dashes (-) anywhere - in code, text, translations, or documentation. Use a regular hyphen/dash (-) instead. `(hook)`
 
 ## Code Standards
 
-- Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured)
-- Complete code only - no TODOs, no placeholders, no incomplete implementations
-- **Comments**: see [`rules/comments.md`](rules/comments.md). Default NONE; one-line non-obvious WHY only; hook-enforced.
-- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security, jira, comments)
+- Use the project's formatter/linter (Biome, ESLint, Prettier - whatever is configured) `(review-time: per-repo configuration choice)`
+- Complete code only - no TODOs, no placeholders, no incomplete implementations `(hook)`
+- **Comments**: see [`rules/comments.md`](rules/comments.md). `(review-time: pointer, the substance is enforced in the linked file)`
+- Detailed standards are in rules/ (typescript, tests, database, infrastructure, security, jira, comments) `(review-time: pointer to detailed rule files)`
 
 ## Docs Sync
 
-- Engineering docs live in each repo's `/docs/` tree, organized by [Diataxis](https://diataxis.fr/) (explanation, reference, how-to, tutorials) plus an `adr/` folder for Architecture Decision Records
-- When code changes affect behavior documented in `docs/`, update the relevant docs in the same PR
-- Use the `/document` slash command to create or refresh docs - it embeds the quality rules and Diataxis routing
-- Never let docs drift from implementation - if you change it, document it
-- Only update docs that describe behavior actually changed in this session - no forward-looking references, planned features, or speculative content
-- Diagrams default to Mermaid (text-based, GitHub-rendered, AI-readable). Use drawio when the diagram needs custom shapes, multi-layer architecture, >2 swimlanes, or precise layout - see `rules/diagrams.md` for the policy and `/diagram` skill for the workflow
-- ADRs are immutable once Accepted - a reversed decision creates a new ADR that supersedes the old one
+- Engineering docs live in each repo's `/docs/` tree, organized by [Diataxis](https://diataxis.fr/) (explanation, reference, how-to, tutorials) plus an `adr/` folder for Architecture Decision Records `(review-time: directory-layout convention)`
+- When code changes affect behavior documented in `docs/`, update the relevant docs in the same PR `(review-time: requires recognizing behavior-doc impact)`
+- Use the `/document` slash command to create or refresh docs - it embeds the quality rules and Diataxis routing `(review-time: workflow guidance)`
+- Never let docs drift from implementation - if you change it, document it `(review-time: drift recognition)`
+- Only update docs that describe behavior actually changed in this session - no forward-looking references, planned features, or speculative content `(review-time: session-scope discipline)`
+- Diagrams default to Mermaid (text-based, GitHub-rendered, AI-readable). Use drawio when the diagram needs custom shapes, multi-layer architecture, >2 swimlanes, or precise layout - see `rules/diagrams.md` for the policy and `/diagram` skill for the workflow `(review-time: diagram-tool selection)`
+- ADRs are immutable once Accepted - a reversed decision creates a new ADR that supersedes the old one `(review-time: ADR lifecycle convention, overridden per-repo)`
 
 ## Behavioral Rules
 
-- **Scope**: only implement what was asked - no drive-by refactors, extra features, or unsolicited improvements
-- **Minimal fix**: for bug fixes, identify the root cause and state the smallest possible change first (ideally 1-5 lines). Only expand the scope if the minimal fix is provably insufficient. Never introduce new abstractions, files, or patterns as part of a bug fix unless the user explicitly asks
-- **Decisions**: ask before making architectural choices - never silently pick a pattern, library, or approach
-- **Cost**: warn before any change that increases costs (new cloud resources, paid services, upgraded tiers)
-- **Testing**: always write tests when implementing a new feature or fixing a bug - no exceptions
-- **Conciseness**: be direct and terse during implementation - save explanations for when asked
-- **Existing patterns**: follow the conventions already in the codebase - consistency over personal preference
-- **Context first**: before choosing an approach, check how similar problems are already solved in the codebase - grep for existing patterns, read neighboring files, and follow established conventions rather than guessing
-- **Verification**: always run `/verify-done` before pushing - never push without all checks passing
-- **Atomic feature unit**: "implement" means implement + commit on a feature branch + push + open PR. Never stop after the code change. Never commit to `main`/`master` directly. If on a protected branch, create a feature branch first.
-- **Parallelization**: when a task has 2+ independent sub-tasks touching different files, split across multiple agents using git worktrees - see `rules/parallel-agents.md`
-- **One question at a time**: when asking the user a clarifying question, ask only one per turn and wait for the answer before asking the next - no stacked or bundled questions, even closely related ones. See `rules/communication.md`
+- **Scope**: only implement what was asked - no drive-by refactors, extra features, or unsolicited improvements `(review-time: scope judgment)`
+- **Minimal fix**: for bug fixes, identify the root cause and state the smallest possible change first (ideally 1-5 lines). Only expand the scope if the minimal fix is provably insufficient. Never introduce new abstractions, files, or patterns as part of a bug fix unless the user explicitly asks `(review-time: minimal-fix judgment)`
+- **Decisions**: ask before making architectural choices - never silently pick a pattern, library, or approach `(review-time: requires recognizing an architectural choice point)`
+- **Cost**: warn before any change that increases costs (new cloud resources, paid services, upgraded tiers) `(review-time: cost-impact recognition)`
+- **Testing**: always write tests when implementing a new feature or fixing a bug - no exceptions `(review-time: per-PR judgment about test coverage of the change)`
+- **Conciseness**: be direct and terse during implementation - save explanations for when asked `(review-time: phrasing-length judgment)`
+- **Existing patterns**: follow the conventions already in the codebase - consistency over personal preference `(review-time: pattern-recognition in surrounding code)`
+- **Context first**: before choosing an approach, check how similar problems are already solved in the codebase - grep for existing patterns, read neighboring files, and follow established conventions rather than guessing `(review-time: workflow discipline)`
+- **Verification**: always run `/verify-done` before pushing - never push without all checks passing `(hook)`
+- **Atomic feature unit**: "implement" means implement + commit on a feature branch + push + open PR. Never stop after the code change. Never commit to `main`/`master` directly. If on a protected branch, create a feature branch first. `(hook)`
+- **Parallelization**: when a task has 2+ independent sub-tasks touching different files, split across multiple agents using git worktrees - see `rules/parallel-agents.md` `(review-time: parallelization judgment, see rules/parallel-agents.md)`
+- **One question at a time**: when asking the user a clarifying question, ask only one per turn and wait for the answer before asking the next - no stacked or bundled questions, even closely related ones. See `rules/communication.md` `(review-time: conversational cadence)`
 
 Detailed git, testing, and exploration rules are in `rules/` (git-conventions, engineering-principles).
 
 ## Learning from Mistakes
 
-- When corrected, update the relevant CLAUDE.md or rule file so the mistake is not repeated
-- Check if an existing rule already covers the correction - update it rather than adding a duplicate
+- When corrected, update the relevant CLAUDE.md or rule file so the mistake is not repeated `(review-time: meta-process for rule maintenance)`
+- Check if an existing rule already covers the correction - update it rather than adding a duplicate `(review-time: dedup discipline)`
 
 ## Environment
 
-- macOS, zsh, Node.js (check `.nvmrc`), npm
-- Docker for local services
-- Cloud: GCP primary, AWS secondary
-- Current year: 2026 - verify when generating dates, timestamps, or date-dependent logic
-- Access boundaries: .env files, credentials, and secrets are blocked by deny rules - do not attempt workarounds. For Sentry, staging databases, and external services requiring auth, ask the user for credentials or URLs rather than trying to authenticate
+- macOS, zsh, Node.js (check `.nvmrc`), npm `(review-time: environment description, not a rule per se)`
+- Docker for local services `(review-time: environment description)`
+- Cloud: GCP primary, AWS secondary `(review-time: provider preference)`
+- Current year: 2026 - verify when generating dates, timestamps, or date-dependent logic `(review-time: requires knowing whether a date is involved)`
+- Access boundaries: .env files, credentials, and secrets are blocked by deny rules - do not attempt workarounds. For Sentry, staging databases, and external services requiring auth, ask the user for credentials or URLs rather than trying to authenticate `(review-time: backed by permissions.deny; "do not attempt workarounds" is behavioral)`
 
 @RTK.md
 
@@ -86,7 +86,6 @@ The files below are loaded into every session via these `@`-imports. Edit the in
 @rules/agent-routing.md
 @rules/comments.md
 @rules/communication.md
-@rules/comments.md
 @rules/context7.md
 @rules/rule-authoring.md
 @rules/database.md

--- a/RTK.md
+++ b/RTK.md
@@ -47,10 +47,10 @@ operators it cannot parse cleanly. To keep adoption high:
 
 - **Do not append `2>&1`** - RTK filters already surface stderr usefully; the
   redirect suppresses the rewrite and loses the savings. Let failure output
-  flow through naturally.
+  flow through naturally. `(review-time: requires recognizing the redirect in the command being composed)`
 - Avoid command substitution (`$(...)`), pipes into interpreters
   (`| python -c`, `| node -e`), and compound commands (`&&`, `;`) when a
-  simpler single-command form exists.
+  simpler single-command form exists. `(review-time: command-shape choice)`
 
 **Exception: `glab`** - RTK has no `glab` filter yet (tracked upstream at
 rtk-ai/rtk#1085). Until that ships, `glab` commands bypass RTK regardless of
@@ -64,17 +64,17 @@ makes it a scalpel, not a session-wide shield. Reach for it only when an
 rtk adapter is provably broken for one specific command.
 
 - **Default**: bare `npm` / bare tool invocation. Trust RTK filters to
-  surface failures. Do not prefix `rtk proxy` out of habit.
+  surface failures. Do not prefix `rtk proxy` out of habit. `(review-time: command-composition discipline)`
 - **When one adapter misbehaves** (e.g. the lint adapter on a Biome
   project emitting `ESLint output (JSON parse failed: EOF ...)`), scope
   `rtk proxy` to just that one command (`rtk proxy npm run lint`). Leave
-  every other command on bare invocation so their adapters keep working.
+  every other command on bare invocation so their adapters keep working. `(review-time: requires recognising adapter failure)`
 - **A quiet proxied run is not a validated run**. `rtk proxy` shows raw
   end-of-stream output, which can look like success even when a coverage
   gate, typecheck, or integration assertion failed mid-stream. If you
   used `rtk proxy`, re-read the raw output yourself; do not trust the
-  tail.
+  tail. `(review-time: output-reading discipline)`
 - **Before reaching for proxy, dry-run the rewrite**: `rtk hook check
   "<cmd>"` prints what rtk will rewrite the command to. If it routes to
   an adapter that does not match the actual tool (`biome check` ->
-  `rtk lint check`), that is the collision to scope a proxy around.
+  `rtk lint check`), that is the collision to scope a proxy around. `(review-time: workflow step)`

--- a/rules/agent-routing.md
+++ b/rules/agent-routing.md
@@ -6,11 +6,11 @@ Specialized agent personas live in `~/.claude/agents/`. Each captures domain exp
 
 ## Loading model
 
-When a task touches a specialized domain, **spawn a subagent** via the Agent tool with the matching `subagent_type`. The subagent loads the agent file in its own context, runs the work, and returns a summary to the parent.
+When a task touches a specialized domain, **spawn a subagent** via the Agent tool with the matching `subagent_type`. The subagent loads the agent file in its own context, runs the work, and returns a summary to the parent. `(review-time: domain-classification of the task)`
 
-Do NOT read agent files into the main conversation. That pollutes context and bleeds biases across unrelated work later in the session. The agent file is for the subagent; you act on the subagent's summary.
+Do NOT read agent files into the main conversation. That pollutes context and bleeds biases across unrelated work later in the session. The agent file is for the subagent; you act on the subagent's summary. `(review-time: file-access decision, not a code pattern)`
 
-Skip subagent spawning for trivial changes (typos, one-liner fixes, config tweaks).
+Skip subagent spawning for trivial changes (typos, one-liner fixes, config tweaks). `(review-time: judging triviality)`
 
 ## Agents
 
@@ -35,17 +35,17 @@ Skip subagent spawning for trivial changes (typos, one-liner fixes, config tweak
 
 ## Cross-domain combinations
 
-- **UI work** -> `Frontend Staff Engineer` + `UX Expert` + `QA Expert` (accessibility)
-- **Feature planning** -> `Product Manager` + the relevant technical agents
-- **Performance work** -> `Backend Staff Engineer` + `Frontend Staff Engineer`
-- **Rate limiting / throttling / DDoS** -> `Backend Staff Engineer` + `Networking Expert`
-- **Data handling for EU subjects** -> include `GDPR Expert`
-- **PR with security implications** -> `PR Reviewer` + `Cybersecurity Expert`
+- **UI work** -> `Frontend Staff Engineer` + `UX Expert` + `QA Expert` (accessibility) `(review-time: cross-domain routing decision)`
+- **Feature planning** -> `Product Manager` + the relevant technical agents `(review-time: cross-domain routing decision)`
+- **Performance work** -> `Backend Staff Engineer` + `Frontend Staff Engineer` `(review-time: cross-domain routing decision)`
+- **Rate limiting / throttling / DDoS** -> `Backend Staff Engineer` + `Networking Expert` `(review-time: cross-domain routing decision)`
+- **Data handling for EU subjects** -> include `GDPR Expert` `(review-time: cross-domain routing decision)`
+- **PR with security implications** -> `PR Reviewer` + `Cybersecurity Expert` `(review-time: cross-domain routing decision)`
 
-When a task crosses domains, spawn multiple subagents in **parallel** - send a single message with multiple Agent tool calls so they run concurrently.
+When a task crosses domains, spawn multiple subagents in **parallel** - send a single message with multiple Agent tool calls so they run concurrently. `(review-time: requires recognizing cross-domain shape)`
 
 ## Rules
 
-- Subagent guardrails apply within their context. Act on the subagent's summary, not the agent file
-- Multiple subagents may produce conflicting recommendations - surface conflicts to the user, do not silently pick a side
-- Subagents see none of the parent conversation - brief them with self-contained prompts (goal, file paths, constraints, verification command)
+- Subagent guardrails apply within their context. Act on the subagent's summary, not the agent file `(review-time: about Claude's use of the agent's reply)`
+- Multiple subagents may produce conflicting recommendations - surface conflicts to the user, do not silently pick a side `(review-time: requires reading multiple subagent outputs)`
+- Subagents see none of the parent conversation - brief them with self-contained prompts (goal, file paths, constraints, verification command) `(review-time: prompt-quality judgment)`

--- a/rules/comments.md
+++ b/rules/comments.md
@@ -10,11 +10,11 @@ Comments should be brief and add value. If the code is self-explanatory, write n
 
 A non-obvious WHY:
 
-- a hidden constraint (e.g., "must run before X for Y reason")
-- a subtle invariant (e.g., "must be even - modulo math relies on it")
-- a workaround for a known bug (e.g., "v4.2.1 of foo throws on empty input")
-- behavior that would surprise a reader who doesn't have the surrounding context
-- context that's spread across files and not obvious from the local code (typical in Terraform, script entrypoints, library boundaries)
+- a hidden constraint (e.g., "must run before X for Y reason") `(review-time: classification of comment intent)`
+- a subtle invariant (e.g., "must be even - modulo math relies on it") `(review-time: classification of comment intent)`
+- a workaround for a known bug (e.g., "v4.2.1 of foo throws on empty input") `(review-time: classification of comment intent)`
+- behavior that would surprise a reader who doesn't have the surrounding context `(review-time: classification of comment intent)`
+- context that's spread across files and not obvious from the local code (typical in Terraform, script entrypoints, library boundaries) `(review-time: classification of comment intent)`
 
 Prefer one line. Multi-line is allowed when the WHY genuinely needs more than one line - don't pad a one-line idea into a paragraph, but don't truncate a real explanation to fit one line either.
 
@@ -22,19 +22,19 @@ Prefer one line. Multi-line is allowed when the WHY genuinely needs more than on
 
 Multi-line comments **must use the block format** for the language, never a stack of single-line comments:
 
-- JS / TS / TSX / CSS / HCL: `/* ... */` (never consecutive `// ...` lines)
-- SQL: `/* ... */` (never consecutive `-- ...` lines)
-- Python: triple-quoted string (never consecutive `# ...` lines used as narrative)
-- Bash: there is no block format; use a single `#` per logical comment and accept the line stack when truly needed
+- JS / TS / TSX / CSS / HCL: `/* ... */` (never consecutive `// ...` lines) `(hook)`
+- SQL: `/* ... */` (never consecutive `-- ...` lines) `(hook)`
+- Python: triple-quoted string (never consecutive `# ...` lines used as narrative) `(review-time: no hook for Python yet)`
+- Bash: there is no block format; use a single `#` per logical comment and accept the line stack when truly needed `(review-time: language limitation, not enforceable)`
 
 This rule is mechanically enforced by `hooks/post-edit-lint.sh`.
 
 ## Forbidden
 
-- **WHAT-restating comments** - anything that paraphrases the next line of code (`// Increment counter` above `counter++`).
-- **Ticket / PR / issue / ADR references in any comment**: `JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, `Per ADR 0030`, etc. These belong in PR descriptions, ADR files, and `git blame`. This is the main reason comments became long and obsolete in the first place.
-- **Em dashes** anywhere - use a regular hyphen.
-- **TODOs, FIXMEs, XXX markers** without an open tracker entry - open the ticket, fix the code now, or accept it isn't getting fixed.
+- **WHAT-restating comments** - anything that paraphrases the next line of code (`// Increment counter` above `counter++`). `(review-time: requires semantic comparison of comment text and the next statement)`
+- **Ticket / PR / issue / ADR references in any comment**: `JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, `Per ADR 0030`, etc. These belong in PR descriptions, ADR files, and `git blame`. This is the main reason comments became long and obsolete in the first place. `(hook)`
+- **Em dashes** anywhere - use a regular hyphen. `(hook)`
+- **TODOs, FIXMEs, XXX markers** without an open tracker entry - open the ticket, fix the code now, or accept it isn't getting fixed. `(hook)`
 
 ## Terraform exception
 

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -6,17 +6,19 @@
 
 Ask **one** question at a time. Wait for the answer before asking the next.
 
-- Do not stack multiple questions in a single turn, even closely related ones.
-- Do not bundle a question with "and also confirm X, Y, Z" tacked onto the end - those are separate questions, ask them on later turns.
-- If you have many things to clarify, pick the single most blocking one and ask only that. The rest go in the next turn.
-- Applies to all interaction (grilling, planning, debugging, code review, casual conversation), not just to the `/grill-with-docs` skill.
+**why-not-mechanizable:** every bullet in this file is about phrasing and turn cadence of free-form text Claude produces, not patterns in tool input. Hooks operate on tool calls, not on conversational output.
+
+- Do not stack multiple questions in a single turn, even closely related ones. `(review-time: see section note)`
+- Do not bundle a question with "and also confirm X, Y, Z" tacked onto the end - those are separate questions, ask them on later turns. `(review-time: see section note)`
+- If you have many things to clarify, pick the single most blocking one and ask only that. The rest go in the next turn. `(review-time: see section note)`
+- Applies to all interaction (grilling, planning, debugging, code review, casual conversation), not just to the `/grill-with-docs` skill. `(review-time: see section note)`
 
 Long multi-question turns are hard to answer clearly. One question per turn keeps the back-and-forth legible and lets each answer actually shape the next question instead of being lost in a wall of text.
 
 ## Phrasing
 
-- Keep the question itself short. Context above the question is fine; the question line itself should be one sentence.
-- Lead with your recommendation when you have one, then ask for confirmation or pushback. Open-ended "what do you think?" without a recommendation wastes a turn.
+- Keep the question itself short. Context above the question is fine; the question line itself should be one sentence. `(review-time: phrasing length is subjective)`
+- Lead with your recommendation when you have one, then ask for confirmation or pushback. Open-ended "what do you think?" without a recommendation wastes a turn. `(review-time: requires reading what Claude is about to say)`
 
 ## Skill-level overrides
 

--- a/rules/context7.md
+++ b/rules/context7.md
@@ -2,9 +2,9 @@
 
 **When to apply:** whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service. Including well-known ones (React, Next.js, Prisma, Tailwind, Django) since your training data may not reflect recent changes.
 
-Use the `ctx7` CLI to fetch current documentation. This covers API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Prefer it over web search for library docs.
+Use the `ctx7` CLI to fetch current documentation. This covers API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Prefer it over web search for library docs. `(review-time: tool-selection decision per question)`
 
-Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts.
+Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts. `(review-time: classifying the user's question requires reading it)`
 
 ## Steps
 
@@ -13,8 +13,8 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 3. Fetch docs: `npx ctx7@latest docs <libraryId> "<user's question>"`
 4. Answer using the fetched documentation
 
-You MUST call `library` first to get a valid ID unless the user provides one directly in `/org/project` format. Use the user's full question as the query -- specific and detailed queries return better results than vague single words. Do not run more than 3 commands per question. Do not include sensitive information (API keys, passwords, credentials) in queries.
+You MUST call `library` first to get a valid ID unless the user provides one directly in `/org/project` format. Use the user's full question as the query -- specific and detailed queries return better results than vague single words. Do not run more than 3 commands per question. Do not include sensitive information (API keys, passwords, credentials) in queries. `(review-time: ordering and query-quality enforcement requires reading the in-progress command)`
 
-For version-specific docs, use `/org/project/version` from the `library` output (e.g., `/vercel/next.js/v14.3.0`).
+For version-specific docs, use `/org/project/version` from the `library` output (e.g., `/vercel/next.js/v14.3.0`). `(review-time: requires knowing when version-specific docs are needed)`
 
-If a command fails with a quota error, inform the user and suggest `npx ctx7@latest login` or setting `CONTEXT7_API_KEY` env var for higher limits. Do not silently fall back to training data.
+If a command fails with a quota error, inform the user and suggest `npx ctx7@latest login` or setting `CONTEXT7_API_KEY` env var for higher limits. Do not silently fall back to training data. `(review-time: error-handling pattern in conversation)`

--- a/rules/database.md
+++ b/rules/database.md
@@ -2,12 +2,12 @@
 
 **When to apply:** editing migrations, SQL files, or any database schema / query code (Prisma, Drizzle, Knex, raw SQL).
 
-- Soft delete only - never hard delete records (use `deleted_at` timestamp)
-- Explicit migrations only - never auto-sync schemas in production
-- Migrations must be backward-compatible (no dropping columns that are still read)
-- Always add indexes for foreign keys and frequently queried columns
-- No `SELECT *` - explicitly list columns
-- No N+1 queries - use joins or batch loading
-- No unbounded queries - always include `LIMIT` or pagination
-- Include both `up` and `down` migration scripts
-- Test migrations against a copy of production-like data before deploying
+- Soft delete only - never hard delete records (use `deleted_at` timestamp) `(review-time: hard-delete detection has too many false positives on dev / test code)`
+- Explicit migrations only - never auto-sync schemas in production `(review-time: enforcement is repo-level config, varies per ORM)`
+- Migrations must be backward-compatible (no dropping columns that are still read) `(review-time: semantic check requires reading app code)`
+- Always add indexes for foreign keys and frequently queried columns `(review-time: requires query-pattern analysis)`
+- No `SELECT *` - explicitly list columns `(hook)`
+- No N+1 queries - use joins or batch loading `(review-time: pattern requires runtime / query-plan analysis)`
+- No unbounded queries - always include `LIMIT` or pagination `(review-time: semantic - knowing when a result set is bounded by query shape)`
+- Include both `up` and `down` migration scripts `(review-time: file-presence check is per-repo)`
+- Test migrations against a copy of production-like data before deploying `(review-time: process, not code pattern)`

--- a/rules/diagrams.md
+++ b/rules/diagrams.md
@@ -10,30 +10,30 @@ Use mermaid for diagrams whose value is the **logical structure**, where a clean
 
 Mermaid is correct when:
 
-- Sequence flows (request lifecycle, auth, async messaging)
-- State machines (order status, sync status)
-- ER diagrams (data models)
-- Class diagrams
-- Simple flowcharts and decision trees
-- Graph/topology with <15 nodes and standard shapes
-- gitGraph, journey, gantt, pie
+- Sequence flows (request lifecycle, auth, async messaging) `(review-time: diagram-type classification)`
+- State machines (order status, sync status) `(review-time: diagram-type classification)`
+- ER diagrams (data models) `(review-time: diagram-type classification)`
+- Class diagrams `(review-time: diagram-type classification)`
+- Simple flowcharts and decision trees `(review-time: diagram-type classification)`
+- Graph/topology with <15 nodes and standard shapes `(review-time: requires diagram analysis)`
+- gitGraph, journey, gantt, pie `(review-time: diagram-type classification)`
 
 How:
 
-- Write inline in the doc using ```` ```mermaid ```` fenced blocks. GitHub renders natively.
-- One diagram per doc maximum, unless it is an architecture doc.
-- Keep labels short - long descriptions go in adjacent prose.
+- Write inline in the doc using ```` ```mermaid ```` fenced blocks. GitHub renders natively. `(review-time: format guidance for diagram authoring)`
+- One diagram per doc maximum, unless it is an architecture doc. `(review-time: doc-classification "architecture")`
+- Keep labels short - long descriptions go in adjacent prose. `(review-time: subjective "short")`
 
 ## Drawio (for complex)
 
 Use drawio when mermaid genuinely fails the diagram. Reach for drawio when:
 
-- Precise grid / column layout matters (network topology, rack diagrams)
-- Custom shapes / icons / cloud provider symbols are required
-- Swimlanes with >2 lanes or nested swimlanes
-- Multi-layer architecture (data plane + control plane stacked)
-- Color and styling carry semantic weight that mermaid styling cannot express cleanly
-- Interactive editing is expected post-merge (cross-team architecture review)
+- Precise grid / column layout matters (network topology, rack diagrams) `(review-time: diagram-complexity judgment)`
+- Custom shapes / icons / cloud provider symbols are required `(review-time: diagram-complexity judgment)`
+- Swimlanes with >2 lanes or nested swimlanes `(review-time: diagram-complexity judgment)`
+- Multi-layer architecture (data plane + control plane stacked) `(review-time: diagram-complexity judgment)`
+- Color and styling carry semantic weight that mermaid styling cannot express cleanly `(review-time: diagram-complexity judgment)`
+- Interactive editing is expected post-merge (cross-team architecture review) `(review-time: workflow choice)`
 
 If you find yourself fighting mermaid syntax for layout reasons, switch to drawio - that's the signal.
 
@@ -41,9 +41,9 @@ If you find yourself fighting mermaid syntax for layout reasons, switch to drawi
 
 For each drawio diagram:
 
-- Source: `docs/diagrams/<topic>.drawio` (XML, the source of truth, committed)
-- Render: `docs/diagrams/<topic>.png` (committed alongside so GitHub previews work)
-- Reference from docs: embed the PNG with a markdown image link, then a one-line caption naming the source file.
+- Source: `docs/diagrams/<topic>.drawio` (XML, the source of truth, committed) `(review-time: file-convention for drawio diagrams)`
+- Render: `docs/diagrams/<topic>.png` (committed alongside so GitHub previews work) `(review-time: file-convention)`
+- Reference from docs: embed the PNG with a markdown image link, then a one-line caption naming the source file. `(review-time: formatting convention)`
 
 ```markdown
 ![Order Lifecycle](diagrams/order-lifecycle.png)
@@ -54,9 +54,9 @@ For each drawio diagram:
 
 The `drawio` MCP server is configured in `.mcp.json`. Three tools are exposed:
 
-- `mcp__drawio__open_drawio_xml` - paste raw drawio XML, opens in the editor
-- `mcp__drawio__open_drawio_csv` - tabular import (org charts, lists)
-- `mcp__drawio__open_drawio_mermaid` - mermaid input rendered through drawio (useful when you want a richer-styled version of an existing mermaid diagram)
+- `mcp__drawio__open_drawio_xml` - paste raw drawio XML, opens in the editor `(review-time: descriptive of available tool)`
+- `mcp__drawio__open_drawio_csv` - tabular import (org charts, lists) `(review-time: descriptive)`
+- `mcp__drawio__open_drawio_mermaid` - mermaid input rendered through drawio (useful when you want a richer-styled version of an existing mermaid diagram) `(review-time: descriptive)`
 
 Workflow:
 
@@ -69,10 +69,10 @@ The `/diagram` skill automates steps 1-3.
 
 ## Forbidden
 
-- Hand-drawn / scanned diagrams (illegible, undiffable, accessibility-hostile).
-- ASCII art for anything more than a 4-node flow (use mermaid).
-- Embedded screenshots of UML tools other than drawio.
-- Diagrams without a captioned source link in the surrounding doc.
+- Hand-drawn / scanned diagrams (illegible, undiffable, accessibility-hostile). `(review-time: image-content classification)`
+- ASCII art for anything more than a 4-node flow (use mermaid). `(review-time: counting nodes in ASCII art)`
+- Embedded screenshots of UML tools other than drawio. `(review-time: image-source classification)`
+- Diagrams without a captioned source link in the surrounding doc. `(review-time: requires reading surrounding doc)`
 
 ## Drift
 

--- a/rules/engineering-principles.md
+++ b/rules/engineering-principles.md
@@ -4,28 +4,28 @@
 
 ## Change Sizing
 
-- **Target ~100 lines per commit** - small changes are easier to review, test, and revert
-- **300 lines is acceptable** for cohesive changes that cannot be split without losing context
-- **1000+ lines must be split** - no exceptions. Break into sequential PRs or stacked commits
-- **PRs touching 15+ files need justification** - rename/migration is fine; "I was in the area" is not
+- **Target ~100 lines per commit** - small changes are easier to review, test, and revert `(review-time: line-count thresholds vary; mechanical check would block legitimate work)`
+- **300 lines is acceptable** for cohesive changes that cannot be split without losing context `(review-time: judging cohesion)`
+- **1000+ lines must be split** - no exceptions. Break into sequential PRs or stacked commits `(review-time: same; could be CI warning but too rigid)`
+- **PRs touching 15+ files need justification** - rename/migration is fine; "I was in the area" is not `(review-time: judging "drive-by" vs "needed")`
 
 ## Vertical Slicing
 
 Implement features as thin end-to-end slices, not horizontal layers.
 
-- **Good**: one complete feature path (UI + API + DB + test) that a user can interact with
-- **Bad**: "all database models first, then all API routes, then all UI components"
-- Each slice should be independently deployable and testable
-- If a slice is too large, narrow the scope (fewer fields, simpler validation, fewer edge cases)
+- **Good**: one complete feature path (UI + API + DB + test) that a user can interact with `(review-time: example, structural advice)`
+- **Bad**: "all database models first, then all API routes, then all UI components" `(review-time: example, anti-pattern)`
+- Each slice should be independently deployable and testable `(review-time: slice-shape judgment)`
+- If a slice is too large, narrow the scope (fewer fields, simpler validation, fewer edge cases) `(review-time: scope judgment)`
 
 ## Chesterton's Fence
 
 Before removing or changing existing code, understand why it exists.
 
-- Run `git blame` and read the commit message that introduced the code
-- Check linked issues or PRs for context
-- If no context exists and the code seems unnecessary, ask - do not silently remove
-- "I don't understand why this is here" is a reason to investigate, not a reason to delete
+- Run `git blame` and read the commit message that introduced the code `(review-time: workflow step)`
+- Check linked issues or PRs for context `(review-time: workflow step)`
+- If no context exists and the code seems unnecessary, ask - do not silently remove `(review-time: requires recognizing absence of context)`
+- "I don't understand why this is here" is a reason to investigate, not a reason to delete `(review-time: meta-principle, not a pattern)`
 
 ## Shift Left
 
@@ -40,17 +40,17 @@ Priority order (earliest to latest):
 5. **Runtime validation** - catch at execution time
 6. **Monitoring/alerting** - catch in production
 
-Prefer solutions higher on this list. If something can be caught by the type system, don't write a test for it - fix the types.
+Prefer solutions higher on this list. If something can be caught by the type system, don't write a test for it - fix the types. `(review-time: meta-principle informing the layer policy)`
 
 ## Context Hierarchy
 
 When information conflicts, follow this priority order:
 
-1. **Rules files** (rules/, CLAUDE.md) - highest authority
-2. **Specifications** (.claude/state/specs/) - agreed requirements
-3. **Source code** - current implementation
-4. **Error output** - runtime signals
-5. **Conversation history** - may be stale or misremembered
+1. **Rules files** (rules/, CLAUDE.md) - highest authority `(review-time: source-of-truth ranking)`
+2. **Specifications** (.claude/state/specs/) - agreed requirements `(review-time: source-of-truth ranking)`
+3. **Source code** - current implementation `(review-time: source-of-truth ranking)`
+4. **Error output** - runtime signals `(review-time: source-of-truth ranking)`
+5. **Conversation history** - may be stale or misremembered `(review-time: source-of-truth ranking)`
 
 ## Anti-Rationalization
 
@@ -68,6 +68,6 @@ Never accept these shortcuts, regardless of justification:
 
 ## Exploration Guard Rails
 
-- For open-ended tasks (seed scripts, data generation, exploratory refactors): explore briefly, then start writing code - partial progress beats perfect plans
-- If you've been reading files for more than 5 minutes without producing code, stop exploring and implement with what you know - we can iterate
-- Never spend an entire session on analysis without producing a working artifact
+- For open-ended tasks (seed scripts, data generation, exploratory refactors): explore briefly, then start writing code - partial progress beats perfect plans `(review-time: time-budget judgment)`
+- If you've been reading files for more than 5 minutes without producing code, stop exploring and implement with what you know - we can iterate `(review-time: requires self-tracking)`
+- Never spend an entire session on analysis without producing a working artifact `(review-time: session-shape judgment)`

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -4,31 +4,31 @@
 
 ## Commits
 
-- Always use conventional commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, etc.)
-- Scope is optional, e.g. `feat(auth): add token refresh`
-- Never add Co-Authored-By or any AI attribution to commits
-- Before committing, verify the current branch with `git branch --show-current` - never commit directly to main/master
-- Never auto-commit or push - wait for explicit instructions
+- Always use conventional commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, etc.) `(hook)`
+- Scope is optional, e.g. `feat(auth): add token refresh` `(review-time: descriptive sub-rule of the format above)`
+- Never add Co-Authored-By or any AI attribution to commits `(hook)`
+- Before committing, verify the current branch with `git branch --show-current` - never commit directly to main/master `(hook)`
+- Never auto-commit or push - wait for explicit instructions `(review-time: depends on conversational signal, not pattern)`
 
 ## Branches and PRs
 
-- NEVER push directly to the default branch (master/main) - always use a feature branch and create a PR
-- NEVER merge PRs automatically - always wait for the user to merge manually
-- After completing any feature implementation, create a PR unless explicitly told otherwise - do not wait to be asked
-- Always rebase onto the target branch (`git fetch origin main && git rebase origin/main`) before creating a PR
-- Always run `/verify-done` before pushing any branch - never push without all checks passing
-- PR descriptions: always use bullet points in the summary section, not prose paragraphs
-- After pushing new commits to an existing PR, update the PR title and description to reflect all changes - use `gh pr edit` to keep them accurate
-- If the repo has a PR template (`.github/pull_request_template.md`), use it. If not, use `~/.claude/pull_request_template.md`
+- NEVER push directly to the default branch (master/main) - always use a feature branch and create a PR `(hook)`
+- NEVER merge PRs automatically - always wait for the user to merge manually `(review-time: depends on user signal, not pattern)`
+- After completing any feature implementation, create a PR unless explicitly told otherwise - do not wait to be asked `(review-time: requires judging "completion")`
+- Always rebase onto the target branch (`git fetch origin main && git rebase origin/main`) before creating a PR `(hook)`
+- Always run `/verify-done` before pushing any branch - never push without all checks passing `(hook)`
+- PR descriptions: always use bullet points in the summary section, not prose paragraphs `(review-time: formatting of free-form text Claude produces)`
+- After pushing new commits to an existing PR, update the PR title and description to reflect all changes - use `gh pr edit` to keep them accurate `(review-time: requires judging "reflects all changes")`
+- If the repo has a PR template (`.github/pull_request_template.md`), use it. If not, use `~/.claude/pull_request_template.md` `(review-time: template selection requires reading directory)`
 
 ## Testing Hygiene
 
-- When modifying test files, ensure all mocks are updated to match new DB queries, service dependencies, and module imports
+- When modifying test files, ensure all mocks are updated to match new DB queries, service dependencies, and module imports `(review-time: requires understanding mock-target coupling)`
 
 ## Versioning
 
-- Follow semantic versioning (semver) - MAJOR for breaking changes, MINOR for new features, PATCH for fixes
+- Follow semantic versioning (semver) - MAJOR for breaking changes, MINOR for new features, PATCH for fixes `(review-time: classifying a change as breaking vs additive requires judgment)`
 
 ## Tooling
 
-- Always use `gh` CLI for GitHub operations (PRs, issues, checks, releases) - never use MCP tools for GitHub
+- Always use `gh` CLI for GitHub operations (PRs, issues, checks, releases) - never use MCP tools for GitHub `(review-time: tool selection per action, not a single regex)`

--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -2,11 +2,11 @@
 
 **When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, or CI/CD workflow files.
 
-- Infrastructure as Code only - no manual changes to cloud resources
-- No `latest` tags for Docker images - always use specific version tags
-- No secrets in code, Dockerfiles, or CI configs - use secret managers
-- No mutable infrastructure - rebuild, don't patch
-- Multi-stage Docker builds to minimize image size
-- CI/CD pipelines must run lint, typecheck, and tests before deploy
-- Always tag cloud resources with project, environment, and owner
-- GCP is primary cloud, AWS is secondary
+- Infrastructure as Code only - no manual changes to cloud resources `(review-time: process, not detectable in code)`
+- No `latest` tags for Docker images - always use specific version tags `(hook)`
+- No secrets in code, Dockerfiles, or CI configs - use secret managers `(review-time: secrets blocked by deny rules + reviewer judgment; pattern detection has false positives)`
+- No mutable infrastructure - rebuild, don't patch `(review-time: requires understanding the change's effect on a running resource)`
+- Multi-stage Docker builds to minimize image size `(review-time: structural Dockerfile pattern, hard to flag without false positives)`
+- CI/CD pipelines must run lint, typecheck, and tests before deploy `(CI)`
+- Always tag cloud resources with project, environment, and owner `(review-time: tag presence varies per Terraform resource type)`
+- GCP is primary cloud, AWS is secondary `(review-time: provider preference, not a code pattern)`

--- a/rules/jira.md
+++ b/rules/jira.md
@@ -8,17 +8,17 @@ Reach for `acli` (Atlassian CLI) before doing anything else.
 
 Trigger this rule when any of the following appears in the user's message:
 
-- A Jira-style key matching `[A-Z]+-\d+`
-- The words "Jira", "ticket", "issue", "story", "epic", "bug" used in a tracker sense (not a generic "there's an issue with X")
-- A Jira URL (`*.atlassian.net/browse/KEY-123`)
+- A Jira-style key matching `[A-Z]+-\d+` `(review-time: trigger condition for the rule, not a rule itself)`
+- The words "Jira", "ticket", "issue", "story", "epic", "bug" used in a tracker sense (not a generic "there's an issue with X") `(review-time: trigger condition)`
+- A Jira URL (`*.atlassian.net/browse/KEY-123`) `(review-time: trigger condition)`
 
-If the reference is ambiguous (could be GitHub issue vs Jira), ask before assuming.
+If the reference is ambiguous (could be GitHub issue vs Jira), ask before assuming. `(review-time: requires judging ambiguity in the user's message)`
 
 ## Tool check
 
-1. Run `which acli` to confirm it is installed.
-2. If installed, run `acli jira auth status` (or attempt a read command) to confirm it is authenticated. If unauthenticated, surface that to the user - do not attempt to authenticate on their behalf.
-3. If not installed or not configured, tell the user and fall back to asking them for the ticket contents.
+1. Run `which acli` to confirm it is installed. `(review-time: procedural step in a sequence)`
+2. If installed, run `acli jira auth status` (or attempt a read command) to confirm it is authenticated. If unauthenticated, surface that to the user - do not attempt to authenticate on their behalf. `(review-time: procedural step)`
+3. If not installed or not configured, tell the user and fall back to asking them for the ticket contents. `(review-time: error-handling pattern in conversation)`
 
 ## Usage
 
@@ -37,8 +37,8 @@ Run `acli jira workitem --help` for the current command surface - flags change b
 
 ## Rules
 
-- **Read first**: when a ticket is referenced, fetch it before asking the user what it says. Do not make the user paste content `acli` could have retrieved.
-- **No silent writes**: never transition, comment on, or update a ticket without explicit user confirmation. Reading is free; writing affects shared state.
-- **Do not invent keys**: only act on keys the user actually provided. Do not guess project prefixes.
-- **Stay scoped**: fetch the specific tickets referenced, not the entire backlog. Avoid broad `--jql` sweeps unless asked.
-- **Surface auth errors**: if `acli` returns an auth or permission error, report it verbatim - do not retry blindly or attempt to re-auth.
+- **Read first**: when a ticket is referenced, fetch it before asking the user what it says. Do not make the user paste content `acli` could have retrieved. `(review-time: ordering in conversational flow)`
+- **No silent writes**: never transition, comment on, or update a ticket without explicit user confirmation. Reading is free; writing affects shared state. `(review-time: requires conversational signal of confirmation)`
+- **Do not invent keys**: only act on keys the user actually provided. Do not guess project prefixes. `(review-time: requires reading user's message)`
+- **Stay scoped**: fetch the specific tickets referenced, not the entire backlog. Avoid broad `--jql` sweeps unless asked. `(review-time: judging "broad" scope)`
+- **Surface auth errors**: if `acli` returns an auth or permission error, report it verbatim - do not retry blindly or attempt to re-auth. `(review-time: error-handling pattern)`

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -6,77 +6,79 @@ When a task can be split into independent pieces, parallelize by spawning multip
 
 ## When to Parallelize
 
+**why-not-mechanizable:** every condition below requires understanding the task shape ("independent", "meaningful effort", "would take significantly longer"). The harness can't see what the task is until I describe it.
+
 Spawn parallel agents when ALL of these are true:
 
-- The task has 2+ independent sub-tasks that touch different files or modules
-- Each sub-task takes meaningful effort (not a one-liner fix)
-- The sub-tasks do not need to read each other's output to proceed
-- The overall task would take significantly longer done sequentially
+- The task has 2+ independent sub-tasks that touch different files or modules `(review-time: see section note)`
+- Each sub-task takes meaningful effort (not a one-liner fix) `(review-time: see section note)`
+- The sub-tasks do not need to read each other's output to proceed `(review-time: see section note)`
+- The overall task would take significantly longer done sequentially `(review-time: see section note)`
 
 Good candidates:
 
-- Implementing features across multiple modules (e.g., API endpoint + frontend page + tests)
-- Writing tests for several unrelated modules
-- Fixing multiple independent bugs in one batch
-- Refactoring several files that do not depend on each other
-- Adding similar functionality to different parts of the codebase (e.g., validation to 5 different endpoints)
-- Research tasks that explore different parts of the codebase
+- Implementing features across multiple modules (e.g., API endpoint + frontend page + tests) `(review-time: example, not a strict rule)`
+- Writing tests for several unrelated modules `(review-time: example)`
+- Fixing multiple independent bugs in one batch `(review-time: example)`
+- Refactoring several files that do not depend on each other `(review-time: example)`
+- Adding similar functionality to different parts of the codebase (e.g., validation to 5 different endpoints) `(review-time: example)`
+- Research tasks that explore different parts of the codebase `(review-time: example)`
 
 ## When NOT to Parallelize
 
 Do NOT spawn parallel agents when:
 
-- The task is a single focused change (one file, one module)
-- Sub-tasks are tightly coupled - one must see the other's output before it can start
-- The work is strictly sequential (step 2 depends on step 1's result)
-- The task is trivial enough to finish in under 2 minutes sequentially
-- Changes will inevitably conflict (e.g., multiple agents editing the same file)
-- There are only cosmetic or config changes
+- The task is a single focused change (one file, one module) `(review-time: task-shape judgment)`
+- Sub-tasks are tightly coupled - one must see the other's output before it can start `(review-time: task-shape judgment)`
+- The work is strictly sequential (step 2 depends on step 1's result) `(review-time: task-shape judgment)`
+- The task is trivial enough to finish in under 2 minutes sequentially `(review-time: time-estimate)`
+- Changes will inevitably conflict (e.g., multiple agents editing the same file) `(review-time: conflict prediction)`
+- There are only cosmetic or config changes `(review-time: task-shape judgment)`
 
 ## How to Split Work
 
-- **File-level isolation**: Each agent should own a distinct set of files. NEVER assign two agents to edit the same file.
-- **Module boundaries**: Split along natural module/package/directory boundaries
-- **Vertical slices**: Prefer giving an agent a complete vertical slice (e.g., "add the /users endpoint including route, controller, service, and tests") over horizontal slices (e.g., "write all controllers")
-- **Self-contained units**: Each agent's task must be completable and testable in isolation
-- **Shared dependencies**: If sub-tasks share a dependency that needs to be created first, either create it before spawning agents or assign it to one agent and make the others wait
+- **File-level isolation**: Each agent should own a distinct set of files. NEVER assign two agents to edit the same file. `(review-time: requires knowing the file plan)`
+- **Module boundaries**: Split along natural module/package/directory boundaries `(review-time: module-boundary recognition)`
+- **Vertical slices**: Prefer giving an agent a complete vertical slice (e.g., "add the /users endpoint including route, controller, service, and tests") over horizontal slices (e.g., "write all controllers") `(review-time: slice-shape choice)`
+- **Self-contained units**: Each agent's task must be completable and testable in isolation `(review-time: completability judgment)`
+- **Shared dependencies**: If sub-tasks share a dependency that needs to be created first, either create it before spawning agents or assign it to one agent and make the others wait `(review-time: dependency-graph reasoning)`
 
 ## Worktree Isolation
 
 Every parallel agent MUST use worktree isolation:
 
-- Set `isolation: "worktree"` on every Agent tool call for parallel work
-- Each agent gets its own full copy of the repo via git worktree
-- Each agent works on its own branch - no risk of stepping on other agents' changes
-- NEVER run parallel agents without worktree isolation - concurrent edits to the same working directory will cause corruption
+- Set `isolation: "worktree"` on every Agent tool call for parallel work `(review-time: tool-call parameter choice; not currently hook-gated on Agent calls)`
+- Each agent gets its own full copy of the repo via git worktree `(review-time: descriptive of the mechanism)`
+- Each agent works on its own branch - no risk of stepping on other agents' changes `(review-time: descriptive of the mechanism)`
+- NEVER run parallel agents without worktree isolation - concurrent edits to the same working directory will cause corruption `(review-time: tool-call parameter choice; not currently hook-gated)`
 
 ## Background Execution
 
-- Spawn agents with `run_in_background: true` so they execute concurrently
-- Launch all independent agents in a single message with multiple Agent tool calls
-- After spawning, wait for automatic completion notifications - do NOT poll or check repeatedly
-- Continue with other non-conflicting work while agents run, if possible
+- Spawn agents with `run_in_background: true` so they execute concurrently `(review-time: tool-call parameter)`
+- Launch all independent agents in a single message with multiple Agent tool calls `(review-time: message-shape choice)`
+- After spawning, wait for automatic completion notifications - do NOT poll or check repeatedly `(review-time: behavioral discipline)`
+- Continue with other non-conflicting work while agents run, if possible `(review-time: requires identifying non-conflicting work)`
 
 ## Merging Results
 
 After all agents complete:
 
-1. Review each agent's changes for correctness
-2. Merge branches one at a time into the main working branch
-3. After each merge, check for conflicts and resolve immediately
-4. Run the full test suite, typecheck, and lint after all merges are complete
-5. If a merge conflict arises, resolve it manually - do NOT re-spawn an agent for conflict resolution
-6. After all branches are merged into the integration branch, prune the agent worktrees: `~/.claude/scripts/worktree-prune.sh --apply`. The conservative rule will only remove worktrees whose branch is upstream-gone or merged into the default - exactly the post-merge state. Locked worktrees will auto-unlock if safe. Anything still active is preserved.
+1. Review each agent's changes for correctness `(review-time: code review)`
+2. Merge branches one at a time into the main working branch `(review-time: workflow step)`
+3. After each merge, check for conflicts and resolve immediately `(review-time: workflow step)`
+4. Run the full test suite, typecheck, and lint after all merges are complete `(review-time: workflow step; pre-push-gate.sh enforces at push)`
+5. If a merge conflict arises, resolve it manually - do NOT re-spawn an agent for conflict resolution `(review-time: subagent-use choice)`
+6. After all branches are merged into the integration branch, prune the agent worktrees: `~/.claude/scripts/worktree-prune.sh --apply`. The conservative rule will only remove worktrees whose branch is upstream-gone or merged into the default - exactly the post-merge state. Locked worktrees will auto-unlock if safe. Anything still active is preserved. `(review-time: cleanup step)`
 
 ## Agent Prompt Quality
 
 Each agent's prompt MUST be self-contained. The agent cannot see the parent conversation. Include:
 
-- **Goal**: Exactly what the agent must accomplish - be specific and unambiguous
-- **Context**: Relevant background (why this change is needed, what the broader task is)
-- **File paths**: Exact files to read and modify - do not make the agent search blindly
-- **Constraints**: Patterns to follow, styles to match, things to avoid
-- **Verification**: How the agent should verify its work (run tests, typecheck, lint)
+- **Goal**: Exactly what the agent must accomplish - be specific and unambiguous `(review-time: prompt-quality)`
+- **Context**: Relevant background (why this change is needed, what the broader task is) `(review-time: prompt-quality)`
+- **File paths**: Exact files to read and modify - do not make the agent search blindly `(review-time: prompt-quality)`
+- **Constraints**: Patterns to follow, styles to match, things to avoid `(review-time: prompt-quality)`
+- **Verification**: How the agent should verify its work (run tests, typecheck, lint) `(review-time: prompt-quality)`
 
 Bad prompt: "Add validation to the API"
 
@@ -84,10 +86,10 @@ Good prompt: "Add Zod input validation to the POST /api/users endpoint in src/ro
 
 ## Limits
 
-- **Target: 4 parallel agents.** Most real tasks decompose cleanly into 2-4 truly independent units; beyond that you're usually inventing artificial seams.
-- **Hard ceiling: 5 parallel agents.** Only go this high when the task genuinely has 5 clean independent slices.
-- If a task splits into more than 5 pieces, batch them into rounds rather than spawning more concurrently.
-- Always prefer 3 well-scoped agents over 6 narrowly-scoped ones.
+- **Target: 4 parallel agents.** Most real tasks decompose cleanly into 2-4 truly independent units; beyond that you're usually inventing artificial seams. `(review-time: parallelism target)`
+- **Hard ceiling: 5 parallel agents.** Only go this high when the task genuinely has 5 clean independent slices. `(review-time: parallelism ceiling)`
+- If a task splits into more than 5 pieces, batch them into rounds rather than spawning more concurrently. `(review-time: batching strategy)`
+- Always prefer 3 well-scoped agents over 6 narrowly-scoped ones. `(review-time: scope-vs-count trade-off)`
 
 Why these numbers:
 

--- a/rules/rule-authoring.md
+++ b/rules/rule-authoring.md
@@ -1,0 +1,62 @@
+# Rule Authoring Policy
+
+**When to apply:** writing or editing any normative bullet in `rules/*.md`, `CLAUDE.md`, `agents/*.md`, `skills/**/SKILL.md`, or `RTK.md`.
+
+## Why this exists
+
+Rules sitting in text files are loaded into every Claude session, but loading is not enforcement. Compliance failures happen when the agent forgets or misreads. The cure isn't more rules - it's making the enforcement layer of each rule explicit so the reader (human or LLM) knows what's mechanically backed and what's attention-dependent. Where mechanical backing is possible, we add it. Where it isn't, we own that the rule depends on attention.
+
+## The five enforcement layers
+
+Ranked by reliability (earliest catch wins per the shift-left principle):
+
+| Tag | Where enforced | Cost when violated |
+|---|---|---|
+| `(hook)` | `~/.claude/hooks/*.sh` via `~/.claude/settings.json` | ~1s, fed back to Claude as a tool result |
+| `(lint)` | Repo `biome.json` / `eslint.config.js` / `.markdownlint*` | `npm run check` run |
+| `(CI)` | `.github/workflows/`, pentla-shared reusables | PR cycle |
+| `(persona)` | A `~/.claude/agents/*.md` persona file's guardrail section | Subagent compliance, not global |
+| `(review-time: <why>)` | Human attention or Claude attention at review or response time | Open-ended |
+
+## The marker requirement
+
+Every **normative** bullet in an in-scope file ends with a tag. A normative bullet asserts a "do X" or "don't Y" - the rule itself. Prose paragraphs (motivation, examples, prerequisites) carry no tag.
+
+Format: backtick-wrapped, single space before, end of line.
+
+```markdown
+- No `var` in JS/TS - use `const` or `let` `(hook)`
+- Prefer interface over type for object shapes `(lint)`
+- Lead with your recommendation when you have one `(review-time: subjective phrasing, not pattern-matchable)`
+```
+
+## The `(review-time)` justification
+
+`(review-time)` is the weakest layer and the easiest place for rules to silently accumulate. To gate that:
+
+- Every `(review-time)` tag MUST include a colon-prefixed justification: `(review-time: <one-line why>)`.
+- The justification answers: *why can't a hook, linter, or CI check catch this?*
+- If many bullets in a single section share the same justification, write the justification once as a `**why-not-mechanizable:**` paragraph immediately under the section heading, then use `(review-time: see section note)` on each bullet.
+- If you can't write a one-line justification, the rule is probably either mechanizable (write the hook instead) or not worth keeping.
+
+## Multi-layer conventions
+
+- A rule with **multiple distinct aspects** belonging to different layers gets split into separate bullets, each with its own tag.
+- A rule whose **single aspect** happens to be caught at multiple layers gets the strongest tag only (hook beats lint beats CI beats persona beats review-time). No `(hook + lint)` compound tags - the strongest layer is the source of truth.
+
+## In-scope files
+
+- `rules/*.md`
+- `CLAUDE.md`
+- `agents/*.md` (only the normative-guardrail sections; persona prose stays untagged)
+- `skills/**/SKILL.md` (only the normative bullets; procedure / steps / examples stay untagged)
+- `RTK.md` (only the normative bullets)
+
+Out of scope: `MEMORY.md`, `keybindings.json`, `settings.json`, `docs/`, `README.md`, generic `scripts/` files.
+
+## Lifecycle - moving a rule between layers
+
+- Adding a new rule: pick the layer at authoring time, mark it. If `(review-time)`, write the justification.
+- Mechanising an existing rule (moving up the table): change the tag and add the hook / lint config / CI check in the same PR. PR description notes the layer change in one line.
+- Demoting a rule (moving down): rare but valid (e.g., a hook becomes unmaintainable). PR description notes the demotion.
+- Removing a rule: just delete it. No tombstone.

--- a/rules/state-persistence.md
+++ b/rules/state-persistence.md
@@ -6,15 +6,15 @@ All work artifacts must be saved to the project-level `.claude/state/` directory
 
 ## Directories
 
-- `.claude/state/research/` - research artifacts from Phase 1
-- `.claude/state/specs/` - specification documents from the /spec skill
-- `.claude/state/plans/` - implementation plans from Phase 2
-- `.claude/state/sessions/` - session diary entries from Phase 5 (Summarize)
+- `.claude/state/research/` - research artifacts from Phase 1 `(review-time: descriptive, not a rule)`
+- `.claude/state/specs/` - specification documents from the /spec skill `(review-time: descriptive, not a rule)`
+- `.claude/state/plans/` - implementation plans from Phase 2 `(review-time: descriptive, not a rule)`
+- `.claude/state/sessions/` - session diary entries from Phase 5 (Summarize) `(review-time: descriptive, not a rule)`
 
 ## Rules
 
-- Create `.claude/state/` directories if they don't exist before writing
-- Use naming convention: `YYYY-MM-DD-descriptive-name.md` (e.g., `2026-03-12-research-auth-refactor.md`)
-- Every non-trivial session should end with a summary saved to `.claude/state/sessions/`
-- Plans and research are per-project, not global
-- Check `.claude/state/` for relevant past work before starting new research
+- Create `.claude/state/` directories if they don't exist before writing `(review-time: simple ops choice, no enforcement value-add)`
+- Use naming convention: `YYYY-MM-DD-descriptive-name.md` (e.g., `2026-03-12-research-auth-refactor.md`) `(review-time: a filename-pattern hook is possible but very high false-positive rate on existing files)`
+- Every non-trivial session should end with a summary saved to `.claude/state/sessions/` `(review-time: subjective threshold "non-trivial")`
+- Plans and research are per-project, not global `(review-time: location preference)`
+- Check `.claude/state/` for relevant past work before starting new research `(review-time: workflow guidance)`

--- a/rules/tests.md
+++ b/rules/tests.md
@@ -2,12 +2,12 @@
 
 **When to apply:** editing test files (`*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`).
 
-- Vitest preferred as the test runner
-- Mock external dependencies only (APIs, databases, file system) - not internal modules
-- Manual class instantiation over dependency injection in tests
-- Test behavior, not implementation details
-- No flaky tests in main branch - if a test is flaky, fix or remove it
-- No hardcoded test data that couples to environment - use factories or builders
-- Each test should be independent - no shared mutable state between tests
-- Prefer `describe`/`it` blocks with descriptive names that read as sentences
-- Run single test files during development, full suite before declaring done
+- Vitest preferred as the test runner `(review-time: preference, not enforceable when team picks otherwise)`
+- Mock external dependencies only (APIs, databases, file system) - not internal modules `(review-time: requires understanding the module boundary being mocked)`
+- Manual class instantiation over dependency injection in tests `(review-time: structural pattern, varies per framework)`
+- Test behavior, not implementation details `(review-time: semantic - which assertions count as implementation-coupled)`
+- No flaky tests in main branch - if a test is flaky, fix or remove it `(CI)`
+- No hardcoded test data that couples to environment - use factories or builders `(review-time: identifying environmental coupling needs reading)`
+- Each test should be independent - no shared mutable state between tests `(review-time: shared-state detection requires analysis)`
+- Prefer `describe`/`it` blocks with descriptive names that read as sentences `(review-time: naming quality is subjective)`
+- Run single test files during development, full suite before declaring done `(review-time: workflow guidance, not code pattern)`

--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -2,14 +2,14 @@
 
 **When to apply:** editing TypeScript files (`*.ts`, `*.tsx`).
 
-- No `any` or `unknown` - use proper types, generics, or branded types
-- 2-space indentation, single quotes
-- Prefer `interface` over `type` for object shapes (unless union/intersection needed)
-- Prefer an options object when a function takes 3+ parameters, or when any parameter is optional. Destructure inside the function body. Exceptions: tightly coupled, order-intuitive positional params where the order IS the contract (e.g., `clamp(value, min, max)`, `range(start, end, step)`, `lerp(a, b, t)`), and variadic/rest functions. Boolean parameters should always be passed via an options object regardless of count - avoid "flag soup" like `doThing(true, false, true)`
-- Destructure imports when possible: `import { foo } from 'bar'`
-- No barrel exports (`index.ts` re-exports) - import directly from source
-- No default exports - use named exports only
-- Zod schemas for runtime validation at system boundaries (API inputs, env vars, external data)
-- Prefer `const` over `let`, never use `var`
-- Use strict null checks - handle `null`/`undefined` explicitly
-- No non-null assertion operator (`!`) - use proper null checks, optional chaining, or narrowing instead
+- No `any` or `unknown` - use proper types, generics, or branded types `(lint)`
+- 2-space indentation, single quotes `(lint)`
+- Prefer `interface` over `type` for object shapes (unless union/intersection needed) `(review-time: structural choice, biome can flag but not in default config)`
+- Prefer an options object when a function takes 3+ parameters, or when any parameter is optional. Destructure inside the function body. Exceptions: tightly coupled, order-intuitive positional params where the order IS the contract (e.g., `clamp(value, min, max)`, `range(start, end, step)`, `lerp(a, b, t)`), and variadic/rest functions. Boolean parameters should always be passed via an options object regardless of count - avoid "flag soup" like `doThing(true, false, true)` `(review-time: requires judgment about which params are "order-intuitive")`
+- Destructure imports when possible: `import { foo } from 'bar'` `(lint)`
+- No barrel exports (`index.ts` re-exports) - import directly from source `(review-time: file-structure pattern, hard to detect without false positives)`
+- No default exports - use named exports only `(lint)`
+- Zod schemas for runtime validation at system boundaries (API inputs, env vars, external data) `(review-time: requires knowing which functions are at the boundary)`
+- Prefer `const` over `let`, never use `var` `(hook)`
+- Use strict null checks - handle `null`/`undefined` explicitly `(lint)`
+- No non-null assertion operator (`!`) - use proper null checks, optional chaining, or narrowing instead `(lint)`


### PR DESCRIPTION
## TL;DR

First of three sub-PRs delivering the rule-enforcement architecture grilled out in \`.claude/state/plans/2026-06-04-rule-enforcement-architecture.md\`. This PR is the **rule-files marker pass + meta-policy**. Zero behavior change - pure documentation.

## What changed

### New: \`rules/rule-authoring.md\`

The meta-policy. Codifies:

- The 5-layer taxonomy: \`(hook)\` > \`(lint)\` > \`(CI)\` > \`(persona)\` > \`(review-time: <why>)\`.
- The marker requirement: every normative bullet ends with a backtick-wrapped tag.
- The \`(review-time)\` justification format: inline \`(review-time: <one-line why>)\` answering \"why can't a hook catch this?\".
- Multi-aspect rules → split into separate bullets. Same-aspect-at-multiple-layers → strongest tag only.
- In-scope file list (\`rules/*.md\`, \`CLAUDE.md\`, \`agents/*.md\`, \`skills/**/SKILL.md\`, \`RTK.md\`).
- Lifecycle: adding / mechanising / demoting / removing a rule.

Imported into the global rule load via \`@rules/rule-authoring.md\` in \`CLAUDE.md\`. Also fixes a missing \`@rules/comments.md\` import that existed in master.

### Marker pass

Every normative bullet in these files now carries a layer tag:

- \`rules/agent-routing.md\`
- \`rules/communication.md\` (uses a section-level \`why-not-mechanizable\` since every bullet shares the same reason)
- \`rules/comments.md\`
- \`rules/context7.md\`
- \`rules/database.md\`
- \`rules/diagrams.md\`
- \`rules/engineering-principles.md\`
- \`rules/git-conventions.md\`
- \`rules/infrastructure.md\`
- \`rules/jira.md\`
- \`rules/parallel-agents.md\` (also uses a section-level note)
- \`rules/state-persistence.md\`
- \`rules/tests.md\`
- \`rules/typescript.md\`
- \`CLAUDE.md\` (Security, Formatting, Code Standards, Docs Sync, Behavioral Rules, Learning from Mistakes, Environment)
- \`RTK.md\` (Hook Bailouts, When NOT to reach for rtk proxy)

## Reliability profile after this PR

Counts of bullets per layer across the marked files (approximate):

| Layer | Approx count | Notes |
|---|---|---|
| \`(hook)\` | 13 | Em-dash, tracker refs, consecutive \`//\`, consecutive \`--\`, \`var\`, TODO, \`SELECT *\` (pending PR β), conventional commits (pending PR β), Co-Authored-By (pending PR β), \`latest\` Docker tag (pending PR β), branch / push gates already live |
| \`(lint)\` | ~7 | Mostly the TypeScript rules biome already catches |
| \`(CI)\` | ~2 | Flaky tests, CI deploy gate |
| \`(persona)\` | 0 | Personas haven't been marked yet (alpha2) |
| \`(review-time: ...)\` | ~150 | The majority - judgment, conversational cadence, task-shape recognition |

This is the honest profile: most rules in the global set are inherently judgment calls that no harness can mechanise.

## What's in the follow-ups

- **PR alpha2**: marker pass on \`agents/*.md\` (16 persona files). Same shape - tag every normative guardrail bullet.
- **PR alpha3**: marker pass on \`skills/**/SKILL.md\` (17 skill files).
- **PR beta**: implement the missing \`(hook)\` checks that this PR's tags promise but don't yet enforce - Co-Authored-By gate, conventional-commit format gate, \`SELECT *\` gate, \`latest\` Docker tag gate.

## Review focus

- **Per-bullet tag accuracy**: skim each file and check that each marker matches the actual enforcement layer.
- **\`(review-time)\` justifications**: are any of them lazy? If the justification doesn't convince you, the rule probably needs splitting / mechanising / dropping.
- **Section-level notes**: \`communication.md\` and the When-to-parallelize block in \`parallel-agents.md\` use the section-level pattern. Sanity check the pattern works.