### PR TITLE
chore(settings): set askUserQuestionTimeout explicitly to never

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -251,5 +251,6 @@
   "autoUpdatesChannel": "stable",
   "minimumVersion": "2.1.92",
   "skipAutoPermissionPrompt": false,
-  "tui": "fullscreen"
+  "tui": "fullscreen",
+  "askUserQuestionTimeout": "never"
 }


### PR DESCRIPTION
## What does this PR do?

Adds an explicit `"askUserQuestionTimeout": "never"` to `settings.json`.

Claude Code v2.1.200 introduced the `askUserQuestionTimeout` setting (enum: `never` | `60s` | `5m` | `10m`) controlling how long an `AskUserQuestion` prompt waits before auto-continuing with whatever answers are selected. `"never"` disables the auto-continue timeout so questions wait indefinitely for a human.

The harness default is already `"never"`, so this is a defensive, self-documenting pin - it makes the intent visible in the shared config and guards against a future harness release changing the default.

Verified locally: JSON parses cleanly, and the enum value maps to a disabled timeout in the installed v2.1.200 binary.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [ ] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
