### PR TITLE
feat(rules,skills): add panel vs lane coordination modes for parallel agents

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# Claude Config
+
+The domain language for this repo's agent-orchestration model: how the main session delegates parallel work to spawned agents, and the two coordination shapes that delegation can take.
+
+## Language
+
+**Teammate**:
+A named agent spawned via the Agent tool (the `name` parameter makes it addressable). Both coordination modes spawn named teammates.
+_Avoid_: "subagent" when the agent is named - reserve subagent for the generic Agent-tool spawn mechanism.
+
+**Lane mode**:
+Parallel teammates in isolated git worktrees, each owning disjoint files, running in the background and reporting to the parent via completion notifications with no peer messaging.
+_Avoid_: "fan-out mode", "worktree mode".
+
+**Panel mode**:
+Named read-only teammates that coordinate peer-to-peer via SendMessage to challenge each other, then converge into one synthesis for the parent.
+_Avoid_: "round-table", "team mode".
+
+## Relationships
+
+- A **Teammate** runs in either **Lane mode** or **Panel mode**.
+- **Lane mode** is for mutating work (build/implementation); **Panel mode** is for read-only work (research, grilling, design).
+- The distinguishing axis is coordination topology: **Lane mode** is a star (teammates report only to the parent), **Panel mode** is a mesh (teammates also message each other). Worktree isolation follows from this: lanes mutate files so they need worktrees, panels are read-only so they do not.
+- Background execution (`run_in_background`) is orthogonal to mode - either mode can run in the background.
+
+## Example dialogue
+
+> **Dev:** "I'm running /build on three file-isolated tracks - should the teammates talk to each other?"
+> **Maintainer:** "No, that's lane mode - each owns its files, runs in a worktree, and reports back via notification. Peer messaging is panel mode, for /research and /grill where teammates need to challenge each other's findings before converging."
+
+## Flagged ambiguities
+
+- "subagent" was used for both the generic spawn mechanism and a named agent - resolved: a named agent is a **Teammate**; "subagent" refers only to the generic Agent-tool spawn.
+- "in the background" was conflated with "spawned as a team" - resolved: background execution is orthogonal to coordination mode.

--- a/commands/research.md
+++ b/commands/research.md
@@ -1,6 +1,6 @@
 Start Phase 1 (Research) for the following topic: $ARGUMENTS
 
