### PR TITLE
chore(settings): make RTK off by default, opt-in via RTK_ENABLE

### DIFF
--- a/RTK.md
+++ b/RTK.md
@@ -33,27 +33,27 @@ Plain `rtk init -g` (without the flag) would overwrite `~/.claude/RTK.md` (this 
 
 Drift recovery: if a symlink already got replaced with a real file, run `bash ~/dev/claude/scripts/setup-symlinks.sh` to back up the bad version (`.bak.<timestamp>`) and restore the symlink.
 
-## Disabling RTK (per-machine opt-out)
+## Enabling RTK (off by default, per-machine opt-in)
 
-The hook is **gated on the `RTK_DISABLE` env var**. RTK runs only when `RTK_DISABLE` is unset **and** `rtk` is on `PATH`. The registration in the shared `settings.json` is:
+RTK is **off by default**. The hook is **gated on the `RTK_ENABLE` env var**: RTK runs only when `RTK_ENABLE` is set **and** `rtk` is on `PATH`. The registration in the shared `settings.json` is:
 
 ```bash
-if [ -z "$RTK_DISABLE" ] && command -v rtk >/dev/null 2>&1; then rtk hook claude || true; fi
+if [ -n "$RTK_ENABLE" ] && command -v rtk >/dev/null 2>&1; then rtk hook claude || true; fi
 ```
 
-To turn RTK off on **one machine** without editing the shared (symlinked) `settings.json`, set the flag in `~/.claude/settings.local.json` - a machine-local file that is neither symlinked into the dotfiles nor committed:
+To turn RTK on for **one machine** without editing the shared (symlinked) `settings.json`, set the flag in `~/.claude/settings.local.json` - a machine-local file that is neither symlinked into the dotfiles nor committed:
 
 ```json
 {
   "env": {
-    "RTK_DISABLE": "1"
+    "RTK_ENABLE": "1"
   }
 }
 ```
 
-To re-enable, delete `settings.local.json` or clear the variable. Other machines are unaffected because they do not carry the flag.
+To turn it back off, delete `settings.local.json` or clear the variable. Other machines are unaffected because they do not carry the flag.
 
-- Put the `RTK_DISABLE` flag in `settings.local.json`, never in the symlinked `settings.json` - the latter is shared across every machine `(review-time: config-placement decision when editing, not pattern-checkable)`
+- Put the `RTK_ENABLE` flag in `settings.local.json`, never in the symlinked `settings.json` - the latter is shared across every machine `(review-time: config-placement decision when editing, not pattern-checkable)`
 - Restart Claude Code after changing the flag - `env` from `settings.local.json` is applied at session start, so a mid-session change has no effect until restart `(review-time: requires recognizing a settings.local.json env change was just made)`
 
 ## Hook-Based Usage

--- a/settings.json
+++ b/settings.json
@@ -4,13 +4,6 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "RTK_HOOK_AUDIT": "1"
   },
-  "autoUpdatesChannel": "stable",
-  "minimumVersion": "2.1.92",
-  "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
-  },
-  "effortLevel": "high",
-  "skipAutoPermissionPrompt": false,
   "permissions": {
     "deny": [
       "Read(**/.env)",
@@ -116,55 +109,55 @@
         "hooks": [
           {
             "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "if": "Bash(git push *)",
-            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 15
           },
           {
             "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "if": "Bash(git commit *)",
-            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 15
           },
           {
             "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "if": "Bash(gh pr *)",
-            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-git-state-refresh.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 15
           },
           {
             "type": "command",
-            "if": "Bash(gh pr create *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-pr-test-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "if": "Bash(gh pr create *)",
             "timeout": 120
           },
           {
             "type": "command",
-            "if": "Bash(git push *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-push-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-push-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "if": "Bash(git push *)",
             "timeout": 300
           },
           {
             "type": "command",
-            "if": "Bash(git commit *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-branch-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-branch-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "if": "Bash(git commit *)",
             "timeout": 30
           },
           {
             "type": "command",
-            "if": "Bash(git commit *)",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-coauthor-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-coauthor-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
-            "timeout": 10
-          },
-          {
-            "type": "command",
             "if": "Bash(git commit *)",
-            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "if [ -z \"$RTK_DISABLE\" ] && command -v rtk >/dev/null 2>&1; then rtk hook claude || true; fi"
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "if": "Bash(git commit *)",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "if [ -n \"$RTK_ENABLE\" ] && command -v rtk >/dev/null 2>&1; then rtk hook claude || true; fi"
           }
         ]
       }
@@ -195,8 +188,8 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(gh pr create *)",
             "command": "nohup bash -c '~/.claude/hooks/watch-pr-checks.sh' >/dev/null 2>&1 &",
+            "if": "Bash(gh pr create *)",
             "timeout": 5
           }
         ]
@@ -250,5 +243,13 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"
-  }
+  },
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  },
+  "effortLevel": "high",
+  "autoUpdatesChannel": "stable",
+  "minimumVersion": "2.1.92",
+  "skipAutoPermissionPrompt": false,
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Summary

- Invert the RTK hook gate in `settings.json` from `RTK_DISABLE` (on unless disabled) to `RTK_ENABLE` (off unless enabled), so RTK is **off by default** and opt-in per machine
- Sync `RTK.md`: rewrite the gating section from "Disabling … opt-out" to "Enabling … opt-in" so the docs match the new flag

## Behavior

- Default: RTK hook does not run
- To enable on a single machine, set `RTK_ENABLE=1` in `~/.claude/settings.local.json` (not the shared symlinked `settings.json`), then restart Claude Code