### PR TITLE
docs(rules): require force-push confirmation and ban AI attribution everywhere

### DIFF
--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -6,7 +6,7 @@
 
 - Always use conventional commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, etc.) `(hook)`
 - Scope is optional, e.g. `feat(auth): add token refresh` `(review-time: descriptive sub-rule of the format above)`
-- Never add Co-Authored-By or any AI attribution to commits `(hook)`
+- Never add Co-Authored-By or any AI attribution anywhere - commits, PR/MR titles and descriptions, issues, comments, or any other artifact. This includes the "Generated with Claude Code" footer harnesses append by default `(hook for commits; review-time for PR bodies and other artifacts)`
 - Before committing, verify the current branch with `git branch --show-current` - never commit directly to main/master `(hook)`
 - Never auto-commit or push - wait for explicit instructions `(review-time: depends on conversational signal, not pattern)`
 

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -13,6 +13,7 @@
 ## Branches and PRs
 
 - NEVER push directly to the default branch (master/main) - always use a feature branch and create a PR `(hook)`
+- NEVER force-push any ref without asking immediately before the push - approval of a plan that includes a force-push is not approval of the push itself. Ask at execution time, every time (applies to agents/subagents too: they must report back for confirmation, not push) `(review-time: requires a fresh user confirmation at execution time; deny rules block bare --force/-f)`
 - NEVER merge PRs automatically - always wait for the user to merge manually `(review-time: depends on user signal, not pattern)`
 - After completing any feature implementation, create a PR unless explicitly told otherwise - do not wait to be asked `(review-time: requires judging "completion")`
 - Always rebase onto the target branch (`git fetch origin main && git rebase origin/main`) before creating a PR `(hook)`


### PR DESCRIPTION
## Summary

- Adds a rule to `rules/git-conventions.md` (Branches and PRs): never force-push any ref without asking immediately before the push
- Plan-level approval of work that includes a force-push does not count as approval of the push itself - the ask happens at execution time, every time; applies to subagents too (they stop and report back instead of pushing)
- Extends the existing AI-attribution ban from commits to ALL artifacts: PR/MR titles and descriptions, issues, comments - including the "Generated with Claude Code" footer harnesses append by default
- Both annotated per the enforcement-tag convention; deny rules already block bare `--force`/`-f` variants