### PR TITLE
chore(skills): replace em dashes with hyphens in vendored skill content

### DIFF
--- a/skills/ci/scripts/gh-ci-monitor.sh
+++ b/skills/ci/scripts/gh-ci-monitor.sh
@@ -5,7 +5,7 @@
 # Emits a line to stdout ONLY when status changes.
 # Exits when the pipeline reaches a terminal state.
 set -uo pipefail
-# Note: no -e — gh pr checks uses non-standard exit codes (8 = pending)
+# Note: no -e - gh pr checks uses non-standard exit codes (8 = pending)
 # that would terminate the script under errexit
 
 branch=$(git branch --show-current)
@@ -25,7 +25,7 @@ while true; do
       *) cur="error|exit-$ec" ;;
     esac
   else
-    # Fallback: no PR yet — check ALL runs for the branch, not just one
+    # Fallback: no PR yet - check ALL runs for the branch, not just one
     lines=$(gh run list --branch "$branch" --json status,conclusion \
       --jq '.[] | "\(.status)|\(.conclusion)"' 2>/dev/null) || lines=""
 

--- a/skills/grill-with-docs/ADR-FORMAT.md
+++ b/skills/grill-with-docs/ADR-FORMAT.md
@@ -2,7 +2,7 @@
 
 ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
 
-Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+Create the `docs/adr/` directory lazily - only when the first ADR is needed.
 
 ## Template
 
@@ -12,15 +12,15 @@ Create the `docs/adr/` directory lazily — only when the first ADR is needed.
 {1-3 sentences: what's the context, what did we decide, and why.}
 ```
 
-That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* - not in filling out sections.
 
 ## Optional sections
 
 Only include these when they add genuine value. Most ADRs won't need them.
 
-- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
-- **Considered Options** — only when the rejected alternatives are worth remembering
-- **Consequences** — only when non-obvious downstream effects need to be called out
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) - useful when decisions are revisited
+- **Considered Options** - only when the rejected alternatives are worth remembering
+- **Consequences** - only when non-obvious downstream effects need to be called out
 
 ## Numbering
 
@@ -30,18 +30,18 @@ Scan `docs/adr/` for the highest existing number and increment by one.
 
 All three of these must be true:
 
-1. **Hard to reverse** — the cost of changing your mind later is meaningful
-2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
-3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+1. **Hard to reverse** - the cost of changing your mind later is meaningful
+2. **Surprising without context** - a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** - there were genuine alternatives and you picked one for specific reasons
 
-If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+If a decision is easy to reverse, skip it - you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
 
 ### What qualifies
 
 - **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
 - **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
-- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library - just the ones that would take a quarter to swap out.
 - **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
 - **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
 - **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
-- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it - otherwise someone will suggest GraphQL again in six months.

--- a/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -29,11 +29,11 @@ _Avoid_: Client, buyer, account
 ## Example dialogue
 
 > **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
-> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+> **Domain expert:** "No - an **Invoice** is only generated once a **Fulfillment** is confirmed."
 
 ## Flagged ambiguities
 
-- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+- "account" was used to mean both **Customer** and **User** - resolved: these are distinct concepts.
 ```
 
 ## Rules
@@ -57,9 +57,9 @@ _Avoid_: Client, buyer, account
 
 ## Contexts
 
-- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
-- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
-- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+- [Ordering](./src/ordering/CONTEXT.md) - receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) - generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) - manages warehouse picking and shipping
 
 ## Relationships
 

--- a/skills/improve-codebase-architecture/DEEPENING.md
+++ b/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,6 +1,6 @@
 # Deepening
 
-How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) - **module**, **interface**, **seam**, **adapter**.
 
 ## Dependency categories
 
@@ -8,7 +8,7 @@ When assessing a candidate for deepening, classify its dependencies. The categor
 
 ### 1. In-process
 
-Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+Pure computation, in-memory state, no I/O. Always deepenable - merge the modules and test through the new interface directly. No adapter needed.
 
 ### 2. Local-substitutable
 
@@ -31,7 +31,7 @@ Third-party services (Stripe, Twilio, etc.) you don't control. The deepened modu
 
 ## Testing strategy: replace, don't layer
 
-- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist - delete them.
 - Write new tests at the deepened module's interface. The **interface is the test surface**.
 - Tests assert on observable outcomes through the interface, not internal state.
-- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.
+- Tests should survive internal refactors - they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,8 +1,8 @@
 # Interface Design
 
-When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) - your first idea is unlikely to be the best.
 
-Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) - **module**, **interface**, **seam**, **adapter**, **leverage**.
 
 ## Process
 
@@ -12,7 +12,7 @@ Before spawning sub-agents, write a user-facing explanation of the problem space
 
 - The constraints any new interface would need to satisfy
 - The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
-- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+- A rough illustrative code sketch to ground the constraints - not a proposal, just a way to make the constraints concrete
 
 Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
 
@@ -22,23 +22,23 @@ Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radi
 
 Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
 
-- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
-- Agent 2: "Maximise flexibility — support many use cases and extension."
-- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 1: "Minimize the interface - aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility - support many use cases and extension."
+- Agent 3: "Optimise for the most common caller - make the default case trivial."
 - Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
 
 Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
 
 Each sub-agent outputs:
 
-1. Interface (types, methods, params — plus invariants, ordering, error modes)
+1. Interface (types, methods, params - plus invariants, ordering, error modes)
 2. Usage example showing how callers use it
 3. What the implementation hides behind the seam
 4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
-5. Trade-offs — where leverage is high, where it's thin
+5. Trade-offs - where leverage is high, where it's thin
 
 ### 3. Present and compare
 
 Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
 
-After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated - the user wants a strong read, not a menu.

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -3,26 +3,26 @@ name: improve-codebase-architecture
 description: "Finds deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable."
 ---
 
-> Source: [mattpocock/skills — engineering/improve-codebase-architecture](https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture)
+> Source: [mattpocock/skills - engineering/improve-codebase-architecture](https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture)
 
 # Improve Codebase Architecture
 
-Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+Surface architectural friction and propose **deepening opportunities** - refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
 
 ## Glossary
 
 **why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
-Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+Use these terms exactly in every suggestion. Consistent language is the point - don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
 
-- **Module** — anything with an interface and an implementation (function, class, package, slice). `(review-time: see section note)`
-- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature. `(review-time: see section note)`
-- **Implementation** — the code inside. `(review-time: see section note)`
-- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation. `(review-time: see section note)`
-- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.") `(review-time: see section note)`
-- **Adapter** — a concrete thing satisfying an interface at a seam. `(review-time: see section note)`
-- **Leverage** — what callers get from depth. `(review-time: see section note)`
-- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place. `(review-time: see section note)`
+- **Module** - anything with an interface and an implementation (function, class, package, slice). `(review-time: see section note)`
+- **Interface** - everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature. `(review-time: see section note)`
+- **Implementation** - the code inside. `(review-time: see section note)`
+- **Depth** - leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation. `(review-time: see section note)`
+- **Seam** - where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.") `(review-time: see section note)`
+- **Adapter** - a concrete thing satisfying an interface at a seam. `(review-time: see section note)`
+- **Leverage** - what callers get from depth. `(review-time: see section note)`
+- **Locality** - what maintainers get from depth: change, bugs, knowledge concentrated in one place. `(review-time: see section note)`
 
 Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
 
@@ -38,10 +38,10 @@ This skill is _informed_ by the project's domain model. The domain language give
 
 Read the project's domain glossary and any ADRs in the area you're touching first.
 
-Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics - explore organically and note where you experience friction:
 
 - Where does understanding one concept require bouncing between many small modules? `(review-time: see section note)`
-- Where are modules **shallow** — interface nearly as complex as the implementation? `(review-time: see section note)`
+- Where are modules **shallow** - interface nearly as complex as the implementation? `(review-time: see section note)`
 - Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)? `(review-time: see section note)`
 - Where do tightly-coupled modules leak across their seams? `(review-time: see section note)`
 - Which parts of the codebase are untested, or hard to test through their current interface? `(review-time: see section note)`
@@ -52,24 +52,24 @@ Apply the **deletion test** to anything you suspect is shallow: would deleting i
 
 Present a numbered list of deepening opportunities. For each candidate:
 
-- **Files** — which files/modules are involved `(review-time: see section note)`
-- **Problem** — why the current architecture is causing friction `(review-time: see section note)`
-- **Solution** — plain English description of what would change `(review-time: see section note)`
-- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve `(review-time: see section note)`
+- **Files** - which files/modules are involved `(review-time: see section note)`
+- **Problem** - why the current architecture is causing friction `(review-time: see section note)`
+- **Solution** - plain English description of what would change `(review-time: see section note)`
+- **Benefits** - explained in terms of locality and leverage, and also in how tests would improve `(review-time: see section note)`
 
-**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" - not "the FooBarHandler," and not "the Order service."
 
-**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 - but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
 
 Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
 
 ### 3. Grilling loop
 
-Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them - constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
 
 Side effects happen inline as decisions crystallize:
 
-- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist. `(review-time: see section note)`
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` - same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist. `(review-time: see section note)`
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there. `(review-time: see section note)`
-- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md). `(review-time: see section note)`
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing - skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md). `(review-time: see section note)`
 - **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md). `(review-time: see section note)`


### PR DESCRIPTION
## What does this PR do?

- Replaces all 53 remaining em dashes with hyphens across the vendored skill content (`improve-codebase-architecture`, `grill-with-docs`) and two comments in the `ci` monitor script
- This is the adapt step of the vendor-and-adapt policy: upstream content now conforms to the repo-wide no-em-dash formatting rule
- `bash -n` passes on the touched script; the repo is now em-dash-free (`git grep` returns zero matches)

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed (text-only change, no test surface)
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant