### PR TITLE
feat(skills): tag normative bullets per rule-authoring policy (alpha3)

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -9,37 +9,39 @@ Follow these disciplines:
 
 ## Before Starting
 
-- Verify an approved plan exists (in `.claude/state/plans/` or the current conversation)
-- If no plan exists, stop and ask the user to run /plan first
-- Read the plan and identify the task list
-- Load relevant expert agents based on the plan's domain (see `rules/agent-routing.md`) - their guardrails apply to every increment
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
+- Verify an approved plan exists (in `.claude/state/plans/` or the current conversation) `(review-time: see section note)`
+- If no plan exists, stop and ask the user to run /plan first `(review-time: see section note)`
+- Read the plan and identify the task list `(review-time: see section note)`
+- Load relevant expert agents based on the plan's domain (see `rules/agent-routing.md`) - their guardrails apply to every increment `(review-time: see section note)`
 
 ## Increment Rules
 
 For each task in the plan:
 
-1. **Ask**: "What is the simplest thing that could work?"
-2. **Scope**: touch only what the task requires - no drive-by refactors, no "while I'm here" changes
-3. **Follow `rules/engineering-principles.md`**: vertical slicing, change sizing (~100 lines per commit, max 300, split at 1000+), and anti-rationalization rules all apply
-4. **Compile continuously**: the project must build after every increment. Run typecheck after each file change.
-5. **Test alongside**: write tests as part of the increment, not as a separate step afterward
-6. **Checkpoint**: after completing each task:
-   - Run `/verify-done` (typecheck + lint + tests + build) - do not rely on post-edit hooks alone
-   - If all pass, commit with a conventional commit message
-   - If any fail, fix before moving to the next task - never accumulate errors across tasks
+1. **Ask**: "What is the simplest thing that could work?" `(review-time: see section note)`
+2. **Scope**: touch only what the task requires - no drive-by refactors, no "while I'm here" changes `(review-time: see section note)`
+3. **Follow `rules/engineering-principles.md`**: vertical slicing, change sizing (~100 lines per commit, max 300, split at 1000+), and anti-rationalization rules all apply `(review-time: see section note)`
+4. **Compile continuously**: the project must build after every increment. Run typecheck after each file change. `(review-time: see section note)`
+5. **Test alongside**: write tests as part of the increment, not as a separate step afterward `(review-time: see section note)`
+6. **Checkpoint**: after completing each task: `(review-time: see section note)`
+   - Run `/verify-done` (typecheck + lint + tests + build) - do not rely on post-edit hooks alone `(review-time: see section note)`
+   - If all pass, commit with a conventional commit message `(review-time: see section note)`
+   - If any fail, fix before moving to the next task - never accumulate errors across tasks `(review-time: see section note)`
 
 ## Feature Flags
 
 If the feature is large and will take multiple sessions:
 
-- Use a feature flag to keep incomplete work behind a toggle
-- Each increment should be independently mergeable (behind the flag)
-- The flag is removed only when the full feature is complete and tested
+- Use a feature flag to keep incomplete work behind a toggle `(review-time: see section note)`
+- Each increment should be independently mergeable (behind the flag) `(review-time: see section note)`
+- The flag is removed only when the full feature is complete and tested `(review-time: see section note)`
 
 ## Completion
 
 After all tasks are done:
 
-- Run `/verify-done` one final time
-- Summarize what was built and what changed
-- Flag any deferred items or follow-up work as issues
+- Run `/verify-done` one final time `(review-time: see section note)`
+- Summarize what was built and what changed `(review-time: see section note)`
+- Flag any deferred items or follow-up work as issues `(review-time: see section note)`

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -2,27 +2,29 @@
 
 ## Workflow
 
-1. **Detect VCS platform**: `.gitlab-ci.yml` -> glab, `.github/` -> gh
-2. **Start a Monitor** with the matching script:
-   - GitHub: `bash ~/.claude/skills/ci/scripts/gh-ci-monitor.sh`
-   - GitLab: `bash ~/.claude/skills/ci/scripts/glab-ci-monitor.sh`
-   - Use `persistent: false`, `timeout_ms: 3600000` (1 hour ceiling — CI pipelines can be long)
-   - Description: "CI pipeline on <branch-name>"
-3. **React to Monitor notifications**:
-   - `no-runs|<branch>`: no CI runs found for this branch — inform the user and stop
-   - `error|persistent-failure`: the monitor script hit 5 consecutive errors — report and stop
-   - Status change (e.g., `in_progress|null` → `completed|success`): acknowledge briefly
-   - **Pipeline passes** (`completed|success`):
-     - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"`
-     - Report success
-   - **Pipeline awaiting manual action** (`completed|manual`, GitLab only):
-     - All automatic jobs completed; the pipeline is paused on a manual gate and will not progress without user action
-     - Run `~/.claude/scripts/notify.sh "CI awaiting manual action - <branch-name>"`
-     - Report status and stop watching - do NOT trigger the manual job automatically
-   - **Pipeline fails** (`completed|failure` or any non-success conclusion):
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
+1. **Detect VCS platform**: `.gitlab-ci.yml` -> glab, `.github/` -> gh `(review-time: see section note)`
+2. **Start a Monitor** with the matching script: `(review-time: see section note)`
+   - GitHub: `bash ~/.claude/skills/ci/scripts/gh-ci-monitor.sh` `(review-time: see section note)`
+   - GitLab: `bash ~/.claude/skills/ci/scripts/glab-ci-monitor.sh` `(review-time: see section note)`
+   - Use `persistent: false`, `timeout_ms: 3600000` (1 hour ceiling — CI pipelines can be long) `(review-time: see section note)`
+   - Description: "CI pipeline on <branch-name>" `(review-time: see section note)`
+3. **React to Monitor notifications**: `(review-time: see section note)`
+   - `no-runs|<branch>`: no CI runs found for this branch — inform the user and stop `(review-time: see section note)`
+   - `error|persistent-failure`: the monitor script hit 5 consecutive errors — report and stop `(review-time: see section note)`
+   - Status change (e.g., `in_progress|null` → `completed|success`): acknowledge briefly `(review-time: see section note)`
+   - **Pipeline passes** (`completed|success`): `(review-time: see section note)`
+     - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"` `(review-time: see section note)`
+     - Report success `(review-time: see section note)`
+   - **Pipeline awaiting manual action** (`completed|manual`, GitLab only): `(review-time: see section note)`
+     - All automatic jobs completed; the pipeline is paused on a manual gate and will not progress without user action `(review-time: see section note)`
+     - Run `~/.claude/scripts/notify.sh "CI awaiting manual action - <branch-name>"` `(review-time: see section note)`
+     - Report status and stop watching - do NOT trigger the manual job automatically `(review-time: see section note)`
+   - **Pipeline fails** (`completed|failure` or any non-success conclusion): `(review-time: see section note)`
      a. Fetch the job log:
-        - GitLab: `glab ci trace <job-id>`
-        - GitHub: `gh run view <run-id> --log-failed`
+        - GitLab: `glab ci trace <job-id>` `(review-time: see section note)`
+        - GitHub: `gh run view <run-id> --log-failed` `(review-time: see section note)`
      b. Do NOT pipe output through head, tail, grep, or any other command - run the commands directly
      c. Analyze the root cause - identify the specific failure (test, lint, type check, build, coverage, etc.)
      d. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
@@ -34,27 +36,27 @@
 
 The monitor scripts poll CI status every 30 seconds but only emit a line when the status **changes**. This means:
 
-- Zero token cost while the pipeline is running and status hasn't changed
-- Claude reacts within ~30s of a status change (vs up to 2 min with /loop)
-- No CronDelete cleanup needed — the script exits on terminal state, ending the Monitor
-- If `gh`/`glab` fails 5 times in a row (auth expired, network down), the script exits with an error notification
+- Zero token cost while the pipeline is running and status hasn't changed `(review-time: see section note)`
+- Claude reacts within ~30s of a status change (vs up to 2 min with /loop) `(review-time: see section note)`
+- No CronDelete cleanup needed — the script exits on terminal state, ending the Monitor `(review-time: see section note)`
+- If `gh`/`glab` fails 5 times in a row (auth expired, network down), the script exits with an error notification `(review-time: see section note)`
 
 ## Important: Non-interactive commands only
 
 These commands require a TTY and will NOT work - never use them:
 
-- `glab ci view` (interactive TUI)
-- `gh run watch` (interactive watcher)
-- Any command with `--web` flag (opens browser)
+- `glab ci view` (interactive TUI) `(review-time: see section note)`
+- `gh run watch` (interactive watcher) `(review-time: see section note)`
+- Any command with `--web` flag (opens browser) `(review-time: see section note)`
 
 Safe commands to use:
 
-- `glab ci status`, `glab ci list`, `glab ci trace <job-id>`
-- `gh pr checks`, `gh run list`, `gh run view <run-id> --log-failed`
+- `glab ci status`, `glab ci list`, `glab ci trace <job-id>` `(review-time: see section note)`
+- `gh pr checks`, `gh run list`, `gh run view <run-id> --log-failed` `(review-time: see section note)`
 
 ## Guardrails
 