-Use subagents to explore the codebase efficiently. Read all relevant files, check git history for context, and investigate related patterns.
+For non-trivial topics, run **panel mode** (see `rules/parallel-agents.md`): spawn one `Explore` teammate per subsystem, run one bounded cross-check round via SendMessage so teammates flag contradictions across their areas, then synthesize their findings into the artifact yourself. For narrow topics, explore solo. Read all relevant files, check git history for context, and investigate related patterns.
 
 Save the research artifact to `.claude/state/research/YYYY-MM-DD-research-<topic>.md` (use today's date) containing:
 

--- a/docs/adr/0005-two-coordination-modes-for-parallel-agents.md
+++ b/docs/adr/0005-two-coordination-modes-for-parallel-agents.md
@@ -1,0 +1,53 @@
+# Two coordination modes for parallel agents: lane and panel
+
+## Status
+
+Accepted - 2026-06-30
+
+## Context
+
+ADR 0003 (Accepted 2026-05-09) established that specialized agents are spawned as subagents via the Agent tool, with the parent acting on each subagent's returned summary. `rules/parallel-agents.md` then encoded a single shape for all parallel work: worktree-isolated, file-disjoint teammates running in the background, reporting to the parent via completion notifications. Two of its bullets - "wait for automatic completion notifications, do NOT poll" and "NEVER run parallel agents without worktree isolation" - apply that one shape to every parallel task.
+
+That shape is correct for implementation, but wrong for research and grilling. Both 0003 and `parallel-agents.md` predate two Claude Code features that changed what is possible: nested subagents (2.1.172, 2026-06-10) and implicit agent teams with named, addressable teammates that message each other via SendMessage (2.1.178, 2026-06-15). Neither document contemplated teammates coordinating peer-to-peer, so the config has no vocabulary for it and the "wait for notifications" rule actively suppresses it.
+
+The observable symptom: a prompt like "build this plan in parallel via domain expert subagents" produced a coordinated team only about 60% of the time. A transcript analysis across 49 agent-spawning sessions confirmed the cause is not the word "subagent" (neutral in the data) but the absence of an entry-point that selects a coordination shape, combined with the standing "wait for notifications" rule biasing every spawn toward fire-and-forget.
+
+## Decision
+
+This is an additive decision. ADR 0003's loading model (spawn subagents, do not read persona files into the main conversation; parent acts on summaries) stays valid and untouched. What is new is the coordination topology, which now has two named modes.
+
+**Lane mode** - for mutating work (build/implementation). Parallel teammates in isolated git worktrees, each owning disjoint files, running in the background, reporting to the parent via completion notifications, with no peer messaging. This is a star topology. It is exactly the workflow `rules/parallel-agents.md` already describes and that `drive-fleet` (ADR 0004) orchestrates; the "wait for notifications" and "worktree MUST" rules are scoped to this mode.
+
+**Panel mode** - for read-only work (research, grilling, design). Named teammates that coordinate peer-to-peer via SendMessage to challenge each other, then converge. This is a mesh topology. Because the work is read-only, no worktrees are needed. Panel mode follows a structured protocol with a stop condition:
+
+1. **Independent pass** - each teammate explores its area or forms its position alone.
+2. **Cross-challenge round** - each teammate sees the others' outputs and sends targeted SendMessage challenges. Bounded to one pass for research; iterate-to-convergence for grilling and design.
+3. **Parent converges** - the main session synthesizes the result (research: the artifact; grill: the next question to the user). The parent owns convergence because it holds the user relationship and the artifact; there is no "lead teammate".
+
+The distinguishing axis between the modes is coordination topology (star vs mesh) plus isolation (worktree vs read-only), not whether teammates are named - both modes name their teammates so they are addressable.
+
+**Read-only enforcement** differs by surface, deliberately:
+
+- **Research panels** spawn as the `Explore` agent type, whose toolset excludes Edit/Write/NotebookEdit. The read-only guarantee is mechanical.
+- **Grill and design panels** use the domain-expert agent types from `rules/agent-routing.md` for their personas, with an explicit read-only brief. The Agent tool has no per-spawn tool-restriction parameter, so the guarantee here is soft (brief-level). This is accepted because the value is expert adversarial framing, the work is investigative, and the parent reviews everything before any mutation happens in a later build.
+
+**Mode-selection lives at the entry points**, not only in the reference, so the right mode is pulled without per-prompt wording:
+
+- `commands/research.md` declares panel mode (Explore teammates).
+- `skills/grill-with-docs/SKILL.md` may convene a panel (domain-expert teammates), while keeping the user-facing one-question-at-a-time cadence.
+- `skills/build/SKILL.md` declares that a multi-lane plan maps to one lane-mode teammate per file-isolated lane.
+
+## Consequences
+
+- "Build in parallel" becomes deterministic: a multi-lane plan pulls lane mode at the build entry-point instead of being a per-prompt coin-flip.
+- Research and grilling gain sanctioned peer-to-peer coordination with a stop condition, instead of either fire-and-forget subagents or unbounded mesh chatter.
+- Panel mode's "no worktree" safety rests on the read-only guarantee, which is mechanical for research (Explore) and brief-level for grill/design. A domain-expert panel that ignores its read-only brief could mutate files; the parent's pre-build review is the backstop.
+- `rules/parallel-agents.md` bullets that were unconditional become mode-scoped, removing the contradiction that biased every spawn toward fire-and-forget.
+- ADR 0004 (drive-fleet) is unchanged; it is the canonical lane-mode orchestration and 0005 only references it.
+
+## Considered alternatives
+
+- **Supersede ADR 0003.** Rejected: 0003's loading-model decision is independent of coordination topology and remains correct. Panel mode adds a topology; it does not reverse how agents are loaded.
+- **Free-form mesh chatter for panels.** Rejected: no stop condition, burns tokens, and can loop. The structured independent-then-cross-challenge protocol preserves the peer-challenge value with a bound.
+- **A hard mechanical read-only guarantee everywhere** (Explore/Plan agent types for grill too). Rejected: it would strip the domain-expert personas that make adversarial grilling valuable. Soft read-only plus the pre-build review is the accepted trade-off for grill/design.
+- **Describe the modes only in `rules/parallel-agents.md`.** Rejected: that is what exists today, and it is why mode-selection was a coin-flip. Anchoring selection at the command/skill entry-points is the change that fixes it.

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -2,7 +2,18 @@
 
 **When to apply:** when a task has 2+ independent sub-tasks that touch different files / modules and can run concurrently.
 
-When a task can be split into independent pieces, parallelize by spawning multiple agents in isolated git worktrees. This dramatically reduces wall-clock time for multi-part work.
+When a task can be split into independent pieces, parallelize by spawning multiple named teammates. This dramatically reduces wall-clock time for multi-part work. How those teammates coordinate depends on the mode.
+
+## Two modes of parallel work
+
+Parallel work runs in one of two coordination modes (see `CONTEXT.md` for the glossary). Pick by whether the work mutates files.
+
+- **Lane mode** - mutating work (build / implementation). Teammates run in isolated git worktrees, each owning disjoint files, in the background, reporting to the parent via completion notifications, with no peer messaging (star topology). Choose lane mode when teammates write code. `(review-time: mode-selection judgment)`
+- **Panel mode** - read-only work (research, grilling, design). Named teammates coordinate peer-to-peer via SendMessage to challenge each other, then converge (mesh topology). No worktrees needed because the work is read-only. Choose panel mode when teammates investigate or argue but do not write. `(review-time: mode-selection judgment)`
+
+The distinguishing axis is coordination topology (star vs mesh) plus isolation (worktree vs read-only), not whether teammates are named - both modes name their teammates. Background execution (`run_in_background`) is orthogonal; either mode can run in the background. `(review-time: mode classification, not a code pattern)`
+
+The rest of this file - splitting, worktree isolation, merging - governs **lane mode**. Panel mode has its own section below.
 
 ## When to Parallelize
 
@@ -45,19 +56,20 @@ Do NOT spawn parallel agents when:
 
 ## Worktree Isolation
 
-Every parallel agent MUST use worktree isolation:
+Worktree isolation applies to **lane mode** (file-mutating work). Panel mode is read-only and needs no worktrees. Every lane-mode teammate MUST use worktree isolation:
 
-- Set `isolation: "worktree"` on every Agent tool call for parallel work `(review-time: tool-call parameter choice; not currently hook-gated on Agent calls)`
-- Each agent gets its own full copy of the repo via git worktree `(review-time: descriptive of the mechanism)`
-- Each agent works on its own branch - no risk of stepping on other agents' changes `(review-time: descriptive of the mechanism)`
-- NEVER run parallel agents without worktree isolation - concurrent edits to the same working directory will cause corruption `(review-time: tool-call parameter choice; not currently hook-gated)`
+- Set `isolation: "worktree"` on every Agent tool call for lane-mode parallel work `(review-time: tool-call parameter choice; not currently hook-gated on Agent calls)`
+- Each teammate gets its own full copy of the repo via git worktree `(review-time: descriptive of the mechanism)`
+- Each teammate works on its own branch - no risk of stepping on other teammates' changes `(review-time: descriptive of the mechanism)`
+- NEVER run file-mutating parallel teammates without worktree isolation - concurrent edits to the same working directory will cause corruption `(review-time: tool-call parameter choice; not currently hook-gated)`
 
 ## Background Execution
 
-- Spawn agents with `run_in_background: true` so they execute concurrently `(review-time: tool-call parameter)`
-- Launch all independent agents in a single message with multiple Agent tool calls `(review-time: message-shape choice)`
-- After spawning, wait for automatic completion notifications - do NOT poll or check repeatedly `(review-time: behavioral discipline)`
-- Continue with other non-conflicting work while agents run, if possible `(review-time: requires identifying non-conflicting work)`
+- Spawn teammates with `run_in_background: true` so they execute concurrently `(review-time: tool-call parameter)`
+- Launch all independent teammates in a single message with multiple Agent tool calls `(review-time: message-shape choice)`
+- In **lane mode**, after spawning, wait for automatic completion notifications - do NOT poll or check repeatedly `(review-time: behavioral discipline)`
+- In **panel mode**, this rule is inverted: actively coordinate via SendMessage during the cross-challenge round rather than waiting silently for notifications `(review-time: behavioral discipline, mode-dependent)`
+- Continue with other non-conflicting work while teammates run, if possible `(review-time: requires identifying non-conflicting work)`
 
 ## Merging Results
 
@@ -83,6 +95,22 @@ Each agent's prompt MUST be self-contained. The agent cannot see the parent conv
 Bad prompt: "Add validation to the API"
 
 Good prompt: "Add Zod input validation to the POST /api/users endpoint in src/routes/users.ts. Follow the existing validation pattern in src/routes/projects.ts. Create the schema in src/schemas/users.ts. Add tests in src/routes/\_\_tests\_\_/users.test.ts. Run `npm test -- users` to verify. Work on branch parallel/users-validation."
+
+## Panel mode
+
+Panel mode is for read-only parallel work where teammates need to challenge each other: research, grilling a plan, and design exploration. It follows a structured protocol with a stop condition - free-form mesh chatter is forbidden because it has no bound and burns tokens.
+
+- **Independent pass**: each teammate explores its area or forms its position alone `(review-time: protocol step)`
+- **Cross-challenge round**: each teammate sees the others' outputs and sends targeted SendMessage challenges or contradictions - bounded to one pass for research, iterate-to-convergence for grilling and design `(review-time: protocol step, intensity is a judgment call)`
+- **Parent converges**: the main session synthesizes the result (research: the artifact; grill: the next question to the user) - there is no lead teammate, because the parent holds the user relationship and the artifact `(review-time: protocol step)`
+
+Read-only enforcement differs by surface, deliberately:
+
+- **Research panels** spawn as the `Explore` agent type, whose toolset excludes Edit / Write / NotebookEdit - the read-only guarantee is mechanical `(review-time: agent-type selection)`
+- **Grill and design panels** use the domain-expert agent types from `rules/agent-routing.md` for their personas, with an explicit read-only brief - the guarantee is soft (brief-level), backstopped by the parent's review before any later build `(review-time: agent-type selection plus prompt discipline)`
+- NEVER let a panel teammate mutate files - if a task needs writes, it is lane mode, not panel mode `(review-time: mode-selection judgment)`
+
+See ADR 0005 for the rationale and CONTEXT.md for the glossary.
 
 ## Limits
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -15,6 +15,7 @@ Follow these disciplines:
 - If no plan exists, stop and ask the user to run /plan first `(review-time: see section note)`
 - Read the plan and identify the task list `(review-time: see section note)`
 - Load relevant expert agents based on the plan's domain (see `rules/agent-routing.md`) - their guardrails apply to every increment `(review-time: see section note)`
+- If the plan has 2+ file-isolated lanes, execute it in **lane mode** - spawn one lane-mode teammate per lane (see `rules/parallel-agents.md`); single-lane plans stay in this session `(review-time: lane-vs-single judgment from the plan shape)`
 
 ## Increment Rules
 

--- a/skills/grill-with-docs/SKILL.md
+++ b/skills/grill-with-docs/SKILL.md
@@ -3,7 +3,7 @@ name: grill-with-docs
 description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
 ---
 
-> Source: [mattpocock/skills — engineering/grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs)
+> Source: [mattpocock/skills - engineering/grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs)
 
 <what-to-do>
 
@@ -51,17 +51,17 @@ If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The ma
 │       └── docs/adr/
 ```
 
-Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+Create files lazily - only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
 
 ## During the session
 
 ### Challenge against the glossary
 
-When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y - which is it?"
 
 ### Sharpen fuzzy language
 
-When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' - do you mean the Customer or the User? Those are different things."
 
 ### Discuss concrete scenarios
 
@@ -69,11 +69,11 @@ When domain relationships are being discussed, stress-test them with specific sc
 
 ### Cross-reference with code
 
-When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible - which is right?"
 
 ### Update CONTEXT.md inline
 
-When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up - capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
 Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
 
@@ -83,10 +83,19 @@ Don't couple `CONTEXT.md` to implementation details. Only include terms that are
 
 Only offer to create an ADR when all three are true:
 
-1. **Hard to reverse** — the cost of changing your mind later is meaningful `(review-time: see section note)`
-2. **Surprising without context** — a future reader will wonder "why did they do it this way?" `(review-time: see section note)`
-3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons `(review-time: see section note)`
+1. **Hard to reverse** - the cost of changing your mind later is meaningful `(review-time: see section note)`
+2. **Surprising without context** - a future reader will wonder "why did they do it this way?" `(review-time: see section note)`
+3. **The result of a real trade-off** - there were genuine alternatives and you picked one for specific reasons `(review-time: see section note)`
 
 If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+## Panel grilling (optional)
+
+For a plan with genuine cross-domain tension or competing approaches, convene a **panel** (see `rules/parallel-agents.md`) instead of grilling solo:
+
+- Spawn domain-expert teammates via the Agent tool (route per `rules/agent-routing.md`), each with a read-only brief and a distinct stance to argue `(review-time: panel-vs-solo judgment)`
+- Have them debate the plan among themselves via SendMessage - the cross-talk between teammates surfaces contradictions and trade-offs you would miss solo `(review-time: protocol guidance)`
+- Distill their disagreement into the next question and put it to the user - keep the user-facing cadence to one question at a time per `rules/communication.md`; the panel never messages the user directly `(review-time: cadence discipline)`
+- Skip the panel for single-domain plans - solo grilling is cheaper and a panel adds nothing when there is nothing to contend `(review-time: panel-vs-solo judgment)`
 
 </supporting-info>


### PR DESCRIPTION
## What does this PR do?

- Introduces two named coordination modes for parallel agents, so the right one is selected deterministically instead of by prompt wording:
  - **Lane mode** (build/implementation): worktree-isolated, file-disjoint teammates, background, report via completion notifications, no peer messaging (star topology).
  - **Panel mode** (research/grill/design): named read-only teammates that coordinate peer-to-peer via SendMessage to challenge each other, then converge (mesh topology).
- Scopes the previously-unconditional "wait for notifications" and "worktree MUST" rules in `rules/parallel-agents.md` to lane mode, so they stop biasing every spawn toward fire-and-forget.
- Adds the panel-mode structured protocol (independent pass -> bounded cross-challenge round -> parent converges) and the read-only enforcement split (Explore = mechanical, domain-expert = brief-level).
- Anchors mode-selection at entry points: `commands/research.md` (panel), `skills/grill-with-docs/SKILL.md` (optional panel), `skills/build/SKILL.md` (multi-lane plan -> lane mode).
- Records the decision in `docs/adr/0005-two-coordination-modes-for-parallel-agents.md` (additive to ADR 0003, whose loading-model decision is untouched) and adds a `CONTEXT.md` glossary (teammate / lane mode / panel mode).
- Normalizes pre-existing em-dashes to hyphens in `skills/grill-with-docs/SKILL.md` per the repo no-em-dash policy (incidental, same file as a feature edit).

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
