### PR TITLE
feat(skills): adopt Matt Pocock's composable disciplines (vendor-and-adapt)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,10 @@
 # Claude Config
 
-The domain language for this repo's agent-orchestration model: how the main session delegates parallel work to spawned agents, and the two coordination shapes that delegation can take.
+The domain language for this repo's agent-orchestration model (how the main session delegates parallel work to spawned agents, and the two coordination shapes that delegation can take) and its skill model (how skills are invoked and layered).
 
 ## Language
+
+### Agent orchestration
 
 **Teammate**:
 A named agent spawned via the Agent tool (the `name` parameter makes it addressable). Both coordination modes spawn named teammates.
@@ -16,9 +18,42 @@ _Avoid_: "fan-out mode", "worktree mode".
 Named read-only teammates that coordinate peer-to-peer via SendMessage to challenge each other, then converge into one synthesis for the parent.
 _Avoid_: "round-table", "team mode".
 
+### Skill model
+
+**Model-invoked skill**:
+A skill the model may auto-invoke because its `description` carries trigger phrasing; the default for reusable disciplines.
+_Avoid_: "auto skill".
+
+**User-invoked skill**:
+A skill only a human can start (`disable-model-invocation: true`, human-facing description); reserved for orchestration a human should sequence deliberately.
+_Avoid_: "manual skill", "slash-only skill".
+
+**Orchestrator**:
+A skill that sequences other skills into a workflow.
+_Avoid_: "pipeline", "flow".
+
+**Reusable discipline**:
+A single-purpose skill holding one repeatable practice, invoked by an orchestrator or the model.
+_Avoid_: "helper skill".
+
+**Seam**:
+The agreed point where a test exercises behaviour; chosen highest and fewest, fixed during spec and reused by test and build.
+_Avoid_: "mock point".
+
+**Decision ticket**:
+A wayfinder map entry that resolves to a decision, not a deliverable.
+_Avoid_: "task", "story".
+
+**Prototype detour**:
+A throwaway spike taken to de-risk one decision, after which the code is discarded and only the learning kept.
+_Avoid_: "spike task", "POC".
+
 ## Relationships
 
 - A **Teammate** runs in either **Lane mode** or **Panel mode**.
+- Our repo keeps **Orchestrators** at the **Model-invoked** layer (grill and build auto-fire as workflow phases); only `wayfinder` is a **User-invoked** orchestrator.
+- A **Reusable discipline** is always **Model-invoked**; an **Orchestrator** may invoke disciplines.
+- `wayfinder` resolves **Decision tickets** one per session until the fog clears, then hands to the spec stage.
 - **Lane mode** is for mutating work (build/implementation); **Panel mode** is for read-only work (research, grilling, design).
 - The distinguishing axis is coordination topology: **Lane mode** is a star (teammates report only to the parent), **Panel mode** is a mesh (teammates also message each other). Worktree isolation follows from this: lanes mutate files so they need worktrees, panels are read-only so they do not.
 - Background execution (`run_in_background`) is orthogonal to mode - either mode can run in the background.
@@ -32,3 +67,4 @@ _Avoid_: "round-table", "team mode".
 
 - "subagent" was used for both the generic spawn mechanism and a named agent - resolved: a named agent is a **Teammate**; "subagent" refers only to the generic Agent-tool spawn.
 - "in the background" was conflated with "spawned as a team" - resolved: background execution is orthogonal to coordination mode.
+- "skill" was used for both sequencing workflows and single practices - resolved: a sequencing skill is an **Orchestrator**, a single-practice skill is a **Reusable discipline**.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Re-runs are safe: existing files are backed up to `<path>.bak.<timestamp>` befor
 - **`CLAUDE.md`** - core rules loaded every session (workflow, security, code standards). See [ADR 0001](docs/adr/0001-grill-driven-workflow.md).
 - **`rules/`** - modular instruction files `@`-imported into `CLAUDE.md`.
 - **`agents/`** - expert subagent personas spawned via the Agent tool. Routing in [`rules/agent-routing.md`](rules/agent-routing.md); full list in [`docs/agents.md`](docs/agents.md). See [ADR 0003](docs/adr/0003-agents-via-subagent-spawn.md).
