### PR TITLE
fix(hooks): resolve the actual target repo in pre-commit branch gate

### DIFF
--- a/hooks/pre-commit-branch-gate.sh
+++ b/hooks/pre-commit-branch-gate.sh
@@ -16,7 +16,10 @@ esac
 
 [ "$SKIP_COMMIT_BRANCH_GATE" = "1" ] && exit 0
 
-DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+# Resolve the branch from the tool call's cwd, not CLAUDE_PROJECT_DIR: worktree
+# agents commit from feature-branch worktrees while the shared checkout sits on main.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+DIR="${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
 BRANCH=$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
 
 # Not in a git repo, or detached HEAD - let it through. Caller handles their own state.

--- a/hooks/pre-commit-branch-gate.sh
+++ b/hooks/pre-commit-branch-gate.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Pre-commit branch gate.
 # Blocks `git commit` when HEAD is on main or master.
-# PreToolUse hook for Bash(git commit *). Exit 2 blocks the action and feeds the
-# message back to Claude as a tool result.
+# PreToolUse hook for Bash(git commit *) and Bash(git -C *). Exit 2 blocks the
+# action and feeds the message back to Claude as a tool result.
 # Bypass with SKIP_COMMIT_BRANCH_GATE=1 in the environment.
 
 INPUT=$(cat)
@@ -10,16 +10,40 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 case "$COMMAND" in
   *"git commit --help"*|*"git commit -h"*) exit 0 ;;
-  *"git commit"*) ;;
+  *"git commit"*|*"git -C "*) ;;
   *) exit 0 ;;
 esac
 
 [ "$SKIP_COMMIT_BRANCH_GATE" = "1" ] && exit 0
 
-# Resolve the branch from the tool call's cwd, not CLAUDE_PROJECT_DIR: worktree
-# agents commit from feature-branch worktrees while the shared checkout sits on main.
+# `git -C <path> commit` never contains the literal "git commit", so the repo
+# must come from the -C argument. Best-effort parse: unquoted path with the
+# commit subcommand directly after it. A garbled extraction fails open below,
+# because rev-parse on a non-directory yields an empty branch.
+C_PATH=$(printf '%s\n' "$COMMAND" | sed -n 's/.*git -C  *\([^ ]*\)  *commit.*/\1/p' | head -1)
+
+case "$COMMAND" in
+  *"git commit"*) ;;
+  *) [ -z "$C_PATH" ] && exit 0 ;;
+esac
+
+# A leading `cd <path> && git commit` moves the commit's repo away from the
+# recorded tool cwd, which reflects the shell's directory before the cd runs.
+CD_PATH=""
+case "$COMMAND" in
+  "cd "*)
+    CD_PATH=${COMMAND#cd }
+    CD_PATH=${CD_PATH%%"&&"*}
+    CD_PATH=${CD_PATH%%";"*}
+    CD_PATH=$(printf '%s\n' "$CD_PATH" | sed "s/^[[:space:]]*//;s/[[:space:]]*\$//;s/^[\"']//;s/[\"']\$//")
+    ;;
+esac
+
+# Resolve the repo: `git -C` target, then a leading cd prefix, then the tool
+# call's cwd (worktree agents commit from feature-branch worktrees while the
+# shared checkout sits on main), then CLAUDE_PROJECT_DIR.
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-DIR="${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+DIR="${C_PATH:-${CD_PATH:-${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}}}"
 BRANCH=$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
 
 # Not in a git repo, or detached HEAD - let it through. Caller handles their own state.

--- a/settings.json
+++ b/settings.json
@@ -169,6 +169,12 @@
           },
           {
             "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-branch-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-branch-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
+            "if": "Bash(git -C *)",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-coauthor-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-coauthor-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "if": "Bash(git commit *)",
             "timeout": 10


### PR DESCRIPTION
## Summary

- The branch gate resolved the branch from `CLAUDE_PROJECT_DIR`, so it checked the session's project repo rather than the repo a commit actually targets
- Commit 1: resolve from the tool call's `.cwd` in the hook input - worktree lane agents commit from feature-branch worktrees while the shared checkout sits on main, and the old logic blocked them (or worse, passed a main commit because the session repo happened to be on a branch)
- Commit 2: two further gaps found in practice
  - `cd <dir> && git commit` resolves from a leading `cd` prefix, since the recorded tool cwd reflects the shell's directory before the `cd` runs
  - `git -C <dir> commit` never reached the script at all (the `Bash(git commit *)` registration does not match it) - the command is now parsed for the `-C` target and a second `Bash(git -C *)` registration in `settings.json` routes those calls to the gate
- Resolution precedence: `git -C` target, then leading `cd` prefix, then hook-input `.cwd`, then `CLAUDE_PROJECT_DIR`, then `$PWD`
- Parsing is best-effort and fails open: a garbled path yields an empty branch from `rev-parse` and the gate lets the commit through, same as the existing not-a-repo behavior

## Testing

- 14-case matrix run against the script with crafted hook-input JSON: plain commits on main vs feature-branch worktree, `cd`-prefix in both directions, `git -C` in both directions, chained `git -C add && git -C commit`, non-commit `git -C` commands, `--help`, quoted paths, nonexistent dirs (fail open), `CLAUDE_PROJECT_DIR` fallback, and the `SKIP_COMMIT_BRANCH_GATE=1` bypass - all pass
- `bash -n` clean, `jq empty settings.json` clean

## Follow-up (not in this PR)

- The coauthor and conventional-commit gates share the same `Bash(git commit *)`-only registration and are still blind to `git -C` commits