-- After 3 consecutive failures on the **same issue**, stop and escalate - something structural is wrong
-- Never weaken tests, skip linting, or lower coverage thresholds to make CI pass
-- Never use `--no-verify` or skip hooks
-- If a failure looks unrelated to your changes (flaky test, infra issue), flag it to the user rather than trying to fix it
+- After 3 consecutive failures on the **same issue**, stop and escalate - something structural is wrong `(review-time: see section note)`
+- Never weaken tests, skip linting, or lower coverage thresholds to make CI pass `(review-time: see section note)`
+- Never use `--no-verify` or skip hooks `(review-time: see section note)`
+- If a failure looks unrelated to your changes (flaky test, infra issue), flag it to the user rather than trying to fix it `(review-time: see section note)`

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -9,13 +9,15 @@ Hard rule: do NOT write any fix until Phase 3 is reached and the user (or the ev
 
 ## Phase 1 - Evidence
 
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 Gather, do not theorize. Save findings to `.claude/state/research/YYYY-MM-DD-debug-<short-slug>.md`.
 
-- Reproduce locally if feasible. Capture exact error, stack trace, request ID, timestamp.
-- Pull logs (Sentry, Cloud Run, container, browser console) for the affected window.
-- `git log -p --since='2 weeks ago' -- <suspect-paths>` to surface recent changes that touched the code path.
-- Confirm scope: how many users / requests / environments are affected.
-- Check related state: env vars set on the deployed service, DB row state, feature flags, recent deploys.
+- Reproduce locally if feasible. Capture exact error, stack trace, request ID, timestamp. `(review-time: see section note)`
+- Pull logs (Sentry, Cloud Run, container, browser console) for the affected window. `(review-time: see section note)`
+- `git log -p --since='2 weeks ago' -- <suspect-paths>` to surface recent changes that touched the code path. `(review-time: see section note)`
+- Confirm scope: how many users / requests / environments are affected. `(review-time: see section note)`
+- Check related state: env vars set on the deployed service, DB row state, feature flags, recent deploys. `(review-time: see section note)`
 
 If the user already supplied a hypothesis, treat it as a candidate but still gather evidence to confirm or reject.
 
@@ -23,25 +25,25 @@ If the user already supplied a hypothesis, treat it as a candidate but still gat
 
 List 2-3 possible root causes ranked by evidence strength. For each:
 
-- **Hypothesis** - one line.
-- **Evidence for** - log lines, commits, or code paths that support it (with file:line refs).
-- **Evidence against** - what would have to be true that isn't.
-- **Cheapest verification** - what one command, query, or read would confirm or rule it out.
+- **Hypothesis** - one line. `(review-time: see section note)`
+- **Evidence for** - log lines, commits, or code paths that support it (with file:line refs). `(review-time: see section note)`
+- **Evidence against** - what would have to be true that isn't. `(review-time: see section note)`
+- **Cheapest verification** - what one command, query, or read would confirm or rule it out. `(review-time: see section note)`
 
 Pick the top candidate. If two are tied or the user has a strong prior, ask the user to choose. Do not proceed to Phase 3 on a guess.
 
 ## Phase 3 - Fix
 
-- Minimal change first per CLAUDE.md (1-5 lines, ideally). State the change before applying it.
-- Add a regression test that reproduces the original failure and now passes.
-- Run `/verify-done` (lint + typecheck + test + build).
-- Commit on a feature branch with a conventional message that names the root cause.
-- Open a PR per `mr` skill. PR body: link to the alert/log, root cause statement with evidence, and why this fix is correct.
+- Minimal change first per CLAUDE.md (1-5 lines, ideally). State the change before applying it. `(review-time: see section note)`
+- Add a regression test that reproduces the original failure and now passes. `(review-time: see section note)`
+- Run `/verify-done` (lint + typecheck + test + build). `(review-time: see section note)`
+- Commit on a feature branch with a conventional message that names the root cause. `(review-time: see section note)`
+- Open a PR per `mr` skill. PR body: link to the alert/log, root cause statement with evidence, and why this fix is correct. `(review-time: see section note)`
 
 ## Anti-patterns - reject these
 
-- Adding retry / fallback / try-catch as a "fix" before root cause is confirmed.
-- Introducing new abstractions, services, or workspaces as part of a debug fix.
-- Editing logs to make the symptom disappear.
-- Expanding scope ("while I'm here, let me also...").
-- Pushing before all checks pass green locally.
+- Adding retry / fallback / try-catch as a "fix" before root cause is confirmed. `(review-time: see section note)`
+- Introducing new abstractions, services, or workspaces as part of a debug fix. `(review-time: see section note)`
+- Editing logs to make the symptom disappear. `(review-time: see section note)`
+- Expanding scope ("while I'm here, let me also..."). `(review-time: see section note)`
+- Pushing before all checks pass green locally. `(review-time: see section note)`

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -7,37 +7,39 @@ Create or update the diagram for: $ARGUMENTS
 
 ## Step 1 - Pick the format
 
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 Read `rules/diagrams.md` if uncertain. Default to **mermaid** unless one of these triggers fires - then use **drawio**:
 
-- Custom shapes, icons, or cloud provider symbols requested
-- Precise grid / column layout (network topology, rack diagrams)
-- More than 2 swimlanes, or nested swimlanes
-- Multi-layer architecture (stacked data/control planes)
-- Color or styling carries semantic weight that mermaid cannot express
-- The user explicitly says "drawio" or "complex"
+- Custom shapes, icons, or cloud provider symbols requested `(review-time: see section note)`
+- Precise grid / column layout (network topology, rack diagrams) `(review-time: see section note)`
+- More than 2 swimlanes, or nested swimlanes `(review-time: see section note)`
+- Multi-layer architecture (stacked data/control planes) `(review-time: see section note)`
+- Color or styling carries semantic weight that mermaid cannot express `(review-time: see section note)`
+- The user explicitly says "drawio" or "complex" `(review-time: see section note)`
 
 If the diagram is borderline, ask the user before committing to drawio.
 
 ## Step 2 - Locate the doc
 
-- Identify the doc this diagram belongs to. If `docs/` does not exist, ask the user where to put it.
-- Slug the topic from $ARGUMENTS or the parent doc's filename.
+- Identify the doc this diagram belongs to. If `docs/` does not exist, ask the user where to put it. `(review-time: see section note)`
+- Slug the topic from $ARGUMENTS or the parent doc's filename. `(review-time: see section note)`
 
 ## Step 3 - Mermaid path
 
-1. Write the mermaid source inline in the target doc using ```` ```mermaid ```` fenced blocks (one block per diagram).
-2. Match diagram type to purpose: `flowchart` / `sequenceDiagram` / `stateDiagram-v2` / `erDiagram` / `classDiagram` / `gitGraph` / `journey`.
-3. Keep node labels short. Long descriptions go in adjacent prose.
-4. Verify with `mcp__drawio__open_drawio_mermaid` if you want a quick render check (optional).
-5. Commit the doc.
+1. Write the mermaid source inline in the target doc using ```` ```mermaid ```` fenced blocks (one block per diagram). `(review-time: see section note)`
+2. Match diagram type to purpose: `flowchart` / `sequenceDiagram` / `stateDiagram-v2` / `erDiagram` / `classDiagram` / `gitGraph` / `journey`. `(review-time: see section note)`
+3. Keep node labels short. Long descriptions go in adjacent prose. `(review-time: see section note)`
+4. Verify with `mcp__drawio__open_drawio_mermaid` if you want a quick render check (optional). `(review-time: see section note)`
+5. Commit the doc. `(review-time: see section note)`
 
 ## Step 4 - Drawio path
 
-1. Generate drawio XML for the diagram. Use `mcp__drawio__open_drawio_xml` reference (in the tool description) for shape catalogue, edge routing, swimlanes, containers.
-2. Write the source to `docs/diagrams/<slug>.drawio`.
-3. Call `mcp__drawio__open_drawio_xml` with the XML content - opens in the browser editor for the user to review and export PNG.
-4. Instruct the user: `File > Export As > PNG > save to docs/diagrams/<slug>.png`. They commit both files.
-5. In the consuming doc, embed:
+1. Generate drawio XML for the diagram. Use `mcp__drawio__open_drawio_xml` reference (in the tool description) for shape catalogue, edge routing, swimlanes, containers. `(review-time: see section note)`
+2. Write the source to `docs/diagrams/<slug>.drawio`. `(review-time: see section note)`
+3. Call `mcp__drawio__open_drawio_xml` with the XML content - opens in the browser editor for the user to review and export PNG. `(review-time: see section note)`
+4. Instruct the user: `File > Export As > PNG > save to docs/diagrams/<slug>.png`. They commit both files. `(review-time: see section note)`
+5. In the consuming doc, embed: `(review-time: see section note)`
 
    ```markdown
    ![<topic>](diagrams/<slug>.png)
@@ -48,13 +50,13 @@ If the diagram is borderline, ask the user before committing to drawio.
 
 If updating an existing diagram:
 
-- For mermaid: edit the inline block, keep the same diagram type unless the change requires a different one.
-- For drawio: edit the `.drawio` source, re-open via MCP, re-export PNG, replace both files. Same commit.
+- For mermaid: edit the inline block, keep the same diagram type unless the change requires a different one. `(review-time: see section note)`
+- For drawio: edit the `.drawio` source, re-open via MCP, re-export PNG, replace both files. Same commit. `(review-time: see section note)`
 
 ## Anti-patterns
 
-- Do not generate ASCII art instead of a real diagram.
-- Do not write more than one mermaid block per doc unless the doc is explicitly an architecture overview.
-- Do not commit a `.drawio` file without its `.png` (GitHub reviewers need the preview).
-- Do not ship a `.png` without its `.drawio` source (next maintainer needs to edit it).
-- Do not invent layout coordinates manually for drawio - rely on its auto-layout. Set node ids, labels, edges, lanes; let drawio route.
+- Do not generate ASCII art instead of a real diagram. `(review-time: see section note)`
+- Do not write more than one mermaid block per doc unless the doc is explicitly an architecture overview. `(review-time: see section note)`
+- Do not commit a `.drawio` file without its `.png` (GitHub reviewers need the preview). `(review-time: see section note)`
+- Do not ship a `.png` without its `.drawio` source (next maintainer needs to edit it). `(review-time: see section note)`
+- Do not invent layout coordinates manually for drawio - rely on its auto-layout. Set node ids, labels, edges, lanes; let drawio route. `(review-time: see section note)`

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -9,16 +9,18 @@ This skill writes docs that are dual-audience: engineers reading on GitHub AND C
 
 ## Subcommands
 
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 Parse the first word of `$ARGUMENTS` as the subcommand:
 
-- `explain <topic>` - create/update `docs/explanation/<topic>.md` (the *why* and *how it fits together*)
-- `reference <topic>` - create/update `docs/reference/<topic>.md` (lookup tables, env vars, schemas, enums)
-- `how-to <task>` - create/update `docs/how-to/<task>.md` (a recipe to do one thing)
-- `tutorial <topic>` - create/update `docs/tutorials/<topic>.md` (learning path, onboarding)
-- `adr "<title>"` - draft the next-numbered ADR in `docs/adr/`
-- `diagram <type> <topic>` - add or update a mermaid diagram inside the matching doc
-- `audit` - read every `docs/**/*.md`, compare against current code, produce a drift report (read-only, no edits)
-- `bootstrap` - create the full `docs/` skeleton in a repo that has none yet (uses `~/.claude/templates/docs-readme.md` and `~/.claude/templates/adr.md`)
+- `explain <topic>` - create/update `docs/explanation/<topic>.md` (the *why* and *how it fits together*) `(review-time: see section note)`
+- `reference <topic>` - create/update `docs/reference/<topic>.md` (lookup tables, env vars, schemas, enums) `(review-time: see section note)`
+- `how-to <task>` - create/update `docs/how-to/<task>.md` (a recipe to do one thing) `(review-time: see section note)`
+- `tutorial <topic>` - create/update `docs/tutorials/<topic>.md` (learning path, onboarding) `(review-time: see section note)`
+- `adr "<title>"` - draft the next-numbered ADR in `docs/adr/` `(review-time: see section note)`
+- `diagram <type> <topic>` - add or update a mermaid diagram inside the matching doc `(review-time: see section note)`
+- `audit` - read every `docs/**/*.md`, compare against current code, produce a drift report (read-only, no edits) `(review-time: see section note)`
+- `bootstrap` - create the full `docs/` skeleton in a repo that has none yet (uses `~/.claude/templates/docs-readme.md` and `~/.claude/templates/adr.md`) `(review-time: see section note)`
 
 If no subcommand matches, ask the user which one they meant before writing anything.
 
@@ -35,28 +37,28 @@ If a topic does not clearly fit one quadrant, ask. Do not split a single topic a
 
 ## Quality rules (apply to every doc you write)
 
-1. **One topic per file.** If two H1-worthy ideas appear, split into two files.
-2. **Lead with TL;DR** in 3 sentences or fewer, before any heading. Body expands.
-3. **Cite source files** with backticked relative paths (`src/foo/bar.ts`). Link, do not paste. Inline code blocks longer than 15 lines are forbidden - link to the file instead.
-4. **Tables over prose** for any list of more than 3 parallel items.
-5. **Diagrams for relationships only.** No diagram if a 3-row table conveys it. Mermaid by default; drawio for complex per `rules/diagrams.md`. The `/diagram` skill picks format and writes the source.
-6. **Why before how.** Every explanation doc opens with the problem the thing solves.
-7. **No forward-looking content.** Document only behavior that exists now. No "we plan to", no "in the future".
-8. **No issue/PR/ticket numbers.** They rot. Put them in PR descriptions and git history, not docs.
-9. **ADRs are immutable once Accepted.** A new decision = a new ADR with `Status: Supersedes NNNN`. Never edit the body of an Accepted ADR.
-10. **Max 300 lines per doc.** If longer, split by sub-topic.
-11. **No emoji** unless the user explicitly asked for them.
-12. **No em dashes.** Use a regular hyphen.
+1. **One topic per file.** If two H1-worthy ideas appear, split into two files. `(review-time: see section note)`
+2. **Lead with TL;DR** in 3 sentences or fewer, before any heading. Body expands. `(review-time: see section note)`
+3. **Cite source files** with backticked relative paths (`src/foo/bar.ts`). Link, do not paste. Inline code blocks longer than 15 lines are forbidden - link to the file instead. `(review-time: see section note)`
+4. **Tables over prose** for any list of more than 3 parallel items. `(review-time: see section note)`
+5. **Diagrams for relationships only.** No diagram if a 3-row table conveys it. Mermaid by default; drawio for complex per `rules/diagrams.md`. The `/diagram` skill picks format and writes the source. `(review-time: see section note)`
+6. **Why before how.** Every explanation doc opens with the problem the thing solves. `(review-time: see section note)`
+7. **No forward-looking content.** Document only behavior that exists now. No "we plan to", no "in the future". `(review-time: see section note)`
+8. **No issue/PR/ticket numbers.** They rot. Put them in PR descriptions and git history, not docs. `(review-time: see section note)`
+9. **ADRs are immutable once Accepted.** A new decision = a new ADR with `Status: Supersedes NNNN`. Never edit the body of an Accepted ADR. `(review-time: see section note)`
+10. **Max 300 lines per doc.** If longer, split by sub-topic. `(review-time: see section note)`
+11. **No emoji** unless the user explicitly asked for them. `(review-time: see section note)`
+12. **No em dashes.** Use a regular hyphen. `(review-time: see section note)`
 
 ## Diagram conventions
 
 Mermaid is the default. Use ` ```mermaid ` fenced blocks - GitHub renders natively. Diagram type by purpose:
 
-- `flowchart TD` for high-level architecture and decision trees
-- `sequenceDiagram` for request flows, auth flows, async messaging
-- `erDiagram` for data models
-- `stateDiagram-v2` for state machines (order status, sync status)
-- `flowchart LR` with subgraphs for C4-context (services, queues, datastores)
+- `flowchart TD` for high-level architecture and decision trees `(review-time: see section note)`
+- `sequenceDiagram` for request flows, auth flows, async messaging `(review-time: see section note)`
+- `erDiagram` for data models `(review-time: see section note)`
+- `stateDiagram-v2` for state machines (order status, sync status) `(review-time: see section note)`
+- `flowchart LR` with subgraphs for C4-context (services, queues, datastores) `(review-time: see section note)`
 
 Keep node labels short. Long descriptions go in adjacent prose. One diagram per doc maximum unless the doc is explicitly an architecture overview.
 
@@ -89,22 +91,22 @@ Use the `/diagram` skill (or `mcp__drawio__*` tools directly) to author drawio d
 
 When `adr "<title>"`:
 
-1. Scan `docs/adr/` for highest existing number. New file = `NNNN-<kebab-title>.md`, zero-padded to 4 digits.
-2. Use `~/.claude/templates/adr.md` as the body. Fill `<Title>`, today's date, status `Proposed`.
-3. Append a row to `docs/adr/README.md` table.
-4. Ask the user for Context, Decision, Consequences before finalizing - never invent a decision.
+1. Scan `docs/adr/` for highest existing number. New file = `NNNN-<kebab-title>.md`, zero-padded to 4 digits. `(review-time: see section note)`
+2. Use `~/.claude/templates/adr.md` as the body. Fill `<Title>`, today's date, status `Proposed`. `(review-time: see section note)`
+3. Append a row to `docs/adr/README.md` table. `(review-time: see section note)`
+4. Ask the user for Context, Decision, Consequences before finalizing - never invent a decision. `(review-time: see section note)`
 
 ## Audit procedure
 
 When `audit`:
 
-1. Walk `docs/**/*.md`.
-2. For each doc, extract source-file citations (backticked paths). Verify they exist with `Glob`/`Read`. Report missing files.
-3. For each ADR, verify `Status` is one of {Proposed, Accepted, Superseded by NNNN, Deprecated}. Flag malformed ADRs.
-4. For each `docs/reference/*.md`, scan referenced enums/configs (e.g. `src/**/enums/*.ts`) and report mismatches between doc tables and code.
-5. Report doc files exceeding 300 lines.
-6. Report any `docs/**/*.md` not linked from `docs/README.md`.
-7. Output a report only - do NOT edit files. The user runs targeted subcommands afterward to fix drift.
+1. Walk `docs/**/*.md`. `(review-time: see section note)`
+2. For each doc, extract source-file citations (backticked paths). Verify they exist with `Glob`/`Read`. Report missing files. `(review-time: see section note)`
+3. For each ADR, verify `Status` is one of {Proposed, Accepted, Superseded by NNNN, Deprecated}. Flag malformed ADRs. `(review-time: see section note)`
+4. For each `docs/reference/*.md`, scan referenced enums/configs (e.g. `src/**/enums/*.ts`) and report mismatches between doc tables and code. `(review-time: see section note)`
+5. Report doc files exceeding 300 lines. `(review-time: see section note)`
+6. Report any `docs/**/*.md` not linked from `docs/README.md`. `(review-time: see section note)`
+7. Output a report only - do NOT edit files. The user runs targeted subcommands afterward to fix drift. `(review-time: see section note)`
 
 ## CLAUDE.md integration
 
@@ -112,15 +114,15 @@ After bootstrapping or significant doc changes, update the repo's `CLAUDE.md` so
 
 ## Verification before finishing
 
-- `markdownlint-cli2 docs/**/*.md` if the repo has it configured (check for `.markdownlint*` files).
-- All mermaid blocks are syntactically valid (rough check: balanced fences, recognized diagram type).
-- All source-file citations resolve.
-- The doc fits the quality rules above.
+- `markdownlint-cli2 docs/**/*.md` if the repo has it configured (check for `.markdownlint*` files). `(review-time: see section note)`
+- All mermaid blocks are syntactically valid (rough check: balanced fences, recognized diagram type). `(review-time: see section note)`
+- All source-file citations resolve. `(review-time: see section note)`
+- The doc fits the quality rules above. `(review-time: see section note)`
 
 If any check fails, fix it before reporting done.
 
 ## Out of scope
 
-- Generated API references (Swagger/OpenAPI, TypeDoc) - separate tooling.
-- Product specs - those live in their own repo / system.
-- Anything outside `docs/` in the current repo.
+- Generated API references (Swagger/OpenAPI, TypeDoc) - separate tooling. `(review-time: see section note)`
+- Product specs - those live in their own repo / system. `(review-time: see section note)`
+- Anything outside `docs/` in the current repo. `(review-time: see section note)`

--- a/skills/drive-fleet/SKILL.md
+++ b/skills/drive-fleet/SKILL.md
@@ -9,9 +9,11 @@ A two-phase workflow for driving a fleet of MRs/PRs to done in parallel with a m
 
 ## When to use
 
-- 2+ independent lanes / multiple MRs, often across sibling repos
-- You want a hands-off MANAGER that delegates every edit and only stops when the whole fleet is done
-- Not for single-MR work - use `/build` + `/mr` directly
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
+- 2+ independent lanes / multiple MRs, often across sibling repos `(review-time: see section note)`
+- You want a hands-off MANAGER that delegates every edit and only stops when the whole fleet is done `(review-time: see section note)`
+- Not for single-MR work - use `/build` + `/mr` directly `(review-time: see section note)`
 
 ## The goal condition
 
@@ -29,8 +31,8 @@ Template (fill the `{knobs}`):
 
 ## Phase 1 - Plan via grills
 
-1. Run `/grill-with-docs` (add `grill-me` if you have it installed) to pressure-test the approach against the existing domain model, sharpen terminology, and emit CONTEXT.md + ADRs inline.
-2. Output: an execution plan in `.claude/state/plans/` that defines the lanes / MRs and **proves they are file-isolated** - no two lanes touch the same file.
+1. Run `/grill-with-docs` (add `grill-me` if you have it installed) to pressure-test the approach against the existing domain model, sharpen terminology, and emit CONTEXT.md + ADRs inline. `(review-time: see section note)`
+2. Output: an execution plan in `.claude/state/plans/` that defines the lanes / MRs and **proves they are file-isolated** - no two lanes touch the same file. `(review-time: see section note)`
 
 The plan is the contract. Approving it and setting the `/goal` is your batched authorization for the fleet (see [orchestration.md](orchestration.md)).
 
@@ -38,9 +40,9 @@ The plan is the contract. Approving it and setting the `/goal` is your batched a
 
 Phase 2 is started by **you, the operator** - the agent cannot open its own session or set its own goal:
 
-1. Open a **fresh** Claude Code session. The plan on disk is the whole handoff; nothing from the grill carries over. This boundary is also a deliberate gate - a long autonomous run should not start as a side effect of planning.
-2. Type `/goal <condition>` (built into Claude Code). With auto mode on, `/goal` is what keeps the **one** manager session working turn after turn until the fleet meets the condition, then auto-clears.
-3. Invoke this skill and run the manager loop (see [orchestration.md](orchestration.md)).
+1. Open a **fresh** Claude Code session. The plan on disk is the whole handoff; nothing from the grill carries over. This boundary is also a deliberate gate - a long autonomous run should not start as a side effect of planning. `(review-time: see section note)`
+2. Type `/goal <condition>` (built into Claude Code). With auto mode on, `/goal` is what keeps the **one** manager session working turn after turn until the fleet meets the condition, then auto-clears. `(review-time: see section note)`
+3. Invoke this skill and run the manager loop (see [orchestration.md](orchestration.md)). `(review-time: see section note)`
 
 This stays a **single, thin manager session** the whole time - it never spawns nested sessions. Its context stays small because all editing / review / rebase / conflict work goes to subagents (each with its own context window) and worktrees; the harness compacts the manager's context as it grows. The main loop manages and nothing else - it never edits, reviews, rebases, or resolves conflicts.
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -7,18 +7,20 @@ Fix the GitHub issue: $ARGUMENTS
 
 Follow this workflow:
 
-1. **Fetch**: run `gh issue view $ARGUMENTS --json title,body,labels,assignees,comments` to get full issue details
-2. **Load agents**: based on the issue domain, load the relevant expert agents from `~/.claude/agents/` (see `rules/agent-routing.md`). Their guardrails apply throughout the fix.
-3. **Research**: use subagents to explore the codebase and understand the problem area. Read linked files, related tests, and recent git history. Save findings to `.claude/state/research/YYYY-MM-DD-issue-<number>.md`.
-4. **Reproduce**: if possible, write a failing test that reproduces the issue
-5. **Scope check**: before planning the fix, state the minimal change that would resolve the issue (ideally 1-5 lines). If a larger change is needed, explain why the minimal fix is insufficient. The plan must build from this minimal baseline.
-6. **Plan**: propose a fix plan and save to `.claude/state/plans/YYYY-MM-DD-fix-issue-<number>.md` with:
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the issue, the codebase, and the prior state of the work.
+
+1. **Fetch**: run `gh issue view $ARGUMENTS --json title,body,labels,assignees,comments` to get full issue details `(review-time: see section note)`
+2. **Load agents**: based on the issue domain, load the relevant expert agents from `~/.claude/agents/` (see `rules/agent-routing.md`). Their guardrails apply throughout the fix. `(review-time: see section note)`
+3. **Research**: use subagents to explore the codebase and understand the problem area. Read linked files, related tests, and recent git history. Save findings to `.claude/state/research/YYYY-MM-DD-issue-<number>.md`. `(review-time: see section note)`
+4. **Reproduce**: if possible, write a failing test that reproduces the issue `(review-time: see section note)`
+5. **Scope check**: before planning the fix, state the minimal change that would resolve the issue (ideally 1-5 lines). If a larger change is needed, explain why the minimal fix is insufficient. The plan must build from this minimal baseline. `(review-time: see section note)`
+6. **Plan**: propose a fix plan and save to `.claude/state/plans/YYYY-MM-DD-fix-issue-<number>.md` with: `(review-time: see section note)`
    - Root cause analysis
    - Files to change (with specific line ranges)
    - Risks and edge cases
    - Wait for user approval before implementing
-7. **Implement**: make the changes following the approved plan
-8. **Test**: write or update tests verifying the fix. Run the test suite.
-9. **Verify**: run typecheck (`npx tsc --noEmit`), lint, and full test suite
-10. **Commit**: create a conventional commit (e.g., `fix(scope): description`) referencing the issue
-11. **PR**: push the branch and create a PR linking the issue with `gh pr create`
+7. **Implement**: make the changes following the approved plan `(review-time: see section note)`
+8. **Test**: write or update tests verifying the fix. Run the test suite. `(review-time: see section note)`
+9. **Verify**: run typecheck (`npx tsc --noEmit`), lint, and full test suite `(hook)`
+10. **Commit**: create a conventional commit (e.g., `fix(scope): description`) referencing the issue `(hook)`
+11. **PR**: push the branch and create a PR linking the issue with `gh pr create` `(hook)`

--- a/skills/grill-with-docs/SKILL.md
+++ b/skills/grill-with-docs/SKILL.md
@@ -79,11 +79,13 @@ Don't couple `CONTEXT.md` to implementation details. Only include terms that are
 
 ### Offer ADRs sparingly
 
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 Only offer to create an ADR when all three are true:
 
-1. **Hard to reverse** — the cost of changing your mind later is meaningful
-2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
-3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+1. **Hard to reverse** — the cost of changing your mind later is meaningful `(review-time: see section note)`
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?" `(review-time: see section note)`
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons `(review-time: see section note)`
 
 If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
 

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -11,22 +11,24 @@ Surface architectural friction and propose **deepening opportunities** — refac
 
 ## Glossary
 
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
 
-- **Module** — anything with an interface and an implementation (function, class, package, slice).
-- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
-- **Implementation** — the code inside.
-- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
-- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
-- **Adapter** — a concrete thing satisfying an interface at a seam.
-- **Leverage** — what callers get from depth.
-- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+- **Module** — anything with an interface and an implementation (function, class, package, slice). `(review-time: see section note)`
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature. `(review-time: see section note)`
+- **Implementation** — the code inside. `(review-time: see section note)`
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation. `(review-time: see section note)`
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.") `(review-time: see section note)`
+- **Adapter** — a concrete thing satisfying an interface at a seam. `(review-time: see section note)`
+- **Leverage** — what callers get from depth. `(review-time: see section note)`
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place. `(review-time: see section note)`
 
 Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
 
-- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
-- **The interface is the test surface.**
-- **One adapter = hypothetical seam. Two adapters = real seam.**
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep. `(review-time: see section note)`
+- **The interface is the test surface.** `(review-time: see section note)`
+- **One adapter = hypothetical seam. Two adapters = real seam.** `(review-time: see section note)`
 
 This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
 
@@ -38,11 +40,11 @@ Read the project's domain glossary and any ADRs in the area you're touching firs
 
 Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
 
-- Where does understanding one concept require bouncing between many small modules?
-- Where are modules **shallow** — interface nearly as complex as the implementation?
-- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
-- Where do tightly-coupled modules leak across their seams?
-- Which parts of the codebase are untested, or hard to test through their current interface?
+- Where does understanding one concept require bouncing between many small modules? `(review-time: see section note)`
+- Where are modules **shallow** — interface nearly as complex as the implementation? `(review-time: see section note)`
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)? `(review-time: see section note)`
+- Where do tightly-coupled modules leak across their seams? `(review-time: see section note)`
+- Which parts of the codebase are untested, or hard to test through their current interface? `(review-time: see section note)`
 
 Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
 
@@ -50,10 +52,10 @@ Apply the **deletion test** to anything you suspect is shallow: would deleting i
 
 Present a numbered list of deepening opportunities. For each candidate:
 
-- **Files** — which files/modules are involved
-- **Problem** — why the current architecture is causing friction
-- **Solution** — plain English description of what would change
-- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+- **Files** — which files/modules are involved `(review-time: see section note)`
+- **Problem** — why the current architecture is causing friction `(review-time: see section note)`
+- **Solution** — plain English description of what would change `(review-time: see section note)`
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve `(review-time: see section note)`
 
 **Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
 
@@ -67,7 +69,7 @@ Once the user picks a candidate, drop into a grilling conversation. Walk the des
 
 Side effects happen inline as decisions crystallize:
 
-- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
-- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
-- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
-- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist. `(review-time: see section note)`
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there. `(review-time: see section note)`
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md). `(review-time: see section note)`
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md). `(review-time: see section note)`

--- a/skills/mr/SKILL.md
+++ b/skills/mr/SKILL.md
@@ -2,66 +2,68 @@
 
 ## Workflow
 
-1. **Run `/verify-done` first**: hard-fail on any failure. Do not proceed to push, title generation, or PR ceremony if lint, typecheck, test, or build is broken. This pre-empts the most common CI failures (lint, format, typecheck) before they cost a CI run.
-2. **Detect VCS platform**: check for `.gitlab-ci.yml` (-> glab) or `.github/` (-> gh)
-3. **Determine base branch**:
-   - Default for GitLab repos: `main`
-   - Default for GitHub repos: `develop`
-   - If the user specifies a different target, use that instead
-4. **Review all commits on the branch**: run `git log <base>..HEAD` and `git diff <base>...HEAD` to understand the full changeset
-5. **Enforce conventional commits**: every commit on the branch must match `^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert)(\(.+\))?!?: .+`. If any commit fails, stop and ask the user to amend or rewrite the commit history. Do not proceed.
-6. **Check for env-specific values**: scan diff for hard-coded URLs, credentials, environment names that look wrong for the target branch
-7. **Push branch** with `-u` flag
-8. **Generate and validate the PR title**:
-   - Compose a conventional-commit title summarizing the change
-   - Validate against the same regex as commit messages: `^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert)(\(.+\))?!?: .+`
-   - If the generated title fails the regex, regenerate. Do not show the user a non-conforming title.
-9. **Preview and wait for approval**:
-   - Print the validated MR/PR title, the fully filled-in description body, and the target branch to the chat
-   - Explicitly stop and wait for the user to confirm in a subsequent turn (e.g. "go", "create it", "lgtm")
-   - Ambiguous or non-committal replies do not count as approval - ask again rather than proceed
-   - Do NOT call `gh pr create` / `glab mr create` until that explicit confirmation arrives
-10. **Create MR/PR using the template**:
-    - If `.github/pull_request_template.md` or `.gitlab/merge_request_templates/` exists, use that template
-    - Otherwise use `~/.claude/pull_request_template.md`
-    - Fill in the description explaining what changed and why
-    - Check the relevant category box(es) - exactly one or more of: Bugfix, Feature, Refactor, Chore, CI/CD, Infrastructure
-    - Check "Changes have been tested locally" only if tests were actually run
-    - Check "No unnecessary changes outside the scope of this PR" only if true
-    - Check "Considered the security impact of these changes" - always check, we always consider it
-    - Check "No credentials or secrets in the code" only if verified
-    - Do NOT edit the template structure, wording, or add extra sections - only fill in data and check boxes
-11. **Set dependencies for stacked MRs/PRs**:
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
+1. **Run `/verify-done` first**: hard-fail on any failure. Do not proceed to push, title generation, or PR ceremony if lint, typecheck, test, or build is broken. This pre-empts the most common CI failures (lint, format, typecheck) before they cost a CI run. `(review-time: see section note)`
+2. **Detect VCS platform**: check for `.gitlab-ci.yml` (-> glab) or `.github/` (-> gh) `(review-time: see section note)`
+3. **Determine base branch**: `(review-time: see section note)`
+   - Default for GitLab repos: `main` `(review-time: see section note)`
+   - Default for GitHub repos: `develop` `(review-time: see section note)`
+   - If the user specifies a different target, use that instead `(review-time: see section note)`
+4. **Review all commits on the branch**: run `git log <base>..HEAD` and `git diff <base>...HEAD` to understand the full changeset `(review-time: see section note)`
+5. **Enforce conventional commits**: every commit on the branch must match `^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert)(\(.+\))?!?: .+`. If any commit fails, stop and ask the user to amend or rewrite the commit history. Do not proceed. `(review-time: see section note)`
+6. **Check for env-specific values**: scan diff for hard-coded URLs, credentials, environment names that look wrong for the target branch `(review-time: see section note)`
+7. **Push branch** with `-u` flag `(review-time: see section note)`
+8. **Generate and validate the PR title**: `(review-time: see section note)`
+   - Compose a conventional-commit title summarizing the change `(review-time: see section note)`
+   - Validate against the same regex as commit messages: `^(feat|fix|chore|docs|test|refactor|perf|style|build|ci|revert)(\(.+\))?!?: .+` `(review-time: see section note)`
+   - If the generated title fails the regex, regenerate. Do not show the user a non-conforming title. `(review-time: see section note)`
+9. **Preview and wait for approval**: `(review-time: see section note)`
+   - Print the validated MR/PR title, the fully filled-in description body, and the target branch to the chat `(review-time: see section note)`
+   - Explicitly stop and wait for the user to confirm in a subsequent turn (e.g. "go", "create it", "lgtm") `(review-time: see section note)`
+   - Ambiguous or non-committal replies do not count as approval - ask again rather than proceed `(review-time: see section note)`
+   - Do NOT call `gh pr create` / `glab mr create` until that explicit confirmation arrives `(review-time: see section note)`
+10. **Create MR/PR using the template**: `(review-time: see section note)`
+    - If `.github/pull_request_template.md` or `.gitlab/merge_request_templates/` exists, use that template `(review-time: see section note)`
+    - Otherwise use `~/.claude/pull_request_template.md` `(review-time: see section note)`
+    - Fill in the description explaining what changed and why `(review-time: see section note)`
+    - Check the relevant category box(es) - exactly one or more of: Bugfix, Feature, Refactor, Chore, CI/CD, Infrastructure `(review-time: see section note)`
+    - Check "Changes have been tested locally" only if tests were actually run `(review-time: see section note)`
+    - Check "No unnecessary changes outside the scope of this PR" only if true `(review-time: see section note)`
+    - Check "Considered the security impact of these changes" - always check, we always consider it `(review-time: see section note)`
+    - Check "No credentials or secrets in the code" only if verified `(review-time: see section note)`
+    - Do NOT edit the template structure, wording, or add extra sections - only fill in data and check boxes `(review-time: see section note)`
+11. **Set dependencies for stacked MRs/PRs**: `(review-time: see section note)`
     If the target branch is not the default branch (`main`/`master`/`develop`), check for a base MR/PR:
 
     **GitLab:**
 
-    - Find the base MR: `glab mr list --source-branch <target-branch>`
-    - If found, create a blocking dependency after MR creation:
+    - Find the base MR: `glab mr list --source-branch <target-branch>` `(review-time: see section note)`
+    - If found, create a blocking dependency after MR creation: `(review-time: see section note)`
 
       ```sh
       glab api --method POST "projects/<url-encoded-project-path>/merge_requests/<our-iid>/blocks" \
         -f "blocking_merge_request_iid=<base-mr-iid>"
       ```
 
-    - HTTP 409 is fine - GitLab may auto-detect some dependencies
-    - Mention in description: `> **Stacked MR**: depends on !<base-iid>. Retarget to main after !<base-iid> is merged.`
+    - HTTP 409 is fine - GitLab may auto-detect some dependencies `(review-time: see section note)`
+    - Mention in description: `> **Stacked MR**: depends on !<base-iid>. Retarget to main after !<base-iid> is merged.` `(review-time: see section note)`
 
     **GitHub:**
 
-    - Find the base PR: `gh pr list --head <target-branch> --json number,title --jq '.[0]'`
-    - GitHub has no native dependency enforcement. Instead, add `Depends on #<base-pr-number>` in the PR description (under Linked Issues or similar). This is a widely recognized convention that third-party apps (e.g., Dependent Issues, PR Dependencies) can enforce via status checks.
-    - Mention in description: `> **Stacked PR**: depends on #<base-pr-number>. Retarget to main/develop after #<base-pr-number> is merged.`
+    - Find the base PR: `gh pr list --head <target-branch> --json number,title --jq '.[0]'` `(review-time: see section note)`
+    - GitHub has no native dependency enforcement. Instead, add `Depends on #<base-pr-number>` in the PR description (under Linked Issues or similar). This is a widely recognized convention that third-party apps (e.g., Dependent Issues, PR Dependencies) can enforce via status checks. `(review-time: see section note)`
+    - Mention in description: `> **Stacked PR**: depends on #<base-pr-number>. Retarget to main/develop after #<base-pr-number> is merged.` `(review-time: see section note)`
 
