### PR TITLE
feat(hooks): pre-git-state-refresh injects fresh PR state

### DIFF
--- a/hooks/pre-git-state-refresh.sh
+++ b/hooks/pre-git-state-refresh.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Pre-git PR state refresh.
+# Before write-side git/gh commands, probe origin + gh and inject a one-line
+# state block as additionalContext so Claude sees ground truth instead of
+# inferring from stale conversation memory.
+#
+# Triggers (regex on the bash command):
+#   - git push
+#   - git commit (skipped when current branch is main/master)
+#   - gh pr (edit|comment|merge|close|ready|review)
+#
+# Always exit 0. Warn-only; never blocks.
+# Bypass with SKIP_PR_STATE_REFRESH=1.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[ "$SKIP_PR_STATE_REFRESH" = "1" ] && exit 0
+
+# Match trigger commands only. Anything else exits silently.
+case "$COMMAND" in
+  *"git push"*) ;;
+  *"git commit"*) ;;
+  *"gh pr edit"*|*"gh pr comment"*|*"gh pr merge"*) ;;
+  *"gh pr close"*|*"gh pr ready"*|*"gh pr review"*) ;;
+  *) exit 0 ;;
+esac
+
+# --help / -h variants are harmless; skip.
+case "$COMMAND" in
+  *" --help"*|*" -h"*) exit 0 ;;
+esac
+
+emit() {
+  # Inject as additionalContext so Claude sees the state line.
+  jq -n --arg ctx "$1" '{
+    continue: true,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: $ctx
+    }
+  }'
+  exit 0
+}
+
+DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Not in a git repo - nothing to probe.
+if ! git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  emit "[pr-state] unavailable=not-a-repo"
+fi
+
+BRANCH=$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ] && emit "[pr-state] unavailable=detached-head"
+
+# Skip git commit on default branch - the commit-branch-gate already blocks it.
+case "$COMMAND" in
+  *"git commit"*)
+    case "$BRANCH" in
+      main|master) exit 0 ;;
+    esac
+    ;;
+esac
+
+# No remote configured - nothing to fetch / no PR to look up.
+if ! git -C "$DIR" remote get-url origin >/dev/null 2>&1; then
+  emit "[pr-state] branch=$BRANCH unavailable=no-remote"
+fi
+
+# Probe origin and gh. Both errors degrade silently to unavailable.
+git -C "$DIR" fetch --prune origin >/dev/null 2>&1
+PR_JSON=$(gh pr view --json state,mergedAt,headRefName,url 2>/dev/null)
+
+if [ -z "$PR_JSON" ]; then
+  emit "[pr-state] branch=$BRANCH state=NONE (no PR for this branch, or gh unavailable)"
+fi
+
+STATE=$(echo "$PR_JSON" | jq -r '.state // "UNKNOWN"')
+URL=$(echo "$PR_JSON" | jq -r '.url // ""')
+MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt // ""')
+
+LINE="[pr-state] branch=$BRANCH state=$STATE url=$URL"
+[ -n "$MERGED_AT" ] && [ "$MERGED_AT" != "null" ] && LINE="$LINE mergedAt=$MERGED_AT"
+
+# For merged / closed PRs on action commands, append a suggestion so the model
+# pauses and re-evaluates intent.
+case "$STATE" in
+  MERGED)
+    case "$COMMAND" in
+      *"git push"*|*"git commit"*)
+        LINE="$LINE
+SUGGESTION: PR is already merged. If you intended new work, start a fresh branch from the default branch first."
+        ;;
+      *"gh pr edit"*|*"gh pr comment"*|*"gh pr merge"*|*"gh pr close"*|*"gh pr ready"*|*"gh pr review"*)
+        LINE="$LINE
+SUGGESTION: PR is already merged. Confirm with the user before writing to a merged PR."
+        ;;
+    esac
+    ;;
+  CLOSED)
+    LINE="$LINE
+SUGGESTION: PR is closed (not merged). Confirm with the user before acting on it."
+    ;;
+esac
+
+emit "$LINE"

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -21,6 +21,15 @@
 - After pushing new commits to an existing PR, update the PR title and description to reflect all changes - use `gh pr edit` to keep them accurate `(review-time: requires judging "reflects all changes")`
 - If the repo has a PR template (`.github/pull_request_template.md`), use it. If not, use `~/.claude/pull_request_template.md` `(review-time: template selection requires reading directory)`
 
+## PR State Freshness
+
+PR / branch state from earlier in the conversation goes stale. Probe ground truth before acting or claiming.
+
+- Before asserting PR state in a reply (open / merged / closed / checks-passing / "you're all set"), run `gh pr view --json state,mergedAt,statusCheckRollup,url` and base the reply on that output, not on conversation memory `(review-time: requires recognizing a state-claim in the reply)`
+- A probe result is reusable for 5 minutes within the same turn-stream, but only if no state-changing action (`git push`, `gh pr merge`, `gh pr close`, `gh pr ready`, etc.) was taken in between - any such action voids the exemption, re-probe `(review-time: requires tracking probe age and intervening actions)`
+- Write-side `git push` / `git commit` / `gh pr (edit|comment|merge|close|ready|review)` are auto-probed by `hooks/pre-git-state-refresh.sh`, which injects a `[pr-state]` line into the tool context - read that line before deciding the next step `(hook)`
+- If the injected `[pr-state]` line reports `state=MERGED` or `state=CLOSED` for a command that writes to that PR, pause and confirm intent with the user instead of proceeding silently `(review-time: requires reading the injected state line and recognizing intent mismatch)`
+
 ## Testing Hygiene
 
 - When modifying test files, ensure all mocks are updated to match new DB queries, service dependencies, and module imports `(review-time: requires understanding mock-target coupling)`

--- a/settings.json
+++ b/settings.json
@@ -118,6 +118,24 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git push *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr *)",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "if": "Bash(gh pr create *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 120


### PR DESCRIPTION
## What does this PR do?

Adds a two-layer enforcement for a recurring failure pattern: Claude asserting PR / branch state from stale conversation memory instead of probing live state.

- **`hooks/pre-git-state-refresh.sh`** (new, +x) - `PreToolUse` hook that fires on `git push`, `git commit` (non-default branch), and `gh pr *`. Runs `git fetch --prune origin` + `gh pr view --json state,mergedAt,headRefName,url` and emits a `[pr-state] ...` line as `additionalContext` so the model sees ground truth before the call executes. Warn-only (always exits 0), degrades silently outside a repo / with no remote / when `gh` is unavailable. Bypass via `SKIP_PR_STATE_REFRESH=1`.
- **`settings.json`** - three new `PreToolUse` entries pointing the trigger commands at the new hook, placed before existing exit-2 gates so the state line lands even when a later gate blocks.
- **`rules/git-conventions.md`** - new "PR State Freshness" section. Hook covers tool-call paths; rule covers the conversational claim path (which hooks cannot reach). Includes a 5-minute probe-reuse exemption voided by any intervening state-changing action.

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

### Smoke tests run locally

- `git push origin master` -> emits `[pr-state] state=NONE`
- `git status` -> silent exit 0 (not a trigger)
- `git commit` on `master` -> silent exit 0 (default branch skipped)
- `gh pr comment` -> probes, emits state line
- Outside a repo -> `unavailable=not-a-repo`
- `git push --help` -> silent exit 0

### Design decisions (rejected alternatives)

- Hard-block on stale-merged push -> rejected (legitimate uses exist).
- State cache -> rejected (freshness > latency).
- Post-action verification -> rejected (overkill; pre-action covers the failure mode).