### PR TITLE
docs(rtk): gate RTK.md guidance on RTK_ENABLE

### DIFF
--- a/RTK.md
+++ b/RTK.md
@@ -1,5 +1,7 @@
 # RTK - Rust Token Killer
 
+> **Applies only when `RTK_ENABLE` is set.** It is unset by default, so RTK is OFF: the `rtk hook claude` PreToolUse hook does not run, no commands are rewritten, and none of the guidance below is in effect. When `RTK_ENABLE` is empty, ignore this entire file and run commands normally.
+
 **Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
 
 ## Meta Commands (always use rtk directly)


### PR DESCRIPTION
## What does this PR do?

Adds a precondition banner to the top of `RTK.md` so the file's guidance is scoped to when RTK is actually enabled.

Since #87/#88 the `rtk hook claude` PreToolUse hook is gated behind `RTK_ENABLE` and is off by default. But `RTK.md` is imported unconditionally via `@RTK.md`, so its instructions ("all commands are automatically rewritten by the hook", "always use rtk directly", etc.) load into every session even when RTK is off - where they are inaccurate and misleading.

This adds a one-line guard banner stating the file applies only when `RTK_ENABLE` is set, and to ignore it otherwise. Same gate as the hook, so `RTK_ENABLE` now consistently governs both the hook and the guidance. Content-level gate only - no settings or hook changes, no `@import` mechanics.

Verified locally: `markdownlint-cli2` passes with 0 errors under the repo's `.markdownlint.json`.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [ ] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