-- **`skills/`** - reusable `/<skill>` workflows (`/grill-with-docs`, `/build`, `/ship`, `/debug`, …). Skills marked `(mattpocock)` are vendored from [mattpocock/skills](https://github.com/mattpocock/skills).
+- **`skills/`** - reusable `/<skill>` workflows (`/grill-with-docs`, `/build`, `/ship`, `/debug`, `/prototype`, `/wayfinder`, …). Skills carrying a `> Source:` line are vendored from [mattpocock/skills](https://github.com/mattpocock/skills) and adapted to this repo's conventions (see ADR 0006).
 - **`commands/`** - thin slash invocations (`/research`, `/verify-done`, `/worktree`, …).
 - **`hooks/`** - shell scripts wired into `settings.json` for `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd` events.
 - **`scripts/`** - utilities used by hooks and skills (`setup-symlinks.sh`, `statusline.sh`, `notify.sh`, `worktree-prune.sh`).

--- a/docs/adr/0006-vendor-adapt-upstream-skills-keep-orchestration-model-invoked.md
+++ b/docs/adr/0006-vendor-adapt-upstream-skills-keep-orchestration-model-invoked.md
@@ -1,0 +1,37 @@
+# Vendor-and-adapt upstream skills; orchestration stays model-invoked
+
+## Status
+
+Accepted - 2026-07-13
+
+## Context
+
+We vendor five skills from [mattpocock/skills](https://github.com/mattpocock/skills) (`grill-with-docs`, `handoff`, `improve-codebase-architecture`, `write-a-skill`, `to-issues`). Upstream shipped a v1.1 restructure into a composable pipeline - `grill-with-docs -> to-spec -> to-tickets -> implement -> code-review` - where the orchestration skills are **user-invoked** (`disable-model-invocation: true`, the human types each stage and enforces context hygiene by hand) and the reusable disciplines (`tdd`, `code-review`, `domain-modeling`, `codebase-design`, `prototype`, `diagnosing-bugs`) are **model-invoked**, plus `wayfinder` (an on-ramp for too-big efforts) and `ask-matt` (a router over the user-invoked skills).
+
+Our workflow (ADR 0001) puts orchestration at the **model-invoked** layer: the model auto-enters Research -> Grill -> Implement -> Summarize by skill `description`. We evaluated adopting the pipeline wholesale.
+
+The decisive finding: the reusable-discipline layer is model-invoked on both sides - that is the compatible seam. All the conflict sits at the orchestration layer, where upstream is user-invoked and we are model-invoked.
+
+## Decision
+
+Vendor-and-adapt, not verbatim.
+
+- **Keep orchestration model-invoked.** Our `grill-with-docs` and `build` keep auto-firing as workflow phases; the panel-grilling addition and enforcement-layer tag convention are preserved.
+- **Merge upstream's disciplines into our existing skills** rather than importing them standalone: `test` gains the seams discipline + anti-patterns (tautological, horizontal-slicing); `debug` gains the build-a-red-loop-first gate, the minimise step, falsifiable-prediction format, and tagged-instrumentation cleanup; `review-pr` gains the spec-axis pass (does the diff match what the issue asked?); `improve-codebase-architecture` gains the testability and deep-vs-shallow content in its `LANGUAGE.md`.
+- **Add two new skills** where we had no equivalent: `prototype` (a model-invoked discipline - throwaway spike to de-risk one decision, then discard) and `wayfinder` (the sole new user-invoked on-ramp for too-big multi-session efforts, re-homed onto file-based decision maps under `.claude/state/` because we run no issue tracker).
+- **Keep our skill names** (`write-a-skill`, `to-issues`); adopt the upstream content and repoint the `> Source:` links.
+
+Explicitly NOT adopted: the user-invoked staging layer (`to-spec` / `to-tickets` / `implement` as separately typed stages); `ask-matt` (a router only earns its keep once orchestration is user-invoked); `triage` (multi-maintainer OSS intake, not a single-operator config); `code-review`'s Standards axis (redundant with `review-pr` + `prune` + the built-in `/code-review`); the HTML-report output mode (external CDNs conflict with our self-contained norms - the Artifact tool is the correct path if visual output is ever wanted); and `disable-model-invocation` across the board.
+
+## Consequences
+
+- "Adopt the pipeline" resolves to adopting its **composability** (small reusable disciplines) without its **user-invoked orchestration** - the part that conflicted.
+- We forgo upstream's context-hygiene staging (one unbroken window until tickets, fresh context per ticket) and its tracker-based ticketing. Our `.claude/state/` artifacts remain the cross-session state carrier.
+- `wayfinder` fills a real gap (the effort too big for one session) but loses native blocking edges and claim-by-assignment; acceptable for a single operator, and the panel/lane model (ADR 0005) covers the rare multi-agent case.
+- Vendored skills stay drifted from upstream by design (our tags, `> Source:` lines, name choices). Re-vendoring is manual - no pinned upstream SHA - so future syncs repeat this cherry-pick judgment rather than fast-forwarding.
+
+## Considered alternatives
+
+- **Full pipeline verbatim (all user-invoked) + `ask-matt`.** Rejected: inverts our auto-phase workflow, forces the human to sequence every stage, and needs a tracker plus router upkeep. The retraining cost is not justified for a single-operator config.
+- **Hybrid: model-enters / user-steps-stages, or user-kicks-off / model-runs.** Rejected: mixed mental model (the model auto-enters then stalls waiting for a manual next stage); the user-kicks variant also loses the context-hygiene that was the pipeline's main draw.
+- **Adopt the grill split (`grilling` + `domain-modeling`).** Rejected: strands our thin orchestrator pointing at two skills we would then have to vendor, duplicates our inline `CONTEXT.md` / ADR discipline, and discards our panel-grilling addition for zero capability gain.

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -22,11 +22,18 @@ Gather, do not theorize. Save findings to `.claude/state/research/YYYY-MM-DD-deb
 
 If the user already supplied a hypothesis, treat it as a candidate but still gather evidence to confirm or reject.
 
+### Build a red-capable feedback loop
+
+Before hypothesising, build a **tight, red-capable feedback loop** - one command (a failing test, a curl against a running server, a CLI invocation diffing output, a replayed trace) that you have **already run at least once** and that goes red on _this_ bug and green once fixed. Tighten it: faster, sharper signal, more deterministic (pin time, seed RNG). For a flaky bug, raise the reproduction rate until it's debuggable rather than chasing a clean repro. Then **minimise** - shrink to the smallest scenario that still goes red, cutting inputs, config, and steps one at a time. `(review-time: loop construction is creative work, not pattern-checkable)`
+
+No red-capable command, no Phase 2 - jumping to a hypothesis before the loop exists is the exact failure this skill prevents. If you genuinely cannot build one (production-only, no local repro), say so explicitly, list what you tried, and ask the user for environment access or a captured artifact (HAR, log dump, core dump) before proceeding. `(review-time: gate is a judgment about whether a real red-capable loop exists)`
+
 ## Phase 2 - Hypotheses
 
-List 2-3 possible root causes ranked by evidence strength. For each:
+List 3-5 possible root causes ranked by evidence strength - generating several up front stops you anchoring on the first plausible idea. For each:
 
 - **Hypothesis** - one line. `(review-time: see section note)`
+- **Prediction** - the falsifiable test it implies: "if this is the cause, then changing X makes the bug disappear / changing Y makes it worse." If you can't state a prediction, it's a vibe - sharpen or discard it. `(review-time: falsifiability judgment, not pattern-checkable)`
 - **Evidence for** - log lines, commits, or code paths that support it (with file:line refs). `(review-time: see section note)`
 - **Evidence against** - what would have to be true that isn't. `(review-time: see section note)`
 - **Cheapest verification** - what one command, query, or read would confirm or rule it out. `(review-time: see section note)`
@@ -36,7 +43,8 @@ Pick the top candidate. If two are tied or the user has a strong prior, ask the 
 ## Phase 3 - Fix
 
 - Minimal change first per CLAUDE.md (1-5 lines, ideally). State the change before applying it. `(review-time: see section note)`
-- Add a regression test that reproduces the original failure and now passes. `(review-time: see section note)`
+- Add a regression test that reproduces the original failure and now passes - only at a correct seam that exercises the real bug pattern; if no such seam exists, that itself is the finding, note it and hand off to `/improve-codebase-architecture`. `(review-time: see section note)`
+- Remove all temporary instrumentation before committing - tag every debug log with a unique prefix like `[DEBUG-a4f2]` when you add it, so cleanup is a single grep. `(review-time: see section note)`
 - Run `/verify-done` (lint + typecheck + test + build). `(review-time: see section note)`
 - Commit on a feature branch with a conventional message that names the root cause. `(review-time: see section note)`
 - Open a PR per `mr` skill. PR body: link to the alert/log, root cause statement with evidence, and why this fix is correct. `(review-time: see section note)`
@@ -46,5 +54,6 @@ Pick the top candidate. If two are tied or the user has a strong prior, ask the 
 - Adding retry / fallback / try-catch as a "fix" before root cause is confirmed. `(review-time: see section note)`
 - Introducing new abstractions, services, or workspaces as part of a debug fix. `(review-time: see section note)`
 - Editing logs to make the symptom disappear. `(review-time: see section note)`
+- Leaving untagged debug instrumentation in the code after the fix. `(review-time: see section note)`
 - Expanding scope ("while I'm here, let me also..."). `(review-time: see section note)`
 - Pushing before all checks pass green locally. `(review-time: see section note)`

--- a/skills/grill-with-docs/SKILL.md
+++ b/skills/grill-with-docs/SKILL.md
@@ -11,7 +11,9 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 
 Ask the questions one at a time, waiting for feedback on each question before continuing.
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+If a *fact* can be found by exploring the codebase, look it up instead of asking. The *decisions*, though, are mine - put each one to me and wait.
+
+Do not enact the plan until I confirm we have reached a shared understanding.
 
 </what-to-do>
 
@@ -75,7 +77,7 @@ When the user states how something works, check whether the code agrees. If you 
 
 When a term is resolved, update `CONTEXT.md` right there. Don't batch these up - capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
-Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts. `CONTEXT.md` is a glossary and nothing else - not a spec, not a scratch pad.
 
 ### Offer ADRs sparingly
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -4,12 +4,14 @@ description: Compact the current conversation into a handoff document for anothe
 argument-hint: "What will the next session be used for?"
 ---
 
-> Source: [mattpocock/skills — productivity/handoff](https://github.com/mattpocock/skills/tree/main/skills/productivity/handoff)
+> Source: [mattpocock/skills - productivity/handoff](https://github.com/mattpocock/skills/tree/main/skills/productivity/handoff)
 
 Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
 
 Suggest the skills to be used, if any, by the next session.
 
-Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+Redact any sensitive information - secrets, API keys, passwords, or personally identifiable information - before writing it into the document. `(review-time: no hook inspects free-form handoff-doc text before it is written)`
+
+Do not duplicate content already captured in other artifacts (specs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
 
 If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/skills/improve-codebase-architecture/LANGUAGE.md
@@ -35,7 +35,7 @@ What maintainers get from depth. Change, bugs, knowledge, and verification conce
 
 **Deep module** = small interface + lots of implementation:
 
-```
+```text
 ┌─────────────────────┐
 │   Small Interface   │  ← Few methods, simple params
 ├─────────────────────┤
@@ -47,7 +47,7 @@ What maintainers get from depth. Change, bugs, knowledge, and verification conce
 
 **Shallow module** = large interface + little implementation (avoid):
 
-```
+```text
 ┌─────────────────────────────────┐
 │       Large Interface           │  ← Many methods, complex params
 ├─────────────────────────────────┤

--- a/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,22 +1,22 @@
 # Language
 
-Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly - don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
 
 ## Terms
 
 **Module**
-Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+Anything with an interface and an implementation. Deliberately scale-agnostic - applies equally to a function, class, package, or tier-spanning slice.
 _Avoid_: unit, component, service.
 
 **Interface**
 Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
-_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+_Avoid_: API, signature (too narrow - those refer only to the type-level surface).
 
 **Implementation**
-What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+What's inside a module - its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
 
 **Depth**
-Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+Leverage at the interface - the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
 
 **Seam** _(from Michael Feathers)_
 A place where you can alter behaviour without editing in that place. The _location_ at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
@@ -31,12 +31,72 @@ What callers get from depth. More capability per unit of interface they have to 
 **Locality**
 What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
 
+## Deep vs shallow
+
+**Deep module** = small interface + lots of implementation:
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid):
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing an interface, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?
+
 ## Principles
 
-- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts - they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
 - **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
 - **The interface is the test surface.** Callers and tests cross the same seam. If you want to test _past_ the interface, the module is probably the wrong shape.
 - **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Designing for testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them.**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects.**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area.** Fewer methods = fewer tests needed. Fewer params = simpler test setup.
 
 ## Relationships
 
@@ -49,5 +109,5 @@ What maintainers get from depth. Change, bugs, knowledge, and verification conce
 ## Rejected framings
 
 - **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
-- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow - interface here includes every fact a caller must know.
 - **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/skills/prototype/LOGIC.md
+++ b/skills/prototype/LOGIC.md
@@ -1,0 +1,79 @@
+# Logic Prototype
+
+A tiny interactive terminal app that lets the user drive a state model by hand. Use this when the question is about **business logic, state transitions, or data shape** - the kind of thing that looks reasonable on paper but only feels wrong once you push it through real cases.
+
+## When this is the right shape
+
+- "I'm not sure if this state machine handles the edge case where X then Y."
+- "Does this data model actually let me represent the case where..."
+- "I want to feel out what the API should look like before writing it."
+- Anything where the user wants to **press buttons and watch state change**.
+
+If the question is "what should this look like" - wrong branch. Use [UI.md](UI.md).
+
+## Process
+
+### 1. State the question
+
+Before writing code, write down what state model and what question you're prototyping. One paragraph, in the prototype's README or a comment at the top of the file. A logic prototype that answers the wrong question is pure waste - make the question explicit so it can be checked later, whether the user is watching now or returning to it AFK.
+
+### 2. Pick the language
+
+Use whatever the host project uses. If the project has no obvious runtime (e.g. a docs repo), ask.
+
+Match the project's existing conventions for tooling - don't add a new package manager or runtime just for the prototype.
+
+### 3. Isolate the logic in a portable module
+
+Put the actual logic - the bit that's answering the question - behind a small, pure interface that could be lifted out and dropped into the real codebase later. The TUI around it is throwaway; the logic module shouldn't be.
+
+The right shape depends on the question:
+
+- **A pure reducer** - `(state, action) => state`. Good when actions are discrete events and state is a single value.
+- **A state machine** - explicit states and transitions. Good when "which actions are even legal right now" is part of the question.
+- **A small set of pure functions** over a plain data type. Good when there's no implicit current state - just transformations.
+- **A class or module with a clear method surface** when the logic genuinely owns ongoing internal state.
+
+Pick whichever shape best fits the question being asked, *not* whichever is easiest to wire to a TUI. Keep it pure: no I/O, no terminal code, no `console.log` for control flow. The TUI imports it and calls into it; nothing flows the other direction.
+
+This is what makes the prototype useful past its own lifetime: when the question's been answered, the validated reducer / machine / function set can be lifted into the real module on its own.
+
+### 4. Build the smallest TUI that exposes the state
+
+Build it as a **lightweight TUI** - on every tick, clear the screen (`console.clear()` / `print("\033[2J\033[H")` / equivalent) and re-render the whole frame. The user should always see one stable view, not an ever-growing scrollback.
+
+Each frame has two parts, in this order:
+
+1. **Current state**, pretty-printed and diff-friendly (one field per line, or formatted JSON). Use **bold** for field names or section headers and **dim** for less important context (timestamps, IDs, derived values). Native ANSI escape codes are fine - `\x1b[1m` bold, `\x1b[2m` dim, `\x1b[0m` reset. No need to pull in a styling library unless one is already in the project.
+2. **Keyboard shortcuts**, listed at the bottom: `[a] add user  [d] delete user  [t] tick clock  [q] quit`. Bold the key, dim the description, or vice-versa - whatever reads cleanly.
+
+Behaviour:
+
+1. **Initialise state** - a single in-memory object/struct. Render the first frame on start.
+2. **Read one keystroke (or one line)** at a time, dispatch to a handler that mutates state.
+3. **Re-render** the full frame after every action - don't append, replace.
+4. **Loop until quit.**
+
+The whole frame should fit on one screen.
+
+### 5. Make it runnable in one command
+
+Add a script to the project's existing task runner (`package.json` scripts, `Makefile`, `justfile`, `pyproject.toml`). The user should run `pnpm run <prototype-name>` or equivalent - never need to remember a path.
+
+If the host project has no task runner, just put the command at the top of the prototype's README.
+
+### 6. Hand it over
+
+Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" - those are the bugs in the _idea_, which is the whole point. If they want new actions added, add them. Prototypes evolve.
+
+### 7. Capture the answer and the prototype
+
+Once the prototype has answered its question, capture the answer, then capture the prototype the way the [SKILL](SKILL.md) describes. The logic-specific mapping: the validated reducer / machine / function set lifts into the real module (the decision, absorbed); the TUI shell rides along to the throwaway branch that keeps the prototype as a primary source.
+
+## Anti-patterns
+
+- **Don't add tests.** A prototype that needs tests is no longer a prototype.
+- **Don't wire it to the real database.** Use an in-memory store unless the question is specifically about persistence.
+- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't blur the logic and the TUI together.** If the reducer / state machine references `console.log`, prompts, or terminal escape codes, it's no longer portable. Keep the TUI as a thin shell over a pure module.
+- **Don't ship the TUI shell into production.** The shell is optimised for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.

--- a/skills/prototype/LOGIC.md
+++ b/skills/prototype/LOGIC.md
@@ -64,7 +64,7 @@ If the host project has no task runner, just put the command at the top of the p
 
 ### 6. Hand it over
 
-Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" - those are the bugs in the _idea_, which is the whole point. If they want new actions added, add them. Prototypes evolve.
+Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" - those are the bugs in the *idea*, which is the whole point. If they want new actions added, add them. Prototypes evolve.
 
 ### 7. Capture the answer and the prototype
 

--- a/skills/prototype/SKILL.md
+++ b/skills/prototype/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: prototype
+description: Build a throwaway prototype to answer a design question. Use when the user wants to sanity-check whether a state model or logic feels right, or explore what a UI should look like.
+---
+
+> Source: [mattpocock/skills - engineering/prototype](https://github.com/mattpocock/skills/tree/main/skills/engineering/prototype)
+
+# Prototype
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+## Pick a branch
+
+Identify which question is being answered - from the user's prompt, the surrounding code, or by asking if the user is around:
+
+- **"Does this logic / state model feel right?"** -> [LOGIC.md](LOGIC.md). Build a tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
+- **"What should this look like?"** -> [UI.md](UI.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+
+The two branches produce very different artifacts - getting this wrong wastes the whole prototype. If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module -> logic; a page or component -> UI) and state the assumption at the top of the prototype. `(review-time: branch-selection judgment from the question shape)`
+
+## Rules that apply to both
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious - but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure. `(review-time: naming/placement judgment, not pattern-checkable)`
+2. **One command to run.** Whatever the project's existing task runner supports - `pnpm <name>`, `python <path>`, `bun <path>`, etc. The user must be able to start it without thinking. `(review-time: matches the host project's runner, varies per repo)`
+3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE - wipe me" name. `(review-time: judging when persistence is the actual question)`
+4. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast. `(review-time: prototype scope discipline)`
+5. **Surface the state.** After every action (logic) or on every variant switch (UI), print or render the full relevant state so the user can see what changed. `(review-time: prototype-legibility judgment)`
+6. **Capture it when done.** Fold any validated decision into the real code, then capture the prototype itself as a **primary source**: commit it to a throwaway branch, out of main, and leave a context pointer to that branch on the implementation issue or the plan in `.claude/state/`. Capture the answer too - the verdict and the question it settled - in the issue, the plan, or a commit. The main branch keeps only the validated decision. `(review-time: capture discipline; adapts to whether a tracker or a .claude/state plan is in play)`

--- a/skills/prototype/UI.md
+++ b/skills/prototype/UI.md
@@ -1,0 +1,112 @@
+# UI Prototype
+
+Generate **several radically different UI variations** on a single route, switchable from a floating bottom bar. The user flips between variants in the browser, picks one (or steals bits from each), then throws the rest away.
+
+If the question is about logic/state rather than what something looks like - wrong branch. Use [LOGIC.md](LOGIC.md).
+
+## When this is the right shape
+
+- "What should this page look like?"
+- "I want to see a few options for this dashboard before committing."
+- "Try a different layout for the settings screen."
+- Any time the user would otherwise spend a day picking between three vague mockups in their head.
+
+## Two sub-shapes - strongly prefer sub-shape A
+
+A UI prototype is much easier to judge when it's **butting up against the rest of the app** - real header, real sidebar, real data, real density. A throwaway route on its own is a vacuum: every variant looks fine in isolation. Default to sub-shape A whenever there's a plausible existing page to host the variants. Only reach for sub-shape B if the prototype genuinely has no nearby home.
+
+### Sub-shape A - adjustment to an existing page (preferred)
+
+The route already exists. Variants are rendered **on the same route**, gated by a `?variant=` URL search param. The existing data fetching, params, and auth all stay - only the rendering swaps. This is the default; pick it unless there's a specific reason not to.
+
+If the prototype is for something that doesn't yet have a page but *would naturally live inside one* (a new section of the dashboard, a new card on the settings screen, a new step in an existing flow) - that's still sub-shape A. Mount the variants inside the host page.
+
+### Sub-shape B - a new page (last resort)
+
+Only use this when the thing being prototyped genuinely has no existing page to live inside - e.g. an entirely new top-level surface, or a flow that can't be embedded anywhere sensible.
+
+Create a **throwaway route** following whatever routing convention the project already uses - don't invent a new top-level structure. Name it so it's obviously a prototype (e.g. include the word `prototype` in the path or filename). Same `?variant=` pattern.
+
+Before committing to sub-shape B, sanity-check: is there really no existing page this could be embedded in? An empty route hides design problems that a populated one would expose.
+
+In both sub-shapes the floating bottom bar is identical.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**. More than 5 stops being radically different and starts being noise - cap there.
+
+Write down the plan in one line, in the prototype's location or a top-of-file comment:
+
+> "Three variants of the settings page, switchable via `?variant=`, on the existing `/settings` route."
+
+This works whether the user is here to push back or not.
+
+### 2. Generate radically different variants
+
+Draft each variant. Hold each one to:
+
+- The page's purpose and the data it has access to.
+- The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
+- A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
+
+Variants must be **structurally different** - different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+
+### 3. Wire them together
+
+Create a single switcher component on the route:
+
+```tsx
+// pseudo-code - adapt to the project's framework
+const variant = searchParams.get('variant') ?? 'A';
+return (
+  <>
+    {variant === 'A' && <VariantA {...data} />}
+    {variant === 'B' && <VariantB {...data} />}
+    {variant === 'C' && <VariantC {...data} />}
+    <PrototypeSwitcher variants={['A','B','C']} current={variant} />
+  </>
+);
+```
+
+For sub-shape A (existing page): keep all the existing data fetching above the switcher; only the rendered subtree changes per variant.
+
+For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts the same switcher.
+
+### 4. Build the floating switcher
+
+A small fixed-position bar at the bottom-centre of the screen with three pieces:
+
+- **Left arrow** - cycles to the previous variant (wraps around).
+- **Variant label** - shows the current variant key and, if the variant exports a name, that name too. e.g. `B - Sidebar layout`.
+- **Right arrow** - cycles forward (wraps around).
+
+Behaviour:
+
+- Clicking an arrow updates the URL search param (use the framework's router - `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
+- Keyboard: left and right arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
+- Visually distinct from the page (e.g. high-contrast pill, subtle shadow) so it's obviously not part of the design being evaluated.
+- Hidden in production builds - gate on `process.env.NODE_ENV !== 'production'` or an equivalent check, so a stray prototype merge can't ship the bar to users.
+
+Put the switcher in a single shared component so both sub-shapes can reuse it. Locate it wherever shared UI lives in the project.
+
+### 5. Hand it over
+
+Surface the URL (and the `?variant=` keys). The user will flip through whenever they get to it. The interesting feedback is usually **"I want the header from B with the sidebar from C"** - that's the actual design they want.
+
+### 6. Capture the answer and clean up
+
+Once a variant has won, capture the answer - which variant and why - then capture the prototype the way the [SKILL](SKILL.md) describes. Fold the winner into the real code and move the rest onto the throwaway branch, not into main:
+
+- **Sub-shape A** - fold the winner into the existing page; drop the losing variants and the switcher from main.
+- **Sub-shape B** - promote the winning variant to a real route; drop the throwaway route and the switcher from main.
+
+The full set of variants is the primary source, so it lands on the throwaway branch, not the bin - variant components and the switcher left in the main branch rot fast and confuse the next reader.
+
+## Anti-patterns
+
+- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
+- **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub - the question is "what should this look like", not "does the backend work".
+- **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -12,9 +12,10 @@ Follow this process:
 1. **Fetch PR details**: run `gh pr view $ARGUMENTS --json title,body,files,commits,additions,deletions,baseRefName,headRefName` `(review-time: see section note)`
 2. **Read the diff**: run `gh pr diff $ARGUMENTS` to see all changes `(review-time: see section note)`
 3. **Understand intent**: read the PR description, linked issues, and commit messages before reviewing code `(review-time: see section note)`
-4. **Load relevant agents**: based on the files changed, load the appropriate expert agents from `~/.claude/agents/` for domain-specific review `(review-time: see section note)`
-5. **Review systematically** using the checklist in @checklist.md `(review-time: see section note)`
-6. **Produce structured output** in this format: `(review-time: see section note)`
+4. **Spec-conformance pass** (when a spec exists): find the originating spec - issue refs in the commits (via `gh`), a linked issue, or a spec under `.claude/state/specs/` - and check the diff against it, ideally in a parallel sub-agent so it does not pollute the main review context: (a) requirements asked for but missing or partial; (b) behaviour in the diff nobody asked for (scope creep); (c) requirements that look implemented but wrong. Quote the spec line for each finding and place it in the severity buckets below. If there is no spec, skip this pass and note it. `(review-time: see section note)`
+5. **Load relevant agents**: based on the files changed, load the appropriate expert agents from `~/.claude/agents/` for domain-specific review `(review-time: see section note)`
+6. **Review systematically** using the checklist in @checklist.md `(review-time: see section note)`
+7. **Produce structured output** in this format: `(review-time: see section note)`
 
 ```markdown
 ## Summary

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -31,6 +31,12 @@ Write tests for: $ARGUMENTS
 
 If you cannot write a failing test, you do not fully understand the bug. Investigate further.
 
+## Seams - where tests go
+
+A **seam** is the public boundary you test at: the interface where you observe behaviour without reaching inside. Tests live at seams, never against internals.
+
+**Test only at pre-agreed seams.** Before writing any test, write down the seams under test and confirm them with the user - no test is written at an unconfirmed seam. `(review-time: seam agreement is a conversational step, not pattern-checkable)` You can't test everything; agreeing the seams up front lands testing effort on the critical paths and complex logic instead of every edge case.
+
 ## Test Level Selection
 
 Pick the lowest level that captures the behavior (see `references/testing-patterns.md`):
@@ -42,6 +48,12 @@ Pick the lowest level that captures the behavior (see `references/testing-patter
 | Database queries, migrations | Integration test | Needs real database behavior |
 | Critical user journeys | E2E test | Tests the full stack |
 | Visual appearance, layout | Visual regression | Screenshot comparison |
+
+## Anti-patterns
+
+- **Implementation-coupled** - mocks internal collaborators, tests private methods, or verifies through a side channel (querying the database instead of using the interface). The tell: the test breaks when you refactor but behaviour hasn't changed. `(review-time: coupling detection requires reading the assertions against the implementation)`
+- **Tautological** - the assertion recomputes the expected value the way the code does (`expect(add(a, b)).toBe(a + b)`, a self-derived snapshot, a constant asserted equal to itself), so it passes by construction and can never disagree with the code. Expected values must come from an independent source of truth - a known-good literal, a worked example, the spec. `(review-time: requires comparing the assertion to how the code computes)`
+- **Horizontal slicing** - writing all tests first, then all implementation. Bulk tests verify _imagined_ behaviour and go insensitive to real changes. Work in vertical slices instead: one test, one implementation, repeat - each test a tracer bullet responding to what the last cycle taught you. `(review-time: workflow-shape judgment)`
 
 ## Test Quality Gates
 

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -3,13 +3,13 @@ name: to-issues
 description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.
 ---
 
-> Source: [mattpocock/skills — engineering/to-issues](https://github.com/mattpocock/skills/tree/main/skills/engineering/to-issues)
+> Source: [mattpocock/skills - engineering/to-tickets](https://github.com/mattpocock/skills/tree/main/skills/engineering/to-tickets)
 
 # To Issues
 
 Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
 
-The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+Target the project's issue tracker directly - GitHub via `gh` or Jira via `acli`, per `rules/git-conventions.md` and `rules/jira.md`. Use whatever label the tracker already uses to mark agent-ready work.
 
 ## Process
 
@@ -20,6 +20,8 @@ Work from whatever is already in the conversation context. If the user passes an
 ### 2. Explore the codebase (optional)
 
 If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier - "make the change easy, then make the easy change." Any prefactoring should be its own issue, sequenced first. `(review-time: see section note)`
 
 ### 3. Draft vertical slices
 
@@ -32,8 +34,13 @@ Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an
 <vertical-slice-rules>
 - Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests) `(review-time: see section note)`
 - A completed slice is demoable or verifiable on its own `(review-time: see section note)`
+- Each slice is sized to fit in a single fresh context window `(review-time: see section note)`
 - Prefer many thin slices over few thick ones `(review-time: see section note)`
 </vertical-slice-rules>
+
+Give each issue its **blocking edges** - the other issues that must complete before it can start. An issue with no blockers can start immediately. `(review-time: see section note)`
+
+**Wide refactors are the exception to vertical slicing.** A wide refactor is one mechanical change - rename a column, retype a shared symbol - whose blast radius fans across the whole codebase, so a single edit breaks many call sites at once and no vertical slice can land green. Don't force it into a tracer bullet; sequence it as expand-migrate-contract. First **expand**: add the new form beside the old so nothing breaks. Then **migrate** the call sites in batches sized by blast radius (per package, per directory), each batch its own issue blocked by the expand, keeping CI green batch to batch because the old form still exists. Finally **contract**: delete the old form once no caller remains, in an issue blocked by every migrate batch. When even the batches can't stay green alone, keep the sequence but let them share an integration branch that all block a final integrate-and-verify issue - green is promised only there. `(review-time: see section note)`
 
 ### 4. Quiz the user
 
@@ -59,6 +66,8 @@ For each approved slice, publish a new issue to the issue tracker. Use the issue
 
 Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
 
+Work the **frontier**: any issue whose blockers are all done - for a purely linear chain that means top to bottom. Implementation happens one issue at a time via `/build`, clearing context between issues. `(review-time: see section note)`
+
 <issue-template>
 ## Parent
 
@@ -68,7 +77,7 @@ A reference to the parent issue on the issue tracker (if the source was an exist
 
 A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
 
-Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+Avoid specific file paths or code snippets - they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts - not a working demo, just the important bits.
 
 ## Acceptance criteria
 

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: wayfinder
+description: Plan a huge chunk of work - more than one agent session can hold - as a shared map of decision tickets in a local file, and resolve them one at a time until the way to the destination is clear.
+disable-model-invocation: true
+---
+
+> Source: [mattpocock/skills - engineering/wayfinder](https://github.com/mattpocock/skills/tree/main/skills/engineering/wayfinder), re-homed onto a local file map (this repo runs no issue tracker - see ADR 0006).
+
+A loose idea has arrived - too big for one agent session, and wrapped in fog: the way from here to the **destination** isn't visible yet. Wayfinding is about finding that way, not charging at the destination. This skill charts the way as a **shared map** in a local file, then works its **decision tickets** - questions whose resolution is a decision, not slices of a build to execute - one at a time until the route is clear.
+
+The destination varies per effort, and naming it is the first act of charting - it shapes every ticket. It might be a spec to hand off and iterate on, a decision to lock before planning starts, or a change made in place like a data-structure migration. The map is domain-agnostic - engineering work, infra work, whatever fits the shape.
+
+## Plan, don't do
+
+Wayfinder is **planning** by default: each ticket resolves a decision, and the map is done when the way is clear - nothing left to decide before someone goes and does the thing. The pull to just do the work is usually the signal you've reached the edge of the map and it's time to hand off to `/spec`. An effort can override this in its **Notes** - carrying execution into the map itself - but absent that, produce decisions, not deliverables. `(review-time: plan-vs-do judgment; the pull to execute is the hand-off signal)`
+
+## Refer by name
+
+Every ticket has a **name** - its heading. In everything the human reads - narration, the map's Decisions-so-far - refer to it by that name, never by a bare index or number. A wall of `#1, #2, #3` is illegible; names read at a glance. `(review-time: legibility discipline in narration)`
+
+## The Map
+
+The map is a single markdown file at `.claude/state/wayfinder/<effort-slug>.md` - the canonical artifact. Its tickets live inside it under `## Tickets`.
+
+The map is an **index**, not a store. Its Decisions-so-far lists the decisions made; a decision lives in exactly one place - its ticket's `Answer` - so the map never restates it, only gists it. `(review-time: single-source-of-truth discipline)`
+
+### The map body
+
+The whole map at low resolution, loaded once per session.
+
+```markdown
+# Wayfinder: <effort name>
+
+## Destination
+
+<what reaching the end of this map looks like - the spec, decision, or change this effort is finding its way to. One or two lines; every session orients to it before choosing a ticket.>
+
+## Notes
+
+<domain; skills every session should consult; standing preferences for this effort>
+
+## Decisions so far
+
+<!-- the index - one line per closed ticket: enough to judge relevance -->
+
+- **<closed ticket name>** - <one-line gist of the answer>
+
+## Not yet specified
+
+<!-- see "Fog of war": in-scope fog you can't ticket yet; graduates as the frontier advances -->
+
+## Out of scope
+
+<!-- see "Out of scope": work ruled beyond the destination; closed, never graduates -->
+
+## Tickets
+
+### <ticket name>
+
+- Type: research | prototype | grilling | task
+- Mode: HITL | AFK
+- Blocked by: <ticket names, or "-">
+- Status: open | in-progress | closed
+- Question: <the decision or investigation this ticket resolves>
+- Answer: <recorded on resolution>
+```
+
+### Tickets
+
+Each ticket is an entry under `## Tickets`, sized to one ~100K-token agent session. Its `Question` is the decision it resolves. Each carries a **Type** - one of `research`, `prototype`, `grilling`, `task` (see [Ticket Types](#ticket-types)).
+
+A session **claims** a ticket by setting its `Status: in-progress` before any work, so a concurrent session skips it. `(review-time: soft claim; matters only when the map is worked across concurrent sessions)`
+
+**Blocking edges are plain text** in the `Blocked by` field, naming the tickets that must close first. A ticket is **unblocked** when every ticket blocking it is closed; the **frontier** is the open, unblocked, unclaimed tickets - the edge of the known. Scan the `## Tickets` section to compute the frontier; there is no tracker UI to render it. `(review-time: frontier is derived by reading the map, not queried)`
+
+The `Answer` is recorded on resolution (see [Work through the map](#work-through-the-map)). Assets created while resolving a ticket are linked from the ticket, not pasted in.
+
+## Ticket Types
+
+Every ticket is either **HITL** - human in the loop, worked *with* a human who speaks for themselves - or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this). `(review-time: HITL boundary; the agent must not fabricate the human's side)`
+
+- **Research** (AFK): Reading documentation, third-party APIs, or local resources to surface a fact a decision waits on. Resolved by a `/research` subagent. Use when knowledge outside the current working directory is required.
+- **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to - via the `/prototype` skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
+- **Grilling** (HITL): Conversation via the `/grill-with-docs` skill, one question at a time. The default case.
+- **Task** (HITL or AFK): Manual work that must happen before a *decision* can be made - nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that *does* rather than decides - and it earns its place by unblocking a decision, not by delivering the destination. The agent drives it alone where it can (AFK); otherwise it hands the human a precise checklist (HITL). Resolved when the work is done; the answer records what was done and any resulting facts later tickets depend on.
+
+## Fog of war
+
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** - the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets - one at a time, until the way to the destination is clear and no tickets remain.
+
+The map's **Not yet specified** section is where that dim view is written down: the suspected question, the area to revisit later. Write as loosely or as fully as the view allows.
+
+**Fog or ticket?** The test is whether you can state the question precisely now - _not_ whether you can answer it now. `(review-time: fog-vs-ticket judgment; sharpness of the question, not its answerability)`
+
+- **Ticket when** the question is already sharp - even if it's blocked and you can't act on it yet.
+- **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces.
+
+**Not yet specified** excludes what's already decided (Decisions so far), what's already a live ticket, and what's out of scope.
+
+## Out of scope
+
+The destination fixes the scope, so work beyond it is **out of scope** - it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section: work you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it here. `(review-time: scope-boundary judgment)`
+
+Out-of-scope work never graduates - the frontier stops at the destination - so it returns only if the destination is redrawn, and then as a fresh effort.
+
+When a ticket turns out to sit past the destination, **close it** and leave one line in the **Out of scope** section: the gist plus why it's out of scope. It stays out of **Decisions so far**, which records the route actually walked.
+
+## Invocation
+
+Two modes. Either way, **never resolve more than one ticket per session** - with the exception of research tickets. `(review-time: one-ticket-per-session bound keeps context within the smart zone)`
+
+### Chart the map
+
+User invokes with a loose idea.
+
+1. **Name the destination.** Run a `/grill-with-docs` session to pin down what this map is finding its way to - the spec, decision, or change. The destination fixes the scope, so it's settled first.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** - the way to the destination is already clear, the whole journey small enough for one session - you don't need a map. Stop and ask the user how they'd like to proceed. `(review-time: no-fog exit; a well-scoped effort does not need a map)`
+3. **Create the map file** at `.claude/state/wayfinder/<slug>.md`: Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
+4. **Create the tickets you can specify now** under `## Tickets`, then wire `Blocked by` edges. Everything you can't yet specify stays in **Not yet specified**.
+5. **Fire the research subagents.** For each `research` ticket, spin up a `/research` subagent to resolve it in parallel, capturing findings with a context pointer from the ticket.
+6. Stop - charting is one session's work; it hand-resolves nothing.
+
+### Work through the map
+
+User invokes with a map (file path). A ticket is **optional** - without one, you pick the next frontier decision, not the user.
+
+1. Load the **map** file - the low-res view.
+2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: set `Status: in-progress` before any work.
+3. Resolve it - invoke the skills the `## Notes` block names. If in doubt, use `/grill-with-docs`.
+4. Record the resolution: fill the ticket's `Answer`, set `Status: closed`, and append a one-line gist to **Decisions so far**.
+5. Add newly-surfaced tickets and graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified**. If the answer reveals a ticket sits beyond the destination, **rule it out of scope** rather than resolving it. If the decision invalidates other parts of the map, update or delete those tickets.
+
+Concurrent sessions may work unblocked tickets in parallel (via lane mode, per `rules/parallel-agents.md`); expect the map file to be edited concurrently and re-read before writing.

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -86,11 +86,11 @@ Every ticket is either **HITL** - human in the loop, worked *with* a human who s
 
 ## Fog of war
 
-The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** - the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets - one at a time, until the way to the destination is clear and no tickets remain.
+The map is *deliberately* incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** - the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets - one at a time, until the way to the destination is clear and no tickets remain.
 
 The map's **Not yet specified** section is where that dim view is written down: the suspected question, the area to revisit later. Write as loosely or as fully as the view allows.
 
-**Fog or ticket?** The test is whether you can state the question precisely now - _not_ whether you can answer it now. `(review-time: fog-vs-ticket judgment; sharpness of the question, not its answerability)`
+**Fog or ticket?** The test is whether you can state the question precisely now - *not* whether you can answer it now. `(review-time: fog-vs-ticket judgment; sharpness of the question, not its answerability)`
 
 - **Ticket when** the question is already sharp - even if it's blocked and you can't act on it yet.
 - **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces.
@@ -99,7 +99,7 @@ The map's **Not yet specified** section is where that dim view is written down: 
 
 ## Out of scope
 
-The destination fixes the scope, so work beyond it is **out of scope** - it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section: work you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it here. `(review-time: scope-boundary judgment)`
+The destination fixes the scope, so work beyond it is **out of scope** - it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section: work you've consciously ruled out of *this* effort. Scope, not sharpness, lands it here. `(review-time: scope-boundary judgment)`
 
 Out-of-scope work never graduates - the frontier stops at the destination - so it returns only if the destination is redrawn, and then as a fresh effort.
 

--- a/skills/write-a-skill/GLOSSARY.md
+++ b/skills/write-a-skill/GLOSSARY.md
@@ -66,11 +66,7 @@ _Avoid_: chunking, modularity
 
 ## Information Hierarchy
 
-How a skill's content is arranged, and how far down the ladder each piece sits.
-
-### Information Hierarchy
-
-A skill's content ranked by how immediately the agent needs it - a single ladder, produced by two cuts: in-file or behind a pointer, and step or reference. The rungs:
+How a skill's content is arranged, and how far down the ladder each piece sits: a skill's content ranked by how immediately the agent needs it - a single ladder, produced by two cuts: in-file or behind a pointer, and step or reference. The rungs:
 
 - **Steps** - in-file, primary
 - **Reference**, in-file - secondary

--- a/skills/write-a-skill/GLOSSARY.md
+++ b/skills/write-a-skill/GLOSSARY.md
@@ -1,0 +1,201 @@
+# Glossary - Building Great Skills
+
+The domain model for what makes a skill great. A skill exists to wrangle determinism out of a stochastic system; the root virtue is **Predictability**, and every term below is a lever on it. This is the disclosed reference for [`SKILL.md`](SKILL.md).
+
+The terms are grouped by axis: **Invocation** (how a skill is reached), **Information Hierarchy** (how its content is arranged), **Steering** (how the agent's runtime behaviour is shaped), and **Pruning** (how it is kept lean). Each **failure mode** lives beside the lever that cures it, tagged _failure mode_.
+
+**Bold terms** in any definition are themselves defined in this glossary; find them by their heading.
+
+## Predictability
+
+The degree to which a skill makes the agent behave the same _way_ on every run - the same process, not the same output (a brainstorming skill should _predictably_ diverge; its tokens vary, its behaviour doesn't). The root virtue every other term serves - cost and maintainability are symptoms of it, not rivals.
+
+_Avoid_: consistency, reliability, robustness, output-determinism
+
+## Invocation
+
+How a skill is reached - and the two loads you pay for the choice.
+
+### Model-Invoked
+
+A skill that keeps its **description** field, so the agent can see it and fire it autonomously - and the human can still type its name, so model-invocation always _includes_ user reach. There is no model-only state: a description only ever _adds_ agent discovery, never removes the human's. Pays a permanent **context load** on every turn in exchange for that discoverability. Reachable by other skills, because the description that makes it agent-discoverable makes it invocable. A model-invoked skill whose content is all **reference** is also one home for shared reference: another skill can invoke it, so reference needed by several skills lives in one place. Pick model-invocation only when the agent must reach the skill on its own; if it never fires except by hand, drop the description and pay no context load.
+
+_Avoid_: ability, tool, capability
+
+### User-Invoked
+
+A skill with its **description** stripped - invisible to the agent and reachable only by the human typing its name (user-_only_, where **model-invoked** is user-_and-agent_). Trades agent-discoverability for zero **context load**. Because it has no description, nothing but the human can reach it: no other skill can fire it.
+
+_Avoid_: procedure, workflow, command
+
+### Description
+
+The skill's machine-readable trigger, and the one **context pointer** a **model-invoked** skill is forced to keep loaded at all times. Its mere presence _is_ the invocation axis: keep it and the skill is model-invoked (and reachable by other skills); delete it and the skill is **user-invoked**, reachable only by the human. The source of a model-invoked skill's **context load**.
+
+_Avoid_: frontmatter, summary
+
+### Context Pointer
+
+A reference held in the agent's context that names some out-of-context material and encodes the condition for reaching it. The **description** is the top-level context pointer (context window -> skill); pointers to disclosed files are the same object one level down. Its wording, not the target, decides _when_ the agent reaches - and _how reliably_. A must-have target behind a weakly worded pointer is a variance bug: fix the wording first, and inline the material only if sharpening fails.
+
+_Avoid_: link, reference, import
+
+### Context Load
+
+The cost a **model-invoked** skill imposes on the agent's context window - its **description**, always loaded, spending both tokens and attention. What **user-invoked** skills escape by having no description, and the brake on splitting into more model-invoked skills.
+
+_Avoid_: token cost, context bloat
+
+### Cognitive Load
+
+The cost a **user-invoked** skill imposes on the human - what they must hold in their head: which skills exist and when to reach for each (the human is the index). What **model-invocation** removes by being agent-discoverable, and the brake on splitting into more user-invoked skills. Not a cost to minimise: it is the price of human agency, the reason some skills stay user-invoked. Spend it where human judgement matters; remove it where it does not.
+
+_Avoid_: human index, burden, overhead
+
+### Router Skill
+
+A **user-invoked** skill whose job is to point at your other user-invoked skills - naming each and when to reach for it - so the human has one skill to remember instead of many. It can only hint, never fire them: user-invoked skills have no **description**, so nothing but the human can reach them. The cure for **cognitive load** when user-invoked skills multiply.
+
+_Avoid_: dispatcher, menu, registry, index, router procedure
+
+### Granularity
+
+How finely you divide skills. Finer division spends one of the two loads: more **model-invoked** skills spend **context load** (more descriptions crowding the window and competing for attention); more **user-invoked** skills spend **cognitive load** (more for the human to remember and reach for). Two cuts guide the division. By **invocation**, split off a model-invoked skill where you have a distinct **leading word** to trigger it - a trigger word you actually use in your prompts. By **sequence**, split a run of **steps** where a step's **post-completion steps** need hiding, since isolating it in its own context clears what follows. Beware the reverse: merging sequences exposes each step's post-completion steps to what follows, inviting premature completion.
+
+_Avoid_: chunking, modularity
+
+## Information Hierarchy
+
+How a skill's content is arranged, and how far down the ladder each piece sits.
+
+### Information Hierarchy
+
+A skill's content ranked by how immediately the agent needs it - a single ladder, produced by two cuts: in-file or behind a pointer, and step or reference. The rungs:
+
+- **Steps** - in-file, primary
+- **Reference**, in-file - secondary
+- **Reference**, disclosed - behind a **context pointer**
+
+A skill with no **steps** uses just the bottom two rungs - often a legitimately flat peer-set (e.g. every rule of a review on one rung), which is a fine arrangement, not a smell. The hierarchy is independent of invocation: a skill can be model- or user-invoked whether it is all steps, all reference, or both. When a skill has steps, in-file reference that should be disclosed buries them and turns attending to them into a coin-flip - a variance lever, not just a legibility one. Keep the top of the ladder legible; push down it whatever you can.
+
+_Avoid_: structure, organization, layout
+
+### Steps
+
+The ordered actions the agent performs - when a skill has them, the primary tier of its content, and the part that earns its place in SKILL.md. Not every skill has steps: a skill can be all steps (`tdd`), all **reference** (a review), or both, independent of invocation. Every step ends on a **completion criterion**, clear or vague.
+
+_Avoid_: workflow, instructions, choreography
+
+### Reference
+
+Material the agent refers to on demand - definitions, facts, parameters, examples, conditional instructions. When a skill has **steps** it is secondary to them; when a skill has none it is the entire content; or it lives outside any skill entirely - see **External Reference**. Reached via **context pointers**, and the prime candidate for **progressive disclosure**.
+
+_Avoid_: supporting material, docs, background
+
+### External Reference
+
+**Reference** that lives outside the skill system - a plain file, no **description**, no **steps**, not invocable - that any skill can point at. The home for shared reference that needn't fire on its own, and the only shared home two **user-invoked** skills can use, since neither has a description and so neither can fire the other.
+
+_Avoid_: doc, resource, knowledge base
+
+### Progressive Disclosure
+
+Moving **reference** down the ladder - out of SKILL.md and behind a **context pointer** - so the top stays legible. Not primarily a token optimisation; it is how the **information hierarchy** is protected. Licensed by **branching**: disclose what only some branches need, inline what every path needs, and if a pointer fires unreliably on must-have material, sharpen its wording, and pull it back inline only if that fails.
+
+_Avoid_: lazy loading, chunking
+
+### Co-location
+
+Keeping the material an agent needs at once in one place - a concept's definition, rules, and caveats under a single heading, not scattered across the file - so reading one part brings its neighbours with it. The within-file companion to the **Information Hierarchy**: the hierarchy ranks _how far down_ a piece sits; co-location decides _what sits beside it_ once there. There is no formula for the right format of a body of **reference**; the test is that a skill should read like documentation written for the agent, and grouped material reads that way where scattered material does not. Distinct from **Duplication**: that repeats one meaning in two places, where scattering fragments a single meaning across many.
+
+_Avoid_: grouping, clustering, cohesion
+
+### Sprawl
+
+_Failure mode._ A skill that is simply too long - too many lines in SKILL.md - independent of whether they are stale or repeated. Even an all-live, all-unique skill can sprawl. It costs readability (the agent wades through more before it can act, and attention thins across the excess), maintainability (every extra line is one more to keep **relevant**), and tokens. The cure is the **information hierarchy**: push **reference** down behind **context pointers**, and split by **branch** or sequence so each path carries only what it needs. Distinct from **sediment** (length from stale accumulation) and **duplication** (length from repeated meaning) - sprawl is length itself, whatever its cause.
+
+_Avoid_: bloat, length, size, verbosity
+
+## Steering
+
+The levers that shape the agent's runtime behaviour toward **Predictability**.
+
+### Branch
+
+A distinct way a skill can be invoked - a case the skill handles - so different runs take different paths through it. A skill with many steps may carry many branches; a linear one has none.
+
+_Avoid_: path, case, fork
+
+### Leading Word
+
+A compact concept - also called a _Leitwort_ - already living in the model's pretraining, that the agent thinks with while running the skill. It encodes a behavioural principle in the fewest possible tokens by invoking priors the model already holds (e.g. _lesson_, _proximal zone of development_, _fog of war_, _tracer bullets_). Repeated as a token, never as a sentence, it accumulates a distributed definition across the skill and anchors a whole region of behaviour. Coining your own works if you define it clearly, but a made-up word recruits no priors - you pay in definition tokens what a pretrained word gives free. Reach for an existing word first.
+
+A leading word serves **predictability** twice. In the body it anchors **execution** - the agent reaches for the same behaviour every time the concept appears, and inside flat reference it focuses attention on a class of thing to look for, recruiting the right checks each run. In the **description** it anchors **invocation** - and not only within the skill: when the same word lives in your prompts, your docs, and your codebase, the agent links that shared language to the skill and fires it more reliably. Word a description with the leading words you actually use when you want the skill.
+
+_Avoid_: keyword, term, motif
+
+### Completion Criterion
+
+The condition that tells the agent a unit of work is done - the target it judges against. Two properties make it a lever, not just a quality. Its **clarity** (can the agent tell done from not-done?) resists **premature completion** - a vague bound ("understanding reached") lets the agent declare done and slip to the next step; this axis needs _steps_ to bite, since premature completion is a between-steps failure. Its **demand** (how much it requires) sets **legwork** - "every modified model accounted for" forces thorough work where "produce a change list" does not - and this axis is _not_ step-bound: it can bind a body of flat reference too, which is how a skill with no steps still carries an exhaustiveness bar ("every rule applied"). The strongest criteria are both checkable and exhaustive.
+
+_Avoid_: done condition, exit condition, stopping rule
+
+### Legwork
+
+The work an agent does behind the scenes within a single step - reading files, exploring the codebase, making changes, digging up what it needs rather than offloading to the user. It lives below the step structure: never written as its own step, latent in the wording, controlled by the agent rather than the skill. The within-step counterpart to **post-completion steps**' across-step pull. Raised by a **leading word** (_comprehensive_, _thorough_) or a **completion criterion** that demands the work be exhaustive - including the demand axis applied to flat reference, which is what drives a skill of flat reference to cover all its rungs. Goes thin either when that demand is missing or when **premature completion** cuts the step short.
+
+_Avoid_: scope, effort, diligence, coverage
+
+### Post-Completion Steps
+
+The **steps** that follow the current step. Visible, they pull the agent forward into **premature completion** - the more it sees, the stronger the tug; the defence is to hide them by splitting the sequence of steps into two.
+
+_Avoid_: horizon, fog of war, lookahead
+
+### Premature Completion
+
+_Failure mode._ Ending the current step before it is genuinely done, because the agent's attention slips to being done rather than to the work. A between-steps failure: it needs **steps** to occur - a skill with no steps that quits early isn't premature completion but thin **legwork** under an unmet demand. A tug-of-war between two forces: visible **post-completion steps** (the pull forward) and the **completion criterion**'s clarity (the resistance - a sharp, checkable bar holds; a vague one gives way). Fuzziness is the necessary condition: a sharp bound resists the pull no matter how many later steps are visible, so a step that never rushes needs no defending. Two levers hold a step that does, but reach for them in order: **sharpen the bound first** - it is local and cheap. Only when the criterion is irreducibly fuzzy _and_ you actually observe the rush do you **hide the later steps** - and hiding only works across a real context boundary (a user-invoked hand-off or a subagent dispatch; an inline model-invoked call leaves the later steps in context and clears nothing). One cause of thin legwork, but distinct from it: legwork can be thin even when a step runs to full completion.
+
+_Avoid_: premature closure, the rush, rushing, shortcutting
+
+### Negation
+
+_Failure mode._ Steering by prohibition - telling the agent what _not_ to do - which drags the forbidden behaviour into context and makes it _more_ available, not less. _Don't think of an elephant_, and the elephant is all there is; _never write verbose comments_, and verbosity is the pattern the agent has just read. The negation is a weak modifier the strongly-activated concept overruns, so the ban half-reads as an instruction to do the thing. Its **leading word** is the _elephant_: whatever a prohibition names into the frame. Cure: prompt the **positive** - describe the target behaviour ("write one-line comments") so the banned one is never spoken. A prohibition earns its place only as a hard guardrail on a behaviour you cannot phrase positively; even then, pair it with the positive target so attention lands on what to do.
+
+_Avoid_: ironic rebound, don't-prompting, the pink elephant
+
+## Pruning
+
+Keeping a skill lean - each remedy paired with the failure it cures.
+
+### Single Source of Truth
+
+The desired state where each meaning lives in exactly one authoritative place, so a change to the skill's behaviour is a change in one place. **Duplication** is its violation.
+
+_Avoid_: home, canonical location
+
+### Duplication
+
+_Failure mode._ The same meaning given more than one **single source of truth**. It costs maintenance (change one place, you must change the others), costs tokens, and inflates prominence - repeating a meaning weights it on the ladder past its real rank. The accidental inverse of a **leading word**, which raises attention on purpose by repeating a token, never the meaning.
+
+_Avoid_: repetition, redundancy
+
+### Relevance
+
+Whether a line still bears on what the skill does - the lens for what to keep. A line loses relevance either by never bearing on the task (mere exposition, or a **branch** that should be disclosed) or by going stale: drifting out of date as the behaviour or world it describes changes. Shorter skills are easier to keep relevant, because each line is cheaper to check. Distinct from **no-op**: relevance asks whether a line bears on the task, not whether it changes behaviour.
+
+_Avoid_: load-bearing, staleness, freshness
+
+### Sediment
+
+_Failure mode._ Layers of old content that settle in a skill and are never cleared, because adding feels safe and removing feels risky - so stale and irrelevant lines accumulate and you must core down through them to find what is still live. The default fate of any skill without a pruning discipline; the slow erosion of **relevance**, as opposed to **duplication**'s repeated meaning.
+
+_Avoid_: accretion, bloat, cruft, rot
+
+### No-Op
+
+_Failure mode._ An instruction that changes nothing because the model already does it by default - you pay load to tell the agent what it would do anyway. The test: does a line change behaviour versus the default? A line can be perfectly **relevant** and still be a no-op. The same priors that make a **leading word** free make a no-op worthless.
+
+A leading word is a _technique_; No-Op is a _verdict_ on a line - and they cross. A leading word too weak to beat the default is a no-op (_be thorough_ when the agent is already thorough-ish), and the fix is a stronger word that passes the verdict (_relentless_), not a different technique. So the No-Op test - does it change behaviour versus the default? - is also how you grade whether a leading word is earning its repetitions. This is model-relative, not reader-relative: two people disagreeing over whether a line is a no-op disagree about the default, and settle it by running the skill, not by debate.
+
+_Avoid_: redundant instruction, restating the obvious, belaboring

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -1,121 +1,88 @@
 ---
 name: write-a-skill
-description: Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.
+description: Reference and principles for writing and editing skills well - the vocabulary that makes a skill predictable. Use when creating, writing, editing, reviewing, or refactoring an agent skill.
 ---
 
-> Source: [mattpocock/skills — productivity/write-a-skill](https://github.com/mattpocock/skills/tree/main/skills/productivity/write-a-skill)
+> Source: [mattpocock/skills - productivity/writing-great-skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-great-skills). Kept model-invoked here (see ADR 0006); full definitions in [GLOSSARY.md](GLOSSARY.md).
 
-# Writing Skills
+A skill exists to wrangle determinism out of a stochastic system. **Predictability** - the agent taking the same _process_ every run, not producing the same output - is the root virtue; every lever below serves it.
 
-## Process
+**Bold terms** are defined in [`GLOSSARY.md`](GLOSSARY.md); look them up there for the full meaning.
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+## Invocation
 
-1. **Gather requirements** - ask user about: `(review-time: see section note)`
-   - What task/domain does the skill cover? `(review-time: see section note)`
-   - What specific use cases should it handle? `(review-time: see section note)`
-   - Does it need executable scripts or just instructions? `(review-time: see section note)`
-   - Any reference materials to include? `(review-time: see section note)`
+Two choices, trading different costs:
 
-2. **Draft the skill** - create: `(review-time: see section note)`
-   - SKILL.md with concise instructions `(review-time: see section note)`
-   - Additional reference files if content exceeds 500 lines `(review-time: see section note)`
-   - Utility scripts if deterministic operations needed `(review-time: see section note)`
+- A **model-invoked** skill keeps a **description**, so the agent can fire it autonomously _and_ other skills can reach it (you can still type its name too). It contributes to **context load** - the description sits in the window every turn. Mechanics: omit `disable-model-invocation`, and write a model-facing description with rich trigger phrasing ("Use when the user wants..., mentions...").
+- A **user-invoked** skill strips the description from the agent's reach: only you, typing its name, can invoke it - and no other skill can. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing - a one-line summary, trigger lists stripped.
 
-3. **Review with user** - present draft and ask: `(review-time: see section note)`
-   - Does this cover your use cases? `(review-time: see section note)`
-   - Anything missing or unclear? `(review-time: see section note)`
-   - Should any section be more/less detailed? `(review-time: see section note)`
+Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
 
-## Skill Structure
+When user-invoked skills multiply past what you can remember, that piled-up cognitive load is cured by a **router skill**: one user-invoked skill that names the others and when to reach for each.
 
-```text
-skill-name/
-├── SKILL.md           # Main instructions (required)
-├── REFERENCE.md       # Detailed docs (if needed)
-├── EXAMPLES.md        # Usage examples (if needed)
-└── scripts/           # Utility scripts (if needed)
-    └── helper.js
-```
+## Writing the description
 
-## SKILL.md Template
+A model-invoked **description** does two jobs - state what the skill is, and list the **branches** that should trigger it. Every word increases **context load**, so a description earns even harder pruning than the body:
 
-```md
----
-name: skill-name
-description: Brief description of capability. Use when [specific triggers].
----
+- **Front-load the skill's leading word** - the description is where it does its invocation work. `(review-time: skill-authoring judgment, not pattern-checkable)`
+- **One trigger per branch.** Synonyms that rename a single branch are **duplication** - "build features using TDD ... asks for test-first development" is one branch written twice. Collapse them; keep only genuinely distinct branches. `(review-time: skill-authoring judgment, not pattern-checkable)`
+- **Cut identity that's already in the body.** Keep the description to triggers, plus any "when another skill needs..." reach clause. `(review-time: skill-authoring judgment, not pattern-checkable)`
 
-# Skill Name
+## Information hierarchy
 
-## Quick start
+A skill is built from two content types - **steps** and **reference** - that mix freely: a skill can be all steps, all reference, or both. The core decision is which to use and where each sits on the **information hierarchy**, a ladder ranked by how immediately the agent needs the material:
 
-[Minimal working example]
+1. **In-skill step** - an ordered action in `SKILL.md`, the primary tier: what the agent does, in order. Each step ends on a **completion criterion**, the condition that tells the agent the work is done. Make it _checkable_ (can the agent tell done from not-done?) and, where it matters, _exhaustive_ ("every modified model accounted for", not "produce a change list") - a vague criterion invites **premature completion**.
+2. **In-skill reference** - a definition, rule, or fact in `SKILL.md`, consulted on demand. Often a legitimately flat peer-set (every rule of a review on one rung) - a fine arrangement, not a smell. _This skill is all reference._
+3. **External reference** - reference pushed out of `SKILL.md` into a separate file, reached by a **context pointer**, loaded only when the pointer fires. (Spans _disclosed_ reference - a sibling file like `GLOSSARY.md`, still part of the skill - through fully **external reference** that lives outside the skill system and any skill can point at.)
 
-## Workflows
+A demanding completion criterion drives thorough **legwork** - the digging the agent does within the work - whether the skill has steps or not, since "every rule applied" binds flat reference just as "every step done" binds a sequence.
 
-[Step-by-step processes with checklists for complex tasks]
+Push too little down and the top bloats; push too much and you hide material the agent actually needs. That tension is the whole decision.
 
-## Advanced features
+**Progressive disclosure** is the move down the ladder - out of `SKILL.md` into a linked file - so the top stays legible. Mechanics: a linked `.md` file in the skill folder, named for what it holds (this skill discloses its full definitions to `GLOSSARY.md`). Some skills are used in more than one way, and each distinct way is a **branch** - different runs taking different paths through the skill. Branching is the cleanest disclosure test: inline what every branch needs, and push behind a pointer what only some branches reach. A **context pointer**'s _wording_, not its target, decides when and how reliably the agent reaches the material.
 
-[Link to separate files: See [REFERENCE.md](REFERENCE.md)]
-```
+Where the ladder decides _how far down_ a piece sits, **co-location** decides _what sits beside it_ once there: keep a concept's definition, rules, and caveats under one heading rather than scattered, so reading one part brings its neighbours with it.
 
-## Description Requirements
+## When to split
 
-The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
+**Granularity** is how finely you divide skills, and each cut spends one of the two loads, so split only when the cut earns it. Two cuts:
 
-**Goal**: Give your agent just enough info to know:
+- **By invocation** - split off a **model-invoked** skill when you have a distinct **leading word** that should trigger it on its own, or another skill must reach it. You pay **context load** for the new always-loaded **description**, so that independent reach has to be worth it. `(review-time: skill-authoring judgment, not pattern-checkable)`
+- **By sequence** - split a run of **steps** when the steps still ahead (a step's **post-completion steps**) tempt the agent to rush the one in front of it (**premature completion**). Keeping them out of view encourages the agent to do more **legwork** on the current task. `(review-time: skill-authoring judgment, not pattern-checkable)`
 
-1. What capability this skill provides `(review-time: see section note)`
-2. When/why to trigger it (specific keywords, contexts, file types) `(review-time: see section note)`
+## Pruning
 
-**Format**:
+Keep each meaning in a **single source of truth**: one authoritative place, so changing the behaviour is a one-place edit.
 
-- Max 1024 chars `(review-time: see section note)`
-- Write in third person `(review-time: see section note)`
-- First sentence: what it does `(review-time: see section note)`
-- Second sentence: "Use when [specific triggers]" `(review-time: see section note)`
+Check every line for **relevance**: does it still bear on what the skill does?
 
-**Good example**:
+Then hunt **no-ops** sentence by sentence, not just line by line: run the no-op test on each sentence in isolation, and when one fails, delete the whole sentence rather than trim words from it. Be aggressive - most prose that fails should go, not be rewritten.
 
-```text
-Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
-```
+## Leading words
 
-**Bad example**:
+A **leading word** is a compact concept already living in the model's pretraining that the agent thinks with while running the skill (e.g. _lesson_, _fog of war_, _tracer bullets_). Repeated throughout the text (though not necessarily - a strong leading word might only be needed once), it accumulates a distributed definition and anchors a whole region of behaviour in the fewest tokens, by recruiting priors the model already holds.
 
-```text
-Helps with documents.
-```
+It serves predictability twice. In the body it anchors _execution_: the agent reaches for the same behaviour every time the word appears. In the description it anchors _invocation_: when the same word lives in your prompts, docs, and code, the agent links that shared language to the skill and fires it more reliably.
 
-The bad example gives your agent no way to distinguish this from other document skills.
+Hunt for opportunities to refactor skills to use leading words. A triad spelled out at three sites (**duplication**), a description spending a sentence to gesture at one idea - each is a passage begging to **collapse** into a single token. Examples include:
 
-## When to Add Scripts
+- "fast, deterministic, low-overhead" -> _tight_ - one quality restated across a phase - into a single pretrained word (a _tight_ loop).
+- "a loop you believe in" -> _red_ - converts a fuzzy gate into a binary observable state (the loop goes _red_ on the bug, or it doesn't).
 
-Add utility scripts when:
+You win twice over: fewer tokens, _and_ a sharper hook for the agent to hang its thinking on. Assume every skill is carrying restatements that leading words retire - go find them.
 
-- Operation is deterministic (validation, formatting) `(review-time: see section note)`
-- Same code would be generated repeatedly `(review-time: see section note)`
-- Errors need explicit handling `(review-time: see section note)`
+## Failure modes
 
-Scripts save tokens and improve reliability vs generated code.
+Use these to diagnose issues the user may be having with the skill.
 
-## When to Split Files
+- **Premature completion** - ending a step before it's genuinely done, attention slipping to _being done_. Defence, in order: sharpen the completion criterion first (cheap, local); only if it is irreducibly fuzzy _and_ you observe the rush, hide the post-completion steps by splitting (the sequence cut).
+- **Duplication** - the same meaning in more than one place. Costs maintenance and tokens, and inflates a meaning's prominence on the ladder past its real rank.
+- **Sediment** - stale layers that settle because adding feels safe and removing feels risky. The default fate of any skill without a pruning discipline.
+- **Sprawl** - a skill simply too long, even when every line is live and unique. Hurts readability and maintainability and wastes tokens. The cure is the ladder: disclose **reference** behind pointers, and split by **branch** or sequence so each path carries only what it needs.
+- **No-op** - a line the model already obeys by default, so you pay load to say nothing. The test: does it change behaviour versus the default? A weak leading word (_be thorough_ when the agent is already thorough-ish) is a no-op; the fix is a stronger word (_relentless_), not a different technique.
+- **Negation** - steering by prohibition backfires: _don't think of an elephant_ names the elephant and makes it more available, not less. Prompt the **positive** - state the target behaviour so the banned one is never spoken; keep a prohibition only as a hard guardrail you can't phrase positively, and even then pair it with what to do instead.
 
-Split into separate files when:
+## Relationship to this repo's rule-authoring policy
 
-- SKILL.md exceeds 100 lines `(review-time: see section note)`
-- Content has distinct domains (finance vs sales schemas) `(review-time: see section note)`
-- Advanced features are rarely needed `(review-time: see section note)`
-
-## Review Checklist
-
-After drafting, verify:
-
-- [ ] Description includes triggers ("Use when...") `(review-time: see section note)`
-- [ ] SKILL.md under 100 lines `(review-time: see section note)`
-- [ ] No time-sensitive info `(review-time: see section note)`
-- [ ] Consistent terminology `(review-time: see section note)`
-- [ ] Concrete examples included `(review-time: see section note)`
-- [ ] References one level deep `(review-time: see section note)`
+`rules/rule-authoring.md` is the enforcement side of the same idea. Its **no-op test** ("why can't a hook, linter, or CI check catch this?") is the no-op verdict above applied to normative rules; its single-source-of-truth dedup is **single source of truth** here. When writing a skill for this repo, tag only its genuinely normative bullets per that policy - the descriptive reference prose (most of a skill like this one) stays untagged.


### PR DESCRIPTION
## What does this PR do?

- Syncs our vendored `mattpocock/skills` against upstream's v1.1 restructure, per ADR 0006 (in this PR): adopt the composable *disciplines*, keep orchestration model-invoked so our grill->build workflow and panel grilling are preserved.
- Adds two new skills: `prototype` (model-invoked throwaway-spike discipline) and `wayfinder` (user-invoked on-ramp for too-big/foggy efforts, re-homed onto a file-based decision map under `.claude/state/` since we run no tracker).
- Folds upstream content into existing vendored skills:
  - `grill-with-docs` - fact-vs-decision rule, explicit stop-gate, hardened "CONTEXT.md is a glossary" purpose
  - `handoff` - redaction line
  - `improve-codebase-architecture/LANGUAGE.md` - deep-vs-shallow + designing-for-testability
  - `write-a-skill` - adopts the `writing-great-skills` reference + new `GLOSSARY.md`, kept model-invoked under our name
  - `to-issues` - wide-refactor expand/contract exception, prefactor, work-the-frontier, blocking-edges; dropped a stale `/setup-matt-pocock-skills` reference
- Merges upstream disciplines into our skills:
  - `test` - seams discipline + anti-patterns (tautological, horizontal-slicing)
  - `debug` - build-a-red-loop-first gate, minimise, falsifiable predictions, tagged instrumentation
  - `review-pr` - spec-conformance axis
- Deliberately **not** adopted (rationale in ADR 0006): the user-invoked staging pipeline (`to-spec`/`to-tickets`/`implement`), `ask-matt` router, `triage`, `code-review`'s Standards axis, the HTML-report mode, and `disable-model-invocation` across the board.
- Kept our conventions throughout: enforcement-layer tags on normative bullets, `> Source:` attribution, our skill names, gh/acli tracker vocabulary.

## Category

- [x] Feature
- [x] Chore (dependencies, docs, config)

## Linked issues

None - syncs vendored skills against upstream `mattpocock/skills`; design rationale is in ADR 0006 within this PR.

## Review checklist

### General

- [ ] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [ ] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant