### PR TITLE
feat(hooks): add Co-Authored-By, conventional-commit, SELECT *, :latest gates (beta)

### DIFF
--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -125,6 +125,32 @@ $TODOS
 "
 fi
 
+# --- 8. SELECT * in SQL files (rules/database.md: explicitly list columns) ---
+case "$FILE" in
+  *.sql)
+    SELECT_STAR=$(echo "$ADDED" | grep -niE '\bselect[[:space:]]+\*' 2>/dev/null || true)
+    if [ -n "$SELECT_STAR" ]; then
+      VIOLATIONS+="\`SELECT *\` detected. rules/database.md: list columns explicitly. Catalog the columns you actually need:
+$SELECT_STAR
+
+"
+    fi
+    ;;
+esac
+
+# --- 9. `:latest` Docker tag in Dockerfile / compose / k8s (rules/infrastructure.md) ---
+case "$FILE" in
+  *Dockerfile*|*docker-compose*.y*ml|*compose.y*ml|*/k8s/*.y*ml|*/k8s/*.yaml)
+    LATEST_TAG=$(echo "$ADDED" | grep -nE '^[[:space:]]*(FROM[[:space:]]+[^:[:space:]]+:latest\b|image:[[:space:]]*[^:[:space:]]+:latest\b)' 2>/dev/null || true)
+    if [ -n "$LATEST_TAG" ]; then
+      VIOLATIONS+="\`:latest\` Docker tag detected. rules/infrastructure.md: pin a specific version so the build is reproducible:
+$LATEST_TAG
+
+"
+    fi
+    ;;
+esac
+
 if [ -n "$VIOLATIONS" ]; then
   echo "[post-edit-lint] $FILE" >&2
   echo "$VIOLATIONS" >&2

--- a/hooks/pre-commit-coauthor-gate.sh
+++ b/hooks/pre-commit-coauthor-gate.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Pre-commit Co-Authored-By gate.
+# PreToolUse hook on Bash(git commit *). Blocks the commit when the command
+# string contains a Co-Authored-By trailer in any case. Per
+# rules/git-conventions.md: never add Co-Authored-By or any AI attribution.
+# Exit 2 blocks the action and feeds the message back to Claude.
+# Bypass with SKIP_COAUTHOR_GATE=1.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+case "$COMMAND" in
+  *"git commit --help"*|*"git commit -h"*) exit 0 ;;
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+[ "$SKIP_COAUTHOR_GATE" = "1" ] && exit 0
+
+# Match Co-Authored-By in any case anywhere in the command (covers -m, heredocs,
+# and -F file paths whose name might leak the trailer, though that's edge-case).
+if echo "$COMMAND" | grep -qiE '\bco-authored-by:'; then
+  echo "[pre-commit-coauthor-gate] Refusing to commit with Co-Authored-By trailer." >&2
+  echo "Per rules/git-conventions.md, never add Co-Authored-By or any AI attribution to commits." >&2
+  echo "Remove the trailer from the commit message and re-run." >&2
+  echo "(Bypass: SKIP_COAUTHOR_GATE=1)" >&2
+  exit 2
+fi
+
+exit 0

--- a/hooks/pre-commit-conventional-gate.sh
+++ b/hooks/pre-commit-conventional-gate.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Pre-commit conventional-commit format gate.
+# PreToolUse hook on Bash(git commit *). Extracts the subject line from the
+# commit command and checks it against the conventional-commits regex from
+# rules/git-conventions.md.
+#
+# Skips amend / fixup / squash / no-edit (auto-generated messages or reusing
+# existing) and Merge / Revert subjects (git auto-generated).
+#
+# Bypass with SKIP_CONVENTIONAL_GATE=1.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+case "$COMMAND" in
+  *"git commit --help"*|*"git commit -h"*) exit 0 ;;
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+[ "$SKIP_CONVENTIONAL_GATE" = "1" ] && exit 0
+
+# Auto-generated message paths - skip.
+if echo "$COMMAND" | grep -qE -- '(--amend|--fixup=|--squash=|--no-edit|-C[[:space:]]+|--reuse-message=)'; then
+  exit 0
+fi
+
+SUBJECT=$(printf '%s' "$COMMAND" | python3 -c '
+import sys, re
+
+cmd = sys.stdin.read()
+
+# Prefer heredoc when the command uses one - it carries the structured message.
+heredoc_re = re.compile(r"<<-?[\047\"]?(\w+)[\047\"]?")
+m = heredoc_re.search(cmd)
+if m:
+    delim = m.group(1)
+    after = cmd[m.end():]
+    # Drop everything up to and including the first newline after the opener.
+    nl = after.find("\n")
+    if nl != -1:
+        body = after[nl + 1:]
+        for line in body.split("\n"):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == delim:
+                break
+            print(stripped)
+            sys.exit(0)
+
+# Fall back to the first -m / --message value.
+m_re = re.search(r"(?:-m|--message)[=\s]+[\047\"]([^\047\"]+)[\047\"]", cmd)
+if m_re:
+    print(m_re.group(1).splitlines()[0])
+    sys.exit(0)
+' 2>/dev/null)
+
+# Could not extract a subject - let it through; not our concern to second-guess.
+[ -z "$SUBJECT" ] && exit 0
+
+# Git auto-generates Merge / Revert subjects on certain operations.
+case "$SUBJECT" in
+  "Merge "*|"Revert "*) exit 0 ;;
+esac
+
+if ! echo "$SUBJECT" | grep -qE '^(feat|fix|refactor|docs|chore|test|ci|perf|build|style|revert)(\([^)]+\))?!?: .+'; then
+  echo "[pre-commit-conventional-gate] Commit subject does not match the conventional-commits format." >&2
+  echo "Subject: $SUBJECT" >&2
+  echo "Expected: <type>(<scope>)?!?: <description>" >&2
+  echo "Allowed types: feat|fix|refactor|docs|chore|test|ci|perf|build|style|revert" >&2
+  echo "Per rules/git-conventions.md." >&2
+  echo "(Bypass: SKIP_CONVENTIONAL_GATE=1)" >&2
+  exit 2
+fi
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -136,6 +136,18 @@
           },
           {
             "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-coauthor-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-coauthor-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "command -v rtk >/dev/null 2>&1 && rtk hook claude || true"
           }
         ]


### PR DESCRIPTION
## TL;DR

Final sub-PR of the rule-enforcement architecture (alpha1 #75, alpha2 #76, alpha3 #77, this is beta). Adds the four \`(hook)\` checks that PR #75's marker pass promised but didn't yet enforce.

## What's new

### \`hooks/pre-commit-coauthor-gate.sh\`

- PreToolUse on \`Bash(git commit *)\`.
- Greps the command string for \`co-authored-by:\` case-insensitively. Catches inline \`-m\`, heredoc bodies, and anywhere the trailer might appear in the command.
- Exit 2 on match. Bypass: \`SKIP_COAUTHOR_GATE=1\`.
- Wired into \`settings.json\` PreToolUse for \`Bash\`.

### \`hooks/pre-commit-conventional-gate.sh\`

- PreToolUse on \`Bash(git commit *)\`.
- Extracts the subject line from the command:
  - Heredoc body (\`<<EOF\`, \`<<'EOF'\`, \`<<-EOF\`): takes the first non-empty line.
  - Plain \`-m \"...\"\` / \`--message=\"...\"\`: takes the first line of the captured string.
- Checks the subject against \`^(feat|fix|refactor|docs|chore|test|ci|perf|build|style|revert)(\\(scope\\))?!?: .+\`.
- Skips: \`--amend\`, \`--fixup=\`, \`--squash=\`, \`--no-edit\`, \`-C\`, \`--reuse-message=\` (auto-generated messages), and Merge / Revert subjects (git auto-generates).
- Exit 2 on mismatch. Bypass: \`SKIP_CONVENTIONAL_GATE=1\`.
- Wired into \`settings.json\` PreToolUse for \`Bash\`.

### \`hooks/post-edit-lint.sh\` check 8 - SELECT *

- Fires on \`*.sql\` files.
- Regex: \`\\bselect\\s+\\*\` case-insensitive on added lines.
- Per \`rules/database.md\`.

### \`hooks/post-edit-lint.sh\` check 9 - \`:latest\` Docker tag

- Fires on \`Dockerfile*\`, \`*docker-compose*.y*ml\`, \`*compose.y*ml\`, \`*/k8s/*.y*ml\`, \`*/k8s/*.yaml\`.
- Regex catches \`FROM image:latest\` and \`image: foo:latest\` patterns at the start of a line.
- Per \`rules/infrastructure.md\`.

## Layer profile after this PR

Every rule that was tagged \`(hook)\` in PR #75 now has a hook backing it.

## Manual testing

12 fixtures, all behaved as expected:

| # | Fixture | Expected | Actual |
|---|---|---|---|
| 1 | Commit with Co-Authored-By trailer | exit 2 | exit 2 |
| 2 | Commit without trailer | exit 0 | exit 0 |
| 3 | \`feat(scope): do thing\` | exit 0 | exit 0 |
| 4 | \`just a message\` | exit 2 | exit 2 |
| 5 | Heredoc with \`fix(api): null check\` subject | exit 0 | exit 0 |
| 6 | \`git commit --amend --no-edit\` | exit 0 (skipped) | exit 0 |
| 7 | \`Merge branch foo into bar\` | exit 0 (skipped) | exit 0 |
| 8 | \`SELECT * FROM users\` | exit 2 | exit 2 |
| 9 | \`SELECT id, name FROM users\` | exit 0 | exit 0 |
| 10 | \`FROM node:latest\` | exit 2 | exit 2 |
| 11 | \`image: pentla:latest\` in compose | exit 2 | exit 2 |
| 12 | \`FROM node:24.6.0-alpine\` | exit 0 | exit 0 |
| (regression) | Consecutive \`//\` lines | exit 2 | exit 2 |

## Wraps up the architecture work

After this lands, the rule-enforcement architecture is complete:

| Slice | PR | What it shipped |
|---|---|---|
| Comment-policy relaxation + var/TODO hooks | #74 | Loosened block-comment rule; added var + TODO hooks. |
| alpha1 - meta-policy + rules marker pass | #75 | New \`rules/rule-authoring.md\`. Marker pass on rules/, CLAUDE.md, RTK.md. |
| alpha2 - persona marker pass | #76 | Marker pass on 16 persona files. |
| alpha3 - skill marker pass | #77 | Marker pass on 17 skill files. |
| beta - missing hook checks | this | Co-Authored-By gate, conventional-commit gate, SELECT *, :latest. |