### PR TITLE
feat(skills): add prune skill

### DIFF
--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: ponytail-review
+description: >
+  Code review focused exclusively on over-engineering. Finds what to delete:
+  reinvented standard library, unneeded dependencies, speculative abstractions,
+  dead flexibility. One line per finding: location, what to cut, what replaces
+  it. Use when the user says "review for over-engineering",
+  "is this over-engineered", or invokes /ponytail-review. Complements
+  correctness-focused review, this one only hunts complexity.
+---
+
+If no diff is in context, fetch one first: run `git diff HEAD` for uncommitted
+changes, `gh pr diff $ARGUMENTS` for a PR number, or `git diff main...HEAD`
+for the current branch.
+
+Review diffs for unnecessary complexity. One line per finding: location, what
+to cut, what replaces it. The diff's best outcome is getting shorter.
+
+## Format
+
+`L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
+multi-file diffs.
+
+Tags:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Examples
+
+❌ "This EmailValidator class might be more complex than necessary, have you
+considered whether all these validation rules are needed at this stage?"
+
+✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+
+✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+
+✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
+
+✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+
+✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+## Scoring
+
+End with the only metric that matters: `net: -<N> lines possible.`
+
+If there is nothing to cut, say `Lean already. Ship.` and stop.
+
+## Boundaries
+
+**why-not-mechanizable:** scope and YAGNI exceptions are subjective complexity judgments; no hook can detect that a finding belongs in a "correctness" pass versus a "complexity" pass.
+
+- Complexity only - correctness bugs, security holes, and performance go to a normal review pass, not this one `(review-time: see section note)`
+- A single smoke test or `assert`-based self-check is the ponytail minimum, not bloat - never flag it for deletion `(review-time: see section note)`
+- Does not apply the fixes, only lists them `(review-time: see section note)`
+
+## Attribution
+
+Adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) (MIT).

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: ponytail-review
+name: prune
 description: >
   Code review focused exclusively on over-engineering. Finds what to delete:
   reinvented standard library, unneeded dependencies, speculative abstractions,
   dead flexibility. One line per finding: location, what to cut, what replaces
   it. Use when the user says "review for over-engineering",
-  "is this over-engineered", or invokes /ponytail-review. Complements
-  correctness-focused review, this one only hunts complexity.
+  "is this over-engineered", or invokes /prune. Complements correctness-focused
+  review; this one only hunts complexity.
 ---
 
 If no diff is in context, fetch one first: run `git diff HEAD` for uncommitted
@@ -55,7 +55,7 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 **why-not-mechanizable:** scope and YAGNI exceptions are subjective complexity judgments; no hook can detect that a finding belongs in a "correctness" pass versus a "complexity" pass.
 
 - Complexity only - correctness bugs, security holes, and performance go to a normal review pass, not this one `(review-time: see section note)`
-- A single smoke test or `assert`-based self-check is the ponytail minimum, not bloat - never flag it for deletion `(review-time: see section note)`
+- A single smoke test or `assert`-based self-check is the minimum, not bloat - never flag it for deletion `(review-time: see section note)`
 - Does not apply the fixes, only lists them `(review-time: see section note)`
 
 ## Attribution


### PR DESCRIPTION
## Summary

- New skill `skills/ponytail-review/SKILL.md`: a complexity-only review pass focused exclusively on what to delete (reinvented stdlib, unneeded deps, speculative abstractions, dead flexibility)
- On-demand only - no rule changes, no hooks, no settings.json touches
- Five tags (`delete`, `stdlib`, `native`, `yagni`, `shrink`), one line per finding, ends with `net: -N lines possible.` or `Lean already. Ship.`

## Why

`review-pr` covers general review, and the system-level `code-review` skill covers correctness / security / performance / cleanup. Neither is a YAGNI-only lens you can point at a diff. `rules/engineering-principles.md` encodes YAGNI for code being written, but there's no on-demand reviewer that asks only *what can we delete*. This fills that gap.

Pairs with `code-review` for a full pass: correctness first, then `/ponytail-review` to trim whatever survived.

## Source and hardening

Adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) (MIT, attributed inline). The verbatim vendor had four issues I fixed before proposing:

1. **Dropped `"simplify review"` trigger** - the system-level `simplify` skill (`Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes`) matches this phrase and applies fixes to the working tree. A user typing "simplify review of this PR" could get unwanted edits instead of a findings list.
2. **Dropped `"what can we delete"` trigger** - domain-unqualified, fires on infra / migration / prose questions.
3. **Added diff-fetch preamble** - the original assumes a diff is already in context. Now runs `git diff HEAD` / `gh pr diff $ARGUMENTS` / `git diff main...HEAD` when invoked cold.
4. **Removed `"stop ponytail-review"` escape hatch** - implies a stateful mode toggle that doesn't exist in the skill system.

## Conventions

Followed `rules/rule-authoring.md`: tagged the three normative bullets in the Boundaries section with `(review-time: see section note)` plus a `**why-not-mechanizable:**` paragraph. Format spec, tag vocabulary, and examples stay untagged (procedure / definitions, not normative do/don't).

## Test plan

- Invoke `/ponytail-review` with no diff in context - confirm the preamble fetches `git diff HEAD`
- Invoke on a PR number - confirm `gh pr diff <N>` is used
- Confirm "is this over-engineered" routes to the skill but "what can we delete from S3" does not
- Confirm `simplify` skill is still reachable via its own triggers

Happy to revise the name, drop the attribution line, restructure boundaries, or skip the whole thing if it doesn't fit the curation bar.