### PR TITLE
feat(rules): add ticket reporter-voice and PR planning-artifact rules

### DIFF
--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -19,6 +19,7 @@
 - Always rebase onto the target branch (`git fetch origin main && git rebase origin/main`) before creating a PR `(hook)`
 - Always run `/verify-done` before pushing any branch - never push without all checks passing `(hook)`
 - PR descriptions: always use bullet points in the summary section, not prose paragraphs `(review-time: formatting of free-form text Claude produces)`
+- Never reference local planning artifacts (`.claude/state/` plans, research, session diaries) in PR descriptions - they are untracked and invisible to reviewers `(review-time: formatting of free-form text Claude produces)`
 - After pushing new commits to an existing PR, update the PR title and description to reflect all changes - use `gh pr edit` to keep them accurate `(review-time: requires judging "reflects all changes")`
 - If the repo has a PR template (`.github/pull_request_template.md`), use it. If not, use `~/.claude/pull_request_template.md` `(review-time: template selection requires reading directory)`
 

--- a/rules/jira.md
+++ b/rules/jira.md
@@ -42,3 +42,9 @@ Run `acli jira workitem --help` for the current command surface - flags change b
 - **Do not invent keys**: only act on keys the user actually provided. Do not guess project prefixes. `(review-time: requires reading user's message)`
 - **Stay scoped**: fetch the specific tickets referenced, not the entire backlog. Avoid broad `--jql` sweeps unless asked. `(review-time: judging "broad" scope)`
 - **Surface auth errors**: if `acli` returns an auth or permission error, report it verbatim - do not retry blindly or attempt to re-auth. `(review-time: error-handling pattern)`
+
+## Writing tickets
+
+- **Reporter voice**: write every ticket as someone reporting the problem before the fix and investigation are done - even when the fix already exists. Describe symptoms as currently happening, keep any proposed fix in future/conditional tense, and never reference the implementing PR or completed work in the description. PR links belong on the PR side (ticket key in PR title/description), not in the ticket body.
+- **Match the project's format**: before writing, view 1-2 recent tickets the user reported in the same project and mirror their section headings and tone (e.g. "What's happening / Root cause / Why we should fix it / Proposed fix / Acceptance / Related" in plain prose).
+- **Plain language**: summaries readable by non-engineers; keep deep technical detail (status codes, stack traces, code paths) out of the ticket unless the project's existing tickets carry it.


### PR DESCRIPTION
## What does this PR do?

- `rules/git-conventions.md`: PR descriptions must never reference local planning artifacts (`.claude/state/` plans, research, session diaries) - they are untracked and invisible to reviewers
- `rules/jira.md`: new "Writing tickets" section - write every ticket in reporter voice (as filed before the fix/investigation existed, proposed fix in future tense, no PR references in the ticket body), mirror the format of recent tickets in the same project, and keep the language plain

Both rules capture corrections from a recent session so they are applied automatically going forward.

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

N/A

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
