### PR TITLE
feat(rules): path-scope file-type rules to cut always-loaded context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # typically committed because plans/specs are shared decisions.
 .claude/state/
 
+# Agent worktrees and other session-local runtime dirs under .claude/
+.claude/worktrees/
+.claude/plans/
+
 # macOS Finder metadata
 .DS_Store
 **/.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Other intents are first-class workflows with their own shapes, not stripped-down
 - **Minimal fix**: for bug fixes, identify the root cause and state the smallest possible change first (ideally 1-5 lines). Only expand the scope if the minimal fix is provably insufficient. Never introduce new abstractions, files, or patterns as part of a bug fix unless the user explicitly asks `(review-time: minimal-fix judgment)`
 - **Decisions**: ask before making architectural choices - never silently pick a pattern, library, or approach `(review-time: requires recognizing an architectural choice point)`
 - **Cost**: warn before any change that increases costs (new cloud resources, paid services, upgraded tiers) `(review-time: cost-impact recognition)`
+- **Destructive infra ops**: before destroying or deleting any shared or stateful cloud resource, enumerate its consumers and confirm with the user; verify IAM roles are assignable at the target scope before granting - full policy in `rules/infrastructure.md` (path-scoped, may not be loaded in command-only sessions) `(review-time: blast-radius knowledge is external to the command text)`
 - **Testing**: always write tests when implementing a new feature or fixing a bug - no exceptions `(review-time: per-PR judgment about test coverage of the change)`
 - **Conciseness**: be direct and terse during implementation - save explanations for when asked `(review-time: phrasing-length judgment)`
 - **Deliverable length**: match written documents, reports, and summaries to what the task needs - no filler sections, no redundant summaries, no boilerplate padding. Claude 5 models default to longer output; counteract deliberately `(review-time: length judgment on free-form output)`
@@ -89,13 +90,12 @@ The files below are loaded into every session via these `@`-imports. Edit the in
 @rules/communication.md
 @rules/context7.md
 @rules/rule-authoring.md
-@rules/database.md
-@rules/diagrams.md
 @rules/engineering-principles.md
 @rules/git-conventions.md
-@rules/infrastructure.md
 @rules/jira.md
 @rules/parallel-agents.md
 @rules/state-persistence.md
-@rules/tests.md
-@rules/typescript.md
+
+## Path-scoped rules
+
+Five rule files are NOT imported above - they carry `paths:` frontmatter and load on demand when a matching file is touched (`rules/typescript.md`, `rules/tests.md`, `rules/database.md`, `rules/infrastructure.md`, `rules/diagrams.md`). Do not re-add them to the import list: an `@`-import loads a file unconditionally and defeats the scoping. `(review-time: import-list discipline)`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,69 +1,78 @@
 # Expert Agents
 
-16 expert agent personas with strict guardrails, review checklists, and red-flag detection. Each agent is loaded automatically by Claude Code when a task matches its domain via the routing table in [`rules/agent-routing.md`](../rules/agent-routing.md).
+16 expert agent personas: lean spawn-time briefs with repo-specific guardrails, red-flag detection, and explicit output contracts. Each agent is spawned as a subagent when a task matches its domain via the routing table in [`rules/agent-routing.md`](../rules/agent-routing.md) (see ADR 0003 and ADR 0007).
 
 ## Engineering
 
 | Agent | File | Focus |
 | --- | --- | --- |
-| Senior Staff Engineer | [`staff-engineer.md`](../agents/staff-engineer.md) | System design, code architecture, design principles, DDD, SOLID |
-| Senior Frontend Staff Engineer | [`frontend-staff-engineer.md`](../agents/frontend-staff-engineer.md) | React, component architecture, rendering strategies, Core Web Vitals, accessibility |
-| Senior Backend Staff Engineer | [`backend-staff-engineer.md`](../agents/backend-staff-engineer.md) | API design, database engineering, event-driven architecture, caching, resilience |
-| Senior DevOps Engineer | [`devops-engineer.md`](../agents/devops-engineer.md) | IaC, containers, Kubernetes, CI/CD, observability, SRE |
-| Senior QA Expert | [`qa-expert.md`](../agents/qa-expert.md) | Test strategy, test automation, CI testing, performance testing, accessibility testing |
+| Staff Engineer | [`staff-engineer.md`](../agents/staff-engineer.md) | System design, code architecture, design principles, DDD, SOLID |
+| Frontend Staff Engineer | [`frontend-staff-engineer.md`](../agents/frontend-staff-engineer.md) | React, component architecture, rendering strategies, Core Web Vitals, accessibility |
+| Backend Staff Engineer | [`backend-staff-engineer.md`](../agents/backend-staff-engineer.md) | API design, database engineering, event-driven architecture, caching, resilience |
+| DevOps Engineer | [`devops-engineer.md`](../agents/devops-engineer.md) | IaC, containers, Kubernetes, CI/CD, observability, SRE |
+| QA Expert | [`qa-expert.md`](../agents/qa-expert.md) | Test strategy, test automation, CI testing, performance testing, accessibility testing |
 
 ## Infrastructure & Data
 
 | Agent | File | Focus |
 | --- | --- | --- |
-| Senior AWS Expert | [`aws-expert.md`](../agents/aws-expert.md) | AWS services, Well-Architected Framework, cost optimization, IAM |
-| Senior GCP Expert | [`gcp-expert.md`](../agents/gcp-expert.md) | GCP services, Cloud Run, BigQuery, IAM, networking |
-| Senior PostgreSQL Expert | [`postgresql-expert.md`](../agents/postgresql-expert.md) | Query optimization, indexing, partitioning, replication, schema design |
-| Senior Networking Expert | [`networking-expert.md`](../agents/networking-expert.md) | TCP/IP, DNS, load balancing, CDN, VPN, network security |
-| Senior ArgoCD Expert | [`argocd-expert.md`](../agents/argocd-expert.md) | ArgoCD, GitOps, ApplicationSet, sync strategies, Argo Rollouts, progressive delivery |
+| AWS Expert | [`aws-expert.md`](../agents/aws-expert.md) | AWS services, Well-Architected Framework, cost optimization, IAM |
+| GCP Expert | [`gcp-expert.md`](../agents/gcp-expert.md) | GCP services, Cloud Run, BigQuery, IAM, networking |
+| PostgreSQL Expert | [`postgresql-expert.md`](../agents/postgresql-expert.md) | Query optimization, indexing, partitioning, replication, schema design |
+| Networking Expert | [`networking-expert.md`](../agents/networking-expert.md) | TCP/IP, DNS, load balancing, CDN, VPN, network security |
+| ArgoCD Expert | [`argocd-expert.md`](../agents/argocd-expert.md) | ArgoCD, GitOps, ApplicationSet, sync strategies, Argo Rollouts, progressive delivery |
 
 ## Marketing & Analytics
 
 | Agent | File | Focus |
 | --- | --- | --- |
-| Senior GTM Expert | [`gtm-expert.md`](../agents/gtm-expert.md) | Server-side tagging, GTM web/server containers, data layer, Consent Mode v2, Conversion APIs |
+| GTM Expert | [`gtm-expert.md`](../agents/gtm-expert.md) | Server-side tagging, GTM web/server containers, data layer, Consent Mode v2, Conversion APIs |
 
 ## Security & Compliance
 
 | Agent | File | Focus |
 | --- | --- | --- |
-| Senior Cybersecurity Expert | [`cybersecurity-expert.md`](../agents/cybersecurity-expert.md) | OWASP, auth, cryptography, supply chain security, threat modeling |
-| Senior GDPR Expert | [`gdpr-expert.md`](../agents/gdpr-expert.md) | EU data protection, DPIAs, consent management, data subject rights, international transfers |
+| Cybersecurity Expert | [`cybersecurity-expert.md`](../agents/cybersecurity-expert.md) | OWASP, auth, cryptography, supply chain security, threat modeling |
+| GDPR Expert | [`gdpr-expert.md`](../agents/gdpr-expert.md) | EU data protection, DPIAs, consent management, data subject rights, international transfers |
 
 ## Product & Design
 
 | Agent | File | Focus |
 | --- | --- | --- |
-| Senior Product Manager | [`product-manager.md`](../agents/product-manager.md) | Product strategy, user stories, prioritization, roadmapping, metrics |
-| Senior UX Expert | [`ux-expert.md`](../agents/ux-expert.md) | Interaction design, usability, accessibility, design systems, information architecture |
+| Product Manager | [`product-manager.md`](../agents/product-manager.md) | Product strategy, user stories, prioritization, roadmapping, metrics |
+| UX Expert | [`ux-expert.md`](../agents/ux-expert.md) | Interaction design, usability, accessibility, design systems, information architecture |
 
 ## Code Review
 
 | Agent | File | Focus |
 | --- | --- | --- |
-| Senior PR Reviewer | [`pr-reviewer.md`](../agents/pr-reviewer.md) | Structured severity-based code reviews, TypeScript/Node.js, GraphQL, database, security |
+| PR Reviewer | [`pr-reviewer.md`](../agents/pr-reviewer.md) | Structured severity-based code reviews, TypeScript/Node.js, GraphQL, database, security |
 
 ## Agent Structure
 
-Every agent follows the same 9-section structure:
+Every agent follows the same 5-section skeleton (ADR 0007):
 
-1. **Identity** - role, experience, certifications
-2. **Core Expertise** - domain knowledge areas
-3. **Thinking Approach** - 7 principles that guide reasoning
-4. **Response Style** - communication patterns
-5. **Strict Guardrails** - non-negotiable rules flagged as BLOCKER (18-24 per agent)
-6. **Review Checklist** - verification items for code/architecture review (12-14 per agent)
-7. **Red Flags** - patterns that trigger immediate investigation (12-15 per agent)
-8. **Tools & Frameworks** - recommended tooling
-9. **Integration with Workflow** - how the agent works within the research/plan/implement phases
+1. **Role** - 2-3 sentences of responsibility and approach
+2. **How to work** - investigation-first discipline; findings are returned in the final message, not written to report files
+3. **Guardrails** - 6-10 repo-specific, non-obvious blockers, each tagged `(persona)`; anything already covered by `rules/` is deliberately absent because custom subagents inherit CLAUDE.md and all imported rules
+4. **Red Flags** - concrete, easy-to-miss patterns that trigger investigation
+5. **Output format** - the exact shape of the returned summary (severity buckets + verdict for advisory personas; changed/verified/concerns for writer personas)
+
+Two kinds of persona (see CONTEXT.md glossary):
+
+- **Advisory personas** are mechanically read-only via `tools:` frontmatter (no Edit/Write/NotebookEdit): PR Reviewer, Cybersecurity Expert, GDPR Expert, Product Manager, UX Expert. They cannot be lane-mode writers.
+- **Writer personas** (the other 11) omit `tools:` and keep full access for lane-mode implementation work.
 
 ## Routing
 
-The routing table in [`rules/agent-routing.md`](../rules/agent-routing.md) maps domain triggers to agent files. Claude loads matching agents automatically before starting work. Multiple agents load simultaneously when a task crosses domains (e.g., a new API endpoint loads backend + security + QA).
+The routing table in [`rules/agent-routing.md`](../rules/agent-routing.md) maps domain triggers to agent files. Claude spawns matching agents as subagents before starting work (ADR 0003 - agent files are never read into the main conversation). Multiple subagents spawn in parallel when a task crosses domains (e.g., a new API endpoint spawns backend + security + QA).
 
-Additional routing triggers added for: error handling/resilience, API design, data modeling, test strategy/architecture, performance optimization, and PR review.
+## Parallelism limits
+
+`rules/parallel-agents.md` caps lane-mode work at a target of 4 parallel agents with a hard ceiling of 5. The rationale:
+
+- **Merge conflict surface** scales as n*(n-1)/2: 4 agents = 6 pair combinations, 5 = 10, 8 = 28. The jump from 4 to 5 is acceptable; past 5 it gets painful fast.
+- **Review bandwidth**: reviewing 4 separate diffs in one sitting is the upper edge of what a human can do without rubber-stamping.
+- **API rate limits**: parent + 4 children = 5 concurrent token streams, which leaves headroom on standard tiers. 8+ regularly hits throttling and silently serializes the "parallel" work.
+- **Local resources**: each worktree is a full repo copy plus tool processes. 4 is comfortable on a typical Mac; 8+ starts to matter for large monorepos.
+- **Diminishing wall-clock returns**: the slowest agent dictates total time. With 4 agents you already capture ~80% of the theoretical speedup; more mostly buys coordination overhead.

--- a/rules/database.md
+++ b/rules/database.md
@@ -1,3 +1,16 @@
+---
+paths:
+  - "**/*.sql"
+  - "**/migrations/**"
+  - "**/*.prisma"
+  - "**/prisma/**"
+  - "**/drizzle/**"
+  - "**/models/**"
+  - "**/repositories/**"
+  - "**/db/**"
+  - "**/database/**"
+---
+
 # Database Conventions
 
 **When to apply:** editing migrations, SQL files, or any database schema / query code (Prisma, Drizzle, Knex, raw SQL).

--- a/rules/diagrams.md
+++ b/rules/diagrams.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/docs/**"
+  - "**/*.drawio"
+  - "**/*.mmd"
+---
+
 # Diagram Policy
 
 **When to apply:** creating or updating any diagram in `docs/` (flowchart, sequence, architecture, state machine, etc.).

--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -1,3 +1,17 @@
+---
+paths:
+  - "**/*.tf"
+  - "**/*.tfvars"
+  - "**/Dockerfile*"
+  - "**/docker-compose*"
+  - "**/.github/workflows/**"
+  - "**/.gitlab-ci.yml"
+  - "**/k8s/**"
+  - "**/kubernetes/**"
+  - "**/helm/**"
+  - "**/manifests/**"
+---
+
 # Infrastructure Conventions
 
 **When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, or CI/CD workflow files - and when running any infra command that applies, destroys, or grants access (`terraform apply/destroy`, `gcloud`, `gsutil`, `aws`, `kubectl delete`).

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -11,9 +11,7 @@ Parallel work runs in one of two coordination modes (see `CONTEXT.md` for the gl
 - **Lane mode** - mutating work (build / implementation). Teammates run in isolated git worktrees, each owning disjoint files, in the background, reporting to the parent via completion notifications, with no peer messaging (star topology). Choose lane mode when teammates write code. `(review-time: mode-selection judgment)`
 - **Panel mode** - read-only work (research, grilling, design). Named teammates coordinate peer-to-peer via SendMessage to challenge each other, then converge (mesh topology). No worktrees needed because the work is read-only. Choose panel mode when teammates investigate or argue but do not write. `(review-time: mode-selection judgment)`
 
-The distinguishing axis is coordination topology (star vs mesh) plus isolation (worktree vs read-only), not whether teammates are named - both modes name their teammates. Background execution (`run_in_background`) is orthogonal; either mode can run in the background. `(review-time: mode classification, not a code pattern)`
-
-The rest of this file - splitting, worktree isolation, merging - governs **lane mode**. Panel mode has its own section below.
+The distinguishing axis is coordination topology (star vs mesh) plus isolation (worktree vs read-only) - see CONTEXT.md for the full glossary. The rest of this file - splitting, worktree isolation, merging - governs **lane mode**. Panel mode has its own section below. `(review-time: mode classification, not a code pattern)`
 
 ## When to Parallelize
 
@@ -121,10 +119,4 @@ See ADR 0005 for the rationale and CONTEXT.md for the glossary.
 - If a task splits into more than 5 pieces, batch them into rounds rather than spawning more concurrently. `(review-time: batching strategy)`
 - Always prefer 3 well-scoped agents over 6 narrowly-scoped ones. `(review-time: scope-vs-count trade-off)`
 
-Why these numbers:
-
-- **Merge conflict surface** scales as n*(n-1)/2. 4 agents = 6 pair combinations, 5 = 10, 8 = 28. The jump from 4 to 5 is acceptable; past 5 it gets painful fast.
-- **Review bandwidth**: reviewing 4 separate diffs in one sitting is the upper edge of what a human can do without quality dropping into rubber-stamping.
-- **API rate limits**: parent + 4 children = 5 concurrent token streams, which leaves headroom on standard tiers. 8+ regularly hits throttling and silently serializes the "parallel" work.
-- **Local resources**: each worktree is a full repo copy plus tool processes. 4 is comfortable on a typical Mac; 8+ starts to matter for large monorepos.
-- **Diminishing wall-clock returns**: the slowest agent dictates total time. With 4 agents you already capture ~80% of the theoretical speedup; more mostly buys coordination overhead, not speed.
+Rationale for these numbers (conflict surface, review bandwidth, rate limits, local resources, diminishing returns): see `docs/agents.md`, "Parallelism limits".

--- a/rules/tests.md
+++ b/rules/tests.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.test.*"
+  - "**/*.spec.*"
+  - "**/__tests__/**"
+  - "**/e2e/**"
+---
+
 # Testing Standards
 
 **When to apply:** editing test files (`*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`).

--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+---
+
 # TypeScript Standards
 
 **When to apply:** editing TypeScript files (`*.ts`, `*.tsx`).


### PR DESCRIPTION
## What does this PR do?

Phase 3 of the Claude 5 alignment plan: reduce the ~12-13k tokens of rules loaded into every session.

- Add `paths:` frontmatter to `rules/typescript.md`, `tests.md`, `database.md`, `infrastructure.md`, and `diagrams.md` - they now load on demand when a matching file is touched instead of at every session start (supported at user scope per code.claude.com/docs/en/memory, incl. inside custom subagents)
- Remove their five `@`-imports from CLAUDE.md and add a "Path-scoped rules" section documenting why they must not be re-imported
- Add one always-on "Destructive infra ops" summary bullet to CLAUDE.md, since the full infrastructure rule may not be loaded in command-only sessions
- Move the parallelism-limits rationale prose from `rules/parallel-agents.md` to `docs/agents.md` and compress mode-section duplication with CONTEXT.md
- Add `.claude/worktrees/` and `.claude/plans/` to .gitignore (session-local runtime dirs)
- Refresh `docs/agents.md` for the phase-2 persona reality: 5-section skeleton, advisory vs writer personas, spawn-not-load routing, dropped stale "Senior" prefixes

**Verified empirically** with two headless sessions: a scoped rule is absent at session start (probe answers NO) and present after reading a matching `.ts` file (probe answers YES).

Known trade-off: `database.md` is glob-scoped to SQL/migrations/ORM-conventional paths, so DB query code in unconventionally named files will not trigger it; the `SELECT *` hook remains global.

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed (markdown/config only, no test surface)
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant