### PR TITLE
feat(rules): align prompt-authoring and delegation rules with Claude 5 behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 - **Cost**: warn before any change that increases costs (new cloud resources, paid services, upgraded tiers) `(review-time: cost-impact recognition)`
 - **Testing**: always write tests when implementing a new feature or fixing a bug - no exceptions `(review-time: per-PR judgment about test coverage of the change)`
 - **Conciseness**: be direct and terse during implementation - save explanations for when asked `(review-time: phrasing-length judgment)`
+- **Deliverable length**: match written documents, reports, and summaries to what the task needs - no filler sections, no redundant summaries, no boilerplate padding. Claude 5 models default to longer output; counteract deliberately `(review-time: length judgment on free-form output)`
 - **Existing patterns**: follow the conventions already in the codebase - consistency over personal preference `(review-time: pattern-recognition in surrounding code)`
 - **Context first**: before choosing an approach, check how similar problems are already solved in the codebase - grep for existing patterns, read neighboring files, and follow established conventions rather than guessing `(review-time: workflow discipline)`
 - **Verification**: always run `/verify-done` before pushing - never push without all checks passing `(hook)`

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -45,6 +45,8 @@ Do NOT spawn parallel agents when:
 - The task is trivial enough to finish in under 2 minutes sequentially `(review-time: time-estimate)`
 - Changes will inevitably conflict (e.g., multiple agents editing the same file) `(review-time: conflict prediction)`
 - There are only cosmetic or config changes `(review-time: task-shape judgment)`
+- The work fits in a handful of tool calls done inline - Claude 5 models delegate more eagerly than earlier models, and spawn overhead exceeds the win on small tasks `(review-time: task-shape judgment)`
+- The purpose is verifying or double-checking your own completed work - Claude 5 models self-verify; verification subagents add cost without quality gain `(review-time: purpose classification)`
 
 ## How to Split Work
 

--- a/rules/rule-authoring.md
+++ b/rules/rule-authoring.md
@@ -53,6 +53,14 @@ Format: backtick-wrapped, single space before, end of line.
 
 Out of scope: `MEMORY.md`, `keybindings.json`, `settings.json`, `docs/`, `README.md`, generic `scripts/` files.
 
+## Claude 5 authoring defaults
+
+Claude 5 family models (Fable/Opus 5+) changed which instructions help and which hurt. When authoring or editing any rule, persona, or skill, apply these defaults (source: platform.claude.com prompting guide for Opus 5):
+
+- Do not add attention-level verification instructions ("verify your work", "double-check", "re-verify before finishing") - the model self-verifies unprompted, and explicit verification instructions cause over-verification and token waste. Encode verification as mechanical gates (hooks, `/verify-done`, CI) instead. `(review-time: distinguishing attention-level nagging from concrete gate commands requires reading intent)`
+- Do not add conservative-filter review instructions ("only report high-severity", "be conservative with findings") - they suppress real findings. Ask for everything and filter in a later pass. `(review-time: semantic classification of review instructions)`
+- Prefer one clear directive over multi-sentence safety rails - the model is more instruction-sensitive than earlier generations; verbose rails cause over-compliance and scope distortion. When migrating older prompt text, cut rails rather than adding them. `(review-time: phrasing judgment)`
+
 ## Lifecycle - moving a rule between layers
 
 - Adding a new rule: pick the layer at authoring time, mark it. If `(review-time)`, write the justification.


### PR DESCRIPTION
## What does this PR do?

Encodes the documented Claude 5 (Opus 5 / Fable 5) behavioral deltas into the always-loaded rules, per the official prompting guide (platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5):

- **CLAUDE.md**: new "Deliverable length" behavioral rule - Claude 5 defaults to longer written output, so docs/reports/summaries must be sized to substance, no filler or boilerplate
- **rules/parallel-agents.md**: two new "When NOT to Parallelize" bullets - no delegation for work that fits in a handful of inline tool calls (Claude 5 delegates more eagerly), and no verification subagents (Claude 5 self-verifies; verification agents add cost without quality gain)
- **rules/rule-authoring.md**: new "Claude 5 authoring defaults" section governing future rule/persona/skill authoring - no attention-level verification nagging (encode as mechanical gates instead), no conservative-filter review instructions (they suppress real findings on Claude 5), prefer one clear directive over verbose safety rails

A sweep of skills/, rules/, agents/, and commands/ found no existing verify-nagging or suppression language to remove, so this PR is purely additive.

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed (markdown rules only, no test surface)
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant