### PR TITLE
chore: gitignore .claude/state/ in the meta repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Per-session work artifacts (plans, research, specs, session diaries).
+# Per rules/state-persistence.md these live in .claude/state/; in this
+# meta-config repo they are personal notes and do not belong in git
+# history. In domain repos (pentla-api, etc.) the same files are
+# typically committed because plans/specs are shared decisions.
+.claude/state/


### PR DESCRIPTION
Per-session work artifacts (plans, research, specs, session diaries) sit at `.claude/state/` per `rules/state-persistence.md`. In domain repos (pentla-api, etc.) those files are committed because they document shared decisions. In this meta-config repo they're personal notes and don't belong in git history.

Closes the loop on #79 (session diary) without losing the diary text - it'll just sit untracked in the local worktree.