### PR TITLE
chore(config): tier-3 insights follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 ## Behavioral Rules
 
 - **Scope**: only implement what was asked - no drive-by refactors, extra features, or unsolicited improvements `(review-time: scope judgment)`
+- **No unsolicited docs**: outside the `/grill-with-docs` and `/document` workflows (which emit ADRs and docs by design), never create ADRs, READMEs, or other docs unless explicitly asked - an unwanted doc is scope creep that costs a revert `(review-time: requires distinguishing the doc-emitting workflows from ad-hoc doc creation)`
 - **Minimal fix**: for bug fixes, identify the root cause and state the smallest possible change first (ideally 1-5 lines). Only expand the scope if the minimal fix is provably insufficient. Never introduce new abstractions, files, or patterns as part of a bug fix unless the user explicitly asks `(review-time: minimal-fix judgment)`
 - **Decisions**: ask before making architectural choices - never silently pick a pattern, library, or approach `(review-time: requires recognizing an architectural choice point)`
 - **Cost**: warn before any change that increases costs (new cloud resources, paid services, upgraded tiers) `(review-time: cost-impact recognition)`

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -16,6 +16,7 @@
 - NEVER force-push any ref without asking immediately before the push - approval of a plan that includes a force-push is not approval of the push itself. Ask at execution time, every time (applies to agents/subagents too: they must report back for confirmation, not push) `(review-time: requires a fresh user confirmation at execution time; deny rules block bare --force/-f)`
 - NEVER merge PRs automatically - always wait for the user to merge manually `(review-time: depends on user signal, not pattern)`
 - After completing any feature implementation, create a PR unless explicitly told otherwise - do not wait to be asked `(review-time: requires judging "completion")`
+- Always print the full clickable PR/MR URL after opening or referencing a PR - never make the user hunt for it `(review-time: requires recognizing a PR reference in the reply)`
 - Always rebase onto the target branch (`git fetch origin main && git rebase origin/main`) before creating a PR `(hook)`
 - Always run `/verify-done` before pushing any branch - never push without all checks passing `(hook)`
 - PR descriptions: always use bullet points in the summary section, not prose paragraphs `(review-time: formatting of free-form text Claude produces)`

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -8,11 +8,11 @@
 2. **Start a Monitor** with the matching script: `(review-time: see section note)`
    - GitHub: `bash ~/.claude/skills/ci/scripts/gh-ci-monitor.sh` `(review-time: see section note)`
    - GitLab: `bash ~/.claude/skills/ci/scripts/glab-ci-monitor.sh` `(review-time: see section note)`
-   - Use `persistent: false`, `timeout_ms: 3600000` (1 hour ceiling — CI pipelines can be long) `(review-time: see section note)`
+   - Use `persistent: false`, `timeout_ms: 3600000` (1 hour ceiling - CI pipelines can be long) `(review-time: see section note)`
    - Description: "CI pipeline on <branch-name>" `(review-time: see section note)`
 3. **React to Monitor notifications**: `(review-time: see section note)`
-   - `no-runs|<branch>`: no CI runs found for this branch — inform the user and stop `(review-time: see section note)`
-   - `error|persistent-failure`: the monitor script hit 5 consecutive errors — report and stop `(review-time: see section note)`
+   - `no-runs|<branch>`: no CI runs found for this branch - inform the user and stop `(review-time: see section note)`
+   - `error|persistent-failure`: the monitor script hit 5 consecutive errors - report and stop `(review-time: see section note)`
    - Status change (e.g., `in_progress|null` → `completed|success`): acknowledge briefly `(review-time: see section note)`
    - **Pipeline passes** (`completed|success`): `(review-time: see section note)`
      - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"` `(review-time: see section note)`
@@ -27,10 +27,12 @@
         - GitHub: `gh run view <run-id> --log-failed` `(review-time: see section note)`
      b. Do NOT pipe output through head, tail, grep, or any other command - run the commands directly
      c. Analyze the root cause - identify the specific failure (test, lint, type check, build, coverage, etc.)
-     d. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
-     e. **Propose the fix to the user** - explain what failed and what you'd change. Do NOT push automatically
-     f. Wait for user approval before implementing the fix
-     g. After approval: fix, commit with a descriptive message, push
+     d. **Classify the failure as transient or real before proposing any change** - transient = infra outage, rate limit, queued/timed-out runner, auth/network flake, registry or dependency propagation delay; real = a test/lint/type/build/coverage failure caused by the code under change. State the classification `(review-time: see section note)`
+     e. **If transient**: re-run the failed job (`gh run rerun <run-id> --failed` / `glab ci retry <job-id>`) and keep monitoring - do NOT edit code for a transient failure. Escalate to the user only if it recurs after a re-run `(review-time: see section note)`
+     f. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
+     g. **If real, propose the fix to the user** - explain what failed and what you'd change. Do NOT push automatically `(review-time: see section note)`
+     h. Wait for user approval before implementing the fix `(review-time: see section note)`
+     i. After approval: fix, commit with a descriptive message, push `(review-time: see section note)`
 
 ## How it works
 
@@ -38,7 +40,7 @@ The monitor scripts poll CI status every 30 seconds but only emit a line when th
 
 - Zero token cost while the pipeline is running and status hasn't changed `(review-time: see section note)`
 - Claude reacts within ~30s of a status change (vs up to 2 min with /loop) `(review-time: see section note)`
-- No CronDelete cleanup needed — the script exits on terminal state, ending the Monitor `(review-time: see section note)`
+- No CronDelete cleanup needed - the script exits on terminal state, ending the Monitor `(review-time: see section note)`
 - If `gh`/`glab` fails 5 times in a row (auth expired, network down), the script exits with an error notification `(review-time: see section note)`
 
 ## Important: Non-interactive commands only


### PR DESCRIPTION
## Summary

The optional Tier 3 items from the usage-insights review (follows #99). Each targets a report finding that #99 deferred.

- **Transient-vs-real CI classification (`skills/ci/SKILL.md`)** — the report called this out as a strength worth systematizing. The failure branch now:
  - Classifies every failure as transient (outage, rate limit, queued/timed-out runner, auth/network flake, propagation delay) or real (code-caused test/lint/type/build/coverage failure) before proposing any change.
  - Re-runs transient failures (`gh run rerun --failed` / `glab ci retry`) and keeps monitoring instead of editing code; escalates only if it recurs.
- **No unsolicited docs (`CLAUDE.md` Scope)** — tightened scope so ADRs/READMEs/docs are not created outside the `/grill-with-docs` and `/document` workflows unless asked (an unwanted ADR previously needed a force-push revert).
- **Clickable PR URL (`rules/git-conventions.md`)** — global rule to always print the full PR/MR URL, generalizing what `/mr` and `/fix-issue` already do.

## Notes

- All new normative bullets carry enforcement tags per `rules/rule-authoring.md`.
- markdownlint and em-dash checks pass on all three files.
- Not included: the "500-token truncation" item, still assessed as an analysis artifact rather than real session friction.