### PR TITLE
chore(config): shift-left gaps surfaced by usage insights

### DIFF
--- a/hooks/pre-push-gate.sh
+++ b/hooks/pre-push-gate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Pre-push gate: block `git push` if lint/typecheck/test/build fail.
+# Pre-push gate: block `git push` if lint/typecheck/knip/test/build/audit fail.
 # Runs as a PreToolUse hook on Bash(git push *).
 # Exit code 2 blocks the action and sends the error message to Claude.
 # Bypass with SKIP_PUSH_GATE=1 in the environment.
@@ -62,8 +62,12 @@ if [ "$PROJECT_TYPE" = "node" ]; then
   }
   has_script lint && run_step "lint" "CI=true npm run lint --silent"
   has_script typecheck && run_step "typecheck" "CI=true npm run typecheck --silent"
+  has_script knip && run_step "knip" "CI=true npm run knip --silent"
   has_script test && run_step "test" "CI=true npm test --silent"
   has_script build && run_step "build" "CI=true npm run build --silent"
+  # Only critical advisories block: pre-existing high/moderate transitive CVEs are
+  # Dependabot's job, not a push gate's, and would otherwise block unrelated work.
+  command -v npm >/dev/null 2>&1 && run_step "audit" "npm audit --audit-level=critical"
 fi
 
 if [ "$PROJECT_TYPE" = "terraform" ]; then

--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure Conventions
 
-**When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, or CI/CD workflow files.
+**When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, or CI/CD workflow files - and when running any infra command that applies, destroys, or grants access (`terraform apply/destroy`, `gcloud`, `gsutil`, `aws`, `kubectl delete`).
 
 - Infrastructure as Code only - no manual changes to cloud resources `(review-time: process, not detectable in code)`
 - No `latest` tags for Docker images - always use specific version tags `(hook)`
@@ -10,3 +10,11 @@
 - CI/CD pipelines must run lint, typecheck, and tests before deploy `(CI)`
 - Always tag cloud resources with project, environment, and owner `(review-time: tag presence varies per Terraform resource type)`
 - GCP is primary cloud, AWS is secondary `(review-time: provider preference, not a code pattern)`
+
+## Destructive and privileged operations
+
+**why-not-mechanizable:** each rule needs knowledge external to the command text - who consumes a resource, whether a role is valid at a given scope, what a deploy pipeline actually does. A hook sees only the argv, not the blast radius.
+
+- Before destroying or deleting any shared or stateful cloud resource (bucket, database, KV store, secret, DNS zone), enumerate every system that consumes it and confirm with the user - never assume a resource is single-purpose `(review-time: see section note)`
+- Before granting an IAM role, verify the role is assignable at the target scope (project vs folder vs org) before applying - some roles are org/folder-only (e.g. `orgpolicy.policyAdmin`) and an invalid binding can fail the apply and clobber existing bindings `(review-time: see section note)`
+- Read the actual CI/CD workflow and deployment config files before explaining or modifying how a deploy works - never guess at deploy mechanics from naming or convention `(review-time: see section note)`


### PR DESCRIPTION
## Summary

Closes two of the top friction categories from the latest Claude Code usage insights report by adding enforcement where a specific failure had none.

- **Push gate (`hooks/pre-push-gate.sh`)** — addresses "buggy code caught late by strict CI gates" (14 sessions):
  - Run `knip` before push when the repo has a `knip` script — dead-code / unused-export failures now block locally instead of failing CI after the PR opens.
  - Run `npm audit --audit-level=critical` — only critical advisories block; pre-existing high/moderate transitive CVEs stay Dependabot's job so unrelated work isn't blocked.
- **Infra safety rules (`rules/infrastructure.md`)** — addresses "infrastructure and deployment missteps" (destructive/invalid infra needing reverts):
  - Enumerate every consumer before deleting a shared/stateful resource (the dual-purpose GCS bucket incident).
  - Verify an IAM role is assignable at the target scope before granting (the invalid `orgpolicy.policyAdmin` project-level binding).
  - Read the actual CI/CD workflow/deploy config before explaining deploy mechanics — never guess.
  - Broadened the rule's "When to apply" to cover running infra commands, not just editing files.

## Notes

- Both new push-gate steps honor the existing `SKIP_PUSH_GATE=1` escape hatch and only run for node projects.
- Every new normative rule bullet carries an enforcement tag per `rules/rule-authoring.md`.
- Deferred from scope: transient-vs-real CI classification, ADR/doc scope tightening, global clickable-PR-URL rule (Tier 3), and the "500-token truncation" item (likely an analysis artifact, not real session friction).