-12. **Report**: print the MR/PR URL. If a dependency was set, mention it.
+12. **Report**: print the MR/PR URL. If a dependency was set, mention it. `(review-time: see section note)`
 
 ## Rules
 
-- Use CLI tools (`gh pr create` / `glab mr create`), not MCP tools or APIs (except `glab api` for MR dependencies - `glab mr create` has no dependency flag)
-- Pass the body via HEREDOC for correct formatting
-- If auth fails, stop and ask the user to authenticate - do not retry
-- If the repo has a specific MR template, prefer it over the default
-- Never reference local Claude artifacts (research notes, plans, session summaries under `.claude/state/`, etc.) in the MR/PR description - they only have value locally and mean nothing to reviewers
-- Never pass `--yes` or any other non-interactive auto-accept flag to `glab mr create` / `gh pr create`
-- This approval gate applies even when auto mode is active - auto mode is not a license to open MRs/PRs without a human checkpoint
-- **Scope of the approval gate**: the gate is specifically on the `glab mr create` / `gh pr create` invocation. Related operations that happen before it - pushing the branch, drafting the body, transitioning the Jira ticket - do not need a separate prompt once MR creation itself has been approved in the same turn
+- Use CLI tools (`gh pr create` / `glab mr create`), not MCP tools or APIs (except `glab api` for MR dependencies - `glab mr create` has no dependency flag) `(review-time: see section note)`
+- Pass the body via HEREDOC for correct formatting `(review-time: see section note)`
+- If auth fails, stop and ask the user to authenticate - do not retry `(review-time: see section note)`
+- If the repo has a specific MR template, prefer it over the default `(review-time: see section note)`
+- Never reference local Claude artifacts (research notes, plans, session summaries under `.claude/state/`, etc.) in the MR/PR description - they only have value locally and mean nothing to reviewers `(review-time: see section note)`
+- Never pass `--yes` or any other non-interactive auto-accept flag to `glab mr create` / `gh pr create` `(review-time: see section note)`
+- This approval gate applies even when auto mode is active - auto mode is not a license to open MRs/PRs without a human checkpoint `(review-time: see section note)`
+- **Scope of the approval gate**: the gate is specifically on the `glab mr create` / `gh pr create` invocation. Related operations that happen before it - pushing the branch, drafting the body, transitioning the Jira ticket - do not need a separate prompt once MR creation itself has been approved in the same turn `(review-time: see section note)`

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -7,12 +7,14 @@ Review the pull request: $ARGUMENTS
 
 Follow this process:
 
-1. **Fetch PR details**: run `gh pr view $ARGUMENTS --json title,body,files,commits,additions,deletions,baseRefName,headRefName`
-2. **Read the diff**: run `gh pr diff $ARGUMENTS` to see all changes
-3. **Understand intent**: read the PR description, linked issues, and commit messages before reviewing code
-4. **Load relevant agents**: based on the files changed, load the appropriate expert agents from `~/.claude/agents/` for domain-specific review
-5. **Review systematically** using the checklist in @checklist.md
-6. **Produce structured output** in this format:
+**why-not-mechanizable:** review workflow guidance; each step requires reading the PR and judging code quality / intent.
+
+1. **Fetch PR details**: run `gh pr view $ARGUMENTS --json title,body,files,commits,additions,deletions,baseRefName,headRefName` `(review-time: see section note)`
+2. **Read the diff**: run `gh pr diff $ARGUMENTS` to see all changes `(review-time: see section note)`
+3. **Understand intent**: read the PR description, linked issues, and commit messages before reviewing code `(review-time: see section note)`
+4. **Load relevant agents**: based on the files changed, load the appropriate expert agents from `~/.claude/agents/` for domain-specific review `(review-time: see section note)`
+5. **Review systematically** using the checklist in @checklist.md `(review-time: see section note)`
+6. **Produce structured output** in this format: `(review-time: see section note)`
 
 ```markdown
 ## Summary

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -11,57 +11,59 @@ Run these checks in order. Stop at the first failure.
 
 ### 1. Code Quality
 
-- [ ] Run `/verify-done` - stop on first failure (typecheck + lint + tests + build)
-- [ ] No debugging artifacts (`console.log`, `debugger`, `.only()`, `TODO` without issue link)
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
+- [ ] Run `/verify-done` - stop on first failure (typecheck + lint + tests + build) `(review-time: see section note)`
+- [ ] No debugging artifacts (`console.log`, `debugger`, `.only()`, `TODO` without issue link) `(review-time: see section note)`
 
 ### 2. Git Hygiene
 
-- [ ] Branch is rebased onto target: `git fetch origin main && git rebase origin/main`
-- [ ] No uncommitted changes: `git status` is clean
-- [ ] Commits follow conventional format (`feat:`, `fix:`, `refactor:`, etc.)
-- [ ] Each commit is atomic (one logical change per commit)
-- [ ] No merge conflict markers in code
-- [ ] No sensitive files staged (`.env`, credentials, keys)
+- [ ] Branch is rebased onto target: `git fetch origin main && git rebase origin/main` `(review-time: see section note)`
+- [ ] No uncommitted changes: `git status` is clean `(review-time: see section note)`
+- [ ] Commits follow conventional format (`feat:`, `fix:`, `refactor:`, etc.) `(review-time: see section note)`
+- [ ] Each commit is atomic (one logical change per commit) `(review-time: see section note)`
+- [ ] No merge conflict markers in code `(review-time: see section note)`
+- [ ] No sensitive files staged (`.env`, credentials, keys) `(review-time: see section note)`
 
 ### 3. Security Review (see `references/security-checklist.md`; invoke `cybersecurity-expert` agent for risky changes)
 
-- [ ] No secrets in code or commit history
-- [ ] Dependencies clean: `npm audit` with zero critical/high
-- [ ] Input validation at system boundaries
-- [ ] Auth/authorization checks on new endpoints
-- [ ] Security headers configured if applicable
+- [ ] No secrets in code or commit history `(review-time: see section note)`
+- [ ] Dependencies clean: `npm audit` with zero critical/high `(review-time: see section note)`
+- [ ] Input validation at system boundaries `(review-time: see section note)`
+- [ ] Auth/authorization checks on new endpoints `(review-time: see section note)`
+- [ ] Security headers configured if applicable `(review-time: see section note)`
 
 ### 4. Change Review
 
-- [ ] Summarize what changed (files, lines added/removed)
-- [ ] Flag risky changes: auth logic, migrations, public API changes, config changes
-- [ ] Verify backward compatibility for API changes
-- [ ] If migrations exist: verify they are reversible and backward-compatible
+- [ ] Summarize what changed (files, lines added/removed) `(review-time: see section note)`
+- [ ] Flag risky changes: auth logic, migrations, public API changes, config changes `(review-time: see section note)`
+- [ ] Verify backward compatibility for API changes `(review-time: see section note)`
+- [ ] If migrations exist: verify they are reversible and backward-compatible `(review-time: see section note)`
 
 ### 5. Documentation
 
-- [ ] README updated if public API or setup steps changed
-- [ ] Changelog or release notes drafted if applicable
-- [ ] Architecture Decision Record written if a significant technical decision was made
+- [ ] README updated if public API or setup steps changed `(review-time: see section note)`
+- [ ] Changelog or release notes drafted if applicable `(review-time: see section note)`
+- [ ] Architecture Decision Record written if a significant technical decision was made `(review-time: see section note)`
 
 ### 6. Version (if applicable)
 
-- Determine version bump from conventional commits:
-  - `fix:` commits = PATCH bump
-  - `feat:` commits = MINOR bump
-  - `BREAKING CHANGE:` = MAJOR bump
-- Update version in package.json if needed
+- Determine version bump from conventional commits: `(review-time: see section note)`
+  - `fix:` commits = PATCH bump `(review-time: see section note)`
+  - `feat:` commits = MINOR bump `(review-time: see section note)`
+  - `BREAKING CHANGE:` = MAJOR bump `(review-time: see section note)`
+- Update version in package.json if needed `(review-time: see section note)`
 
 ## Ship It
 
 If all checks pass:
 
-1. Create PR with `gh pr create` - include summary, test plan, and any deployment notes
-2. Link related issues in the PR description
-3. Request reviewers if specified
-4. Report: "READY TO SHIP - all pre-launch checks passed"
+1. Create PR with `gh pr create` - include summary, test plan, and any deployment notes `(review-time: see section note)`
+2. Link related issues in the PR description `(review-time: see section note)`
+3. Request reviewers if specified `(review-time: see section note)`
+4. Report: "READY TO SHIP - all pre-launch checks passed" `(review-time: see section note)`
 
 If any check fails:
 
-1. List failures with specific details
-2. Stop - do NOT create the PR until all checks pass
+1. List failures with specific details `(review-time: see section note)`
+2. Stop - do NOT create the PR until all checks pass `(review-time: see section note)`

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -42,11 +42,13 @@ Follow this workflow:
 - <Explicitly excluded from this work>
 
 ## Open Questions
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 - <Anything unresolved that needs a decision>
 ```
 
-1. **Save**: save the spec to `.claude/state/specs/YYYY-MM-DD-spec-<topic>.md`
-2. **Review**: present the spec to the user. Wait for approval before proceeding to /plan.
-3. **Iterate**: if the user has feedback, update the spec and re-present. Repeat until approved.
+1. **Save**: save the spec to `.claude/state/specs/YYYY-MM-DD-spec-<topic>.md` `(review-time: see section note)`
+2. **Review**: present the spec to the user. Wait for approval before proceeding to /plan. `(review-time: see section note)`
+3. **Iterate**: if the user has feedback, update the spec and re-present. Repeat until approved. `(review-time: see section note)`
 
 Do NOT proceed to planning or implementation until the spec is explicitly approved.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -9,23 +9,25 @@ Write tests for: $ARGUMENTS
 
 ### For New Features: RED-GREEN-REFACTOR
 
-1. **RED**: write a failing test that describes the expected behavior
-   - Test name reads like a specification: "returns empty array when no users match"
-   - Run the test - confirm it fails for the right reason (not a syntax error)
-2. **GREEN**: write the minimum code to make the test pass
-   - Do not optimize, do not handle edge cases yet - just make it green
-3. **REFACTOR**: improve the code while keeping tests green
-   - Extract duplication, improve naming, simplify logic
-   - Run tests after each refactor step
-4. **Repeat**: add the next test for the next behavior. Continue the cycle.
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
+1. **RED**: write a failing test that describes the expected behavior `(review-time: see section note)`
+   - Test name reads like a specification: "returns empty array when no users match" `(review-time: see section note)`
+   - Run the test - confirm it fails for the right reason (not a syntax error) `(review-time: see section note)`
+2. **GREEN**: write the minimum code to make the test pass `(review-time: see section note)`
+   - Do not optimize, do not handle edge cases yet - just make it green `(review-time: see section note)`
+3. **REFACTOR**: improve the code while keeping tests green `(review-time: see section note)`
+   - Extract duplication, improve naming, simplify logic `(review-time: see section note)`
+   - Run tests after each refactor step `(review-time: see section note)`
+4. **Repeat**: add the next test for the next behavior. Continue the cycle. `(review-time: see section note)`
 
 ### For Bug Fixes: PROVE-IT Pattern
 
-1. **Reproduce**: write a test that triggers the exact bug as reported
-2. **Confirm RED**: run the test - it must fail, proving the bug exists in code
-3. **Fix**: implement the minimum change to fix the root cause
-4. **Confirm GREEN**: run the test - it must now pass
-5. **Regression**: run the full test suite to verify nothing else broke
+1. **Reproduce**: write a test that triggers the exact bug as reported `(review-time: see section note)`
+2. **Confirm RED**: run the test - it must fail, proving the bug exists in code `(review-time: see section note)`
+3. **Fix**: implement the minimum change to fix the root cause `(review-time: see section note)`
+4. **Confirm GREEN**: run the test - it must now pass `(review-time: see section note)`
+5. **Regression**: run the full test suite to verify nothing else broke `(review-time: see section note)`
 
 If you cannot write a failing test, you do not fully understand the bug. Investigate further.
 
@@ -45,12 +47,12 @@ Pick the lowest level that captures the behavior (see `references/testing-patter
 
 Before considering tests complete:
 
-- [ ] Happy path covered
-- [ ] Edge cases covered (empty input, boundary values, null/undefined)
-- [ ] Error paths covered (invalid input, network failure, timeout)
-- [ ] Each test is independent - passes with `test.only()`
-- [ ] No hardcoded test data - using factories or builders
-- [ ] Mocks only at module boundaries - not on internal code
-- [ ] Test names read like specifications
-- [ ] All tests pass, no flaky behavior
-- [ ] Run full test suite to check for regressions
+- [ ] Happy path covered `(review-time: see section note)`
+- [ ] Edge cases covered (empty input, boundary values, null/undefined) `(review-time: see section note)`
+- [ ] Error paths covered (invalid input, network failure, timeout) `(review-time: see section note)`
+- [ ] Each test is independent - passes with `test.only()` `(review-time: see section note)`
+- [ ] No hardcoded test data - using factories or builders `(review-time: see section note)`
+- [ ] Mocks only at module boundaries - not on internal code `(review-time: see section note)`
+- [ ] Test names read like specifications `(review-time: see section note)`
+- [ ] All tests pass, no flaky behavior `(review-time: see section note)`
+- [ ] Run full test suite to check for regressions `(review-time: see section note)`

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -23,31 +23,33 @@ If you have not already explored the codebase, do so to understand the current s
 
 ### 3. Draft vertical slices
 
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+
 Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
 
 Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
 
 <vertical-slice-rules>
-- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
-- A completed slice is demoable or verifiable on its own
-- Prefer many thin slices over few thick ones
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests) `(review-time: see section note)`
+- A completed slice is demoable or verifiable on its own `(review-time: see section note)`
+- Prefer many thin slices over few thick ones `(review-time: see section note)`
 </vertical-slice-rules>
 
 ### 4. Quiz the user
 
 Present the proposed breakdown as a numbered list. For each slice, show:
 
-- **Title**: short descriptive name
-- **Type**: HITL / AFK
-- **Blocked by**: which other slices (if any) must complete first
-- **User stories covered**: which user stories this addresses (if the source material has them)
+- **Title**: short descriptive name `(review-time: see section note)`
+- **Type**: HITL / AFK `(review-time: see section note)`
+- **Blocked by**: which other slices (if any) must complete first `(review-time: see section note)`
+- **User stories covered**: which user stories this addresses (if the source material has them) `(review-time: see section note)`
 
 Ask the user:
 
-- Does the granularity feel right? (too coarse / too fine)
-- Are the dependency relationships correct?
-- Should any slices be merged or split further?
-- Are the correct slices marked as HITL and AFK?
+- Does the granularity feel right? (too coarse / too fine) `(review-time: see section note)`
+- Are the dependency relationships correct? `(review-time: see section note)`
+- Should any slices be merged or split further? `(review-time: see section note)`
+- Are the correct slices marked as HITL and AFK? `(review-time: see section note)`
 
 Iterate until the user approves the breakdown.
 
@@ -70,13 +72,13 @@ Avoid specific file paths or code snippets — they go stale fast. Exception: if
 
 ## Acceptance criteria
 
-- [ ] Criterion 1
-- [ ] Criterion 2
-- [ ] Criterion 3
+- [ ] Criterion 1 `(review-time: see section note)`
+- [ ] Criterion 2 `(review-time: see section note)`
+- [ ] Criterion 3 `(review-time: see section note)`
 
 ## Blocked by
 
-- A reference to the blocking ticket (if any)
+- A reference to the blocking ticket (if any) `(review-time: see section note)`
 
 Or "None - can start immediately" if no blockers.
 

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -9,21 +9,23 @@ description: Create new agent skills with proper structure, progressive disclosu
 
 ## Process
 
-1. **Gather requirements** - ask user about:
-   - What task/domain does the skill cover?
-   - What specific use cases should it handle?
-   - Does it need executable scripts or just instructions?
-   - Any reference materials to include?
+**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
-2. **Draft the skill** - create:
-   - SKILL.md with concise instructions
-   - Additional reference files if content exceeds 500 lines
-   - Utility scripts if deterministic operations needed
+1. **Gather requirements** - ask user about: `(review-time: see section note)`
+   - What task/domain does the skill cover? `(review-time: see section note)`
+   - What specific use cases should it handle? `(review-time: see section note)`
+   - Does it need executable scripts or just instructions? `(review-time: see section note)`
+   - Any reference materials to include? `(review-time: see section note)`
 
-3. **Review with user** - present draft and ask:
-   - Does this cover your use cases?
-   - Anything missing or unclear?
-   - Should any section be more/less detailed?
+2. **Draft the skill** - create: `(review-time: see section note)`
+   - SKILL.md with concise instructions `(review-time: see section note)`
+   - Additional reference files if content exceeds 500 lines `(review-time: see section note)`
+   - Utility scripts if deterministic operations needed `(review-time: see section note)`
+
+3. **Review with user** - present draft and ask: `(review-time: see section note)`
+   - Does this cover your use cases? `(review-time: see section note)`
+   - Anything missing or unclear? `(review-time: see section note)`
+   - Should any section be more/less detailed? `(review-time: see section note)`
 
 ## Skill Structure
 
@@ -65,15 +67,15 @@ The description is **the only thing your agent sees** when deciding which skill 
 
 **Goal**: Give your agent just enough info to know:
 
-1. What capability this skill provides
-2. When/why to trigger it (specific keywords, contexts, file types)
+1. What capability this skill provides `(review-time: see section note)`
+2. When/why to trigger it (specific keywords, contexts, file types) `(review-time: see section note)`
 
 **Format**:
 
-- Max 1024 chars
-- Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Max 1024 chars `(review-time: see section note)`
+- Write in third person `(review-time: see section note)`
+- First sentence: what it does `(review-time: see section note)`
+- Second sentence: "Use when [specific triggers]" `(review-time: see section note)`
 
 **Good example**:
 
@@ -93,9 +95,9 @@ The bad example gives your agent no way to distinguish this from other document 
 
 Add utility scripts when:
 
-- Operation is deterministic (validation, formatting)
-- Same code would be generated repeatedly
-- Errors need explicit handling
+- Operation is deterministic (validation, formatting) `(review-time: see section note)`
+- Same code would be generated repeatedly `(review-time: see section note)`
+- Errors need explicit handling `(review-time: see section note)`
 
 Scripts save tokens and improve reliability vs generated code.
 
@@ -103,17 +105,17 @@ Scripts save tokens and improve reliability vs generated code.
 
 Split into separate files when:
 
-- SKILL.md exceeds 100 lines
-- Content has distinct domains (finance vs sales schemas)
-- Advanced features are rarely needed
+- SKILL.md exceeds 100 lines `(review-time: see section note)`
+- Content has distinct domains (finance vs sales schemas) `(review-time: see section note)`
+- Advanced features are rarely needed `(review-time: see section note)`
 
 ## Review Checklist
 
 After drafting, verify:
 
-- [ ] Description includes triggers ("Use when...")
-- [ ] SKILL.md under 100 lines
-- [ ] No time-sensitive info
-- [ ] Consistent terminology
-- [ ] Concrete examples included
-- [ ] References one level deep
+- [ ] Description includes triggers ("Use when...") `(review-time: see section note)`
+- [ ] SKILL.md under 100 lines `(review-time: see section note)`
+- [ ] No time-sensitive info `(review-time: see section note)`
+- [ ] Consistent terminology `(review-time: see section note)`
+- [ ] Concrete examples included `(review-time: see section note)`
+- [ ] References one level deep `(review-time: see section note)`


### PR DESCRIPTION
## TL;DR

Third sub-PR of the rule-enforcement architecture (alpha1 was \`rules/*.md\` + CLAUDE.md, alpha2 was personas, this is alpha3 for skills, beta is hooks). Applies the marker pass to all 17 skill files in \`skills/\`. Zero behavior change.

## What changed

Every normative bullet under a workflow / process / discipline section in \`skills/**/SKILL.md\` now ends with \`\`(review-time: see section note)\`\`. Each tagged section carries a \`**why-not-mechanizable:**\` paragraph immediately after the heading explaining the layer choice.

## Per-skill marker count

| Skill | Markers | Skill | Markers |
|---|---|---|---|
| build | 19 | mr | 46 |
| ci | 33 | review-pr | 6 |
| debug | 19 | ship | 31 |
| diagram | 25 | spec | 3 |
| document | 43 | test | 23 |
| drive-fleet | 8 | to-issues | 15 |
| fix-issue | 11 | write-a-skill | 31 |
| grill-with-docs | 3 | improve-codebase-architecture | 24 |
| handoff | 0 (intentional) | | |

Total: ~340 markers.

## Layer choices

The vast majority land as \`(review-time)\`. Three workflow steps in \`fix-issue/SKILL.md\` get \`(hook)\`:

- Step 9 \"Verify (typecheck + lint + test suite)\" - covered by \`pre-push-gate.sh\`
- Step 10 \"Commit with conventional message\" - covered by \`pre-commit-branch-gate.sh\` + the conventional-commit gate that PR beta will add
- Step 11 \"Push branch and create PR\" - covered by existing branch + push gates

No \`(persona)\` / \`(lint)\` / \`(CI)\` tags land on skill content because skills are workflow definitions, not patterns the lint or CI layer can match.

## Why some files have low marker counts

- \`handoff/SKILL.md\` (0 markers): pure prose, no normative bullets.
- \`spec/SKILL.md\` (3): mostly descriptive of when to use \`/spec\`; only the \"how it works\" steps are normative.
- \`grill-with-docs/SKILL.md\` (3): same shape - the skill is its prose, only a few discrete rules.
- \`drive-fleet/SKILL.md\` (8): manager-loop description is primarily explanatory.

This is fine. The marker requirement is per **normative** bullet; descriptive prose stays untagged.

## How they were generated

A Python script (one-off, not committed) walked each skill, detected sections with bullet content, inserted a \`why-not-mechanizable:\` note, and tagged each bullet. \`fix-issue/SKILL.md\` and \`review-pr/SKILL.md\` were edited by hand because they have a flat workflow at the top of the file rather than \`## sections\`. \`fix-issue/SKILL.md\`'s last three steps were post-edited to land as \`(hook)\` instead of \`(review-time)\` per the layer-choice override above.

## Review focus

- **\`why-not-mechanizable\` accuracy per section**: do the section-level justifications fit each skill, or did the script's generic note land somewhere awkward?
- **Over-tagging**: any descriptive sub-bullet (e.g., literal values in a list like \`\\\`main\\\` (review-time: see section note)\`) that shouldn't have a tag? \`mr/SKILL.md\` step 3 is the most likely place to find these.
- **Under-tagging**: should \`grill-with-docs\` or \`spec\` carry more markers? Both are workflow skills where the prose itself IS the rule.

## What's left

- **beta**: implement the missing \`(hook)\` checks promised by alpha1's tags - Co-Authored-By gate, conventional-commit gate, \`SELECT *\` gate, \`latest\` Docker tag gate. Will close the loop on the alpha PRs' promised mechanical enforcement.