### PR TITLE
feat(rules): plain-language policy with hook-backed word check

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,7 +15,7 @@ Parallel teammates in isolated git worktrees, each owning disjoint files, runnin
 _Avoid_: "fan-out mode", "worktree mode".
 
 **Panel mode**:
-Named read-only teammates that coordinate peer-to-peer via SendMessage to challenge each other, then converge into one synthesis for the parent.
+Named read-only teammates that coordinate peer-to-peer via SendMessage to challenge each other, then settle on one combined answer for the parent.
 _Avoid_: "round-table", "team mode".
 
 **Advisory persona**:
@@ -65,7 +65,7 @@ _Avoid_: "spike task", "POC".
 - **Lane mode** is for mutating work (build/implementation); **Panel mode** is for read-only work (research, grilling, design).
 - An **Advisory persona** can join **Panel mode** only; a **Lane mode** teammate must be a **Writer persona**.
 - The distinguishing axis is coordination topology: **Lane mode** is a star (teammates report only to the parent), **Panel mode** is a mesh (teammates also message each other). Worktree isolation follows from this: lanes mutate files so they need worktrees, panels are read-only so they do not.
-- Background execution (`run_in_background`) is orthogonal to mode - either mode can run in the background.
+- Background execution (`run_in_background`) is independent of mode - either mode can run in the background.
 
 ## Example dialogue
 
@@ -75,5 +75,5 @@ _Avoid_: "spike task", "POC".
 ## Flagged ambiguities
 
 - "subagent" was used for both the generic spawn mechanism and a named agent - resolved: a named agent is a **Teammate**; "subagent" refers only to the generic Agent-tool spawn.
-- "in the background" was conflated with "spawned as a team" - resolved: background execution is orthogonal to coordination mode.
+- "in the background" was conflated with "spawned as a team" - resolved: background execution is independent of coordination mode.
 - "skill" was used for both sequencing workflows and single practices - resolved: a sequencing skill is an **Orchestrator**, a single-practice skill is a **Reusable discipline**.

--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Post-edit lint hook backing rules/comments.md. Bypass: SKIP_POST_EDIT_LINT=1.
+# Post-edit lint hook backing rules/comments.md and the plain-language
+# policy in rules/communication.md. Bypass: SKIP_POST_EDIT_LINT=1.
 
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -22,6 +23,26 @@ esac
 if LC_ALL=C grep -q $'\xe2\x80\x94' "$FILE" 2>/dev/null; then
   sed -i '' $'s/\xe2\x80\x94/-/g' "$FILE"
 fi
+
+# --- 1b. Fancy words in markdown (rules/communication.md: plain language) ---
+case "$FILE" in
+  */rules/communication.md) ;; # defines the word list; its examples would trip the check
+  *.md|*.markdown)
+    MD_DIR=$(dirname "$FILE")
+    if git -C "$MD_DIR" rev-parse --git-dir >/dev/null 2>&1 && git -C "$MD_DIR" ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
+      MD_ADDED=$(git -C "$MD_DIR" diff --unified=0 HEAD -- "$FILE" 2>/dev/null | grep -E '^\+[^+]' | sed 's/^\+//')
+    else
+      MD_ADDED=$(cat "$FILE")
+    fi
+    FANCY=$(echo "$MD_ADDED" | grep -inE '\b(utili[sz]e[sd]?|homogeni[sz]e[sd]?|crystalli[sz]e[sd]?|synthesi[sz]e[sd]?|orthogonal|holistic|paradigm|synerg[a-z]*|salient)\b' 2>/dev/null || true)
+    if [ -n "$FANCY" ]; then
+      echo "[post-edit-lint] $FILE" >&2
+      echo "Fancy word in newly added markdown. rules/communication.md (Plain language): say it with the plain word instead (use, combine, unrelated, consistent, important...):" >&2
+      echo "$FANCY" >&2
+      exit 2
+    fi
+    ;;
+esac
 
 # --- Skip docs/text: prose comment markers cause false positives ---
 case "$FILE" in

--- a/rules/comments.md
+++ b/rules/comments.md
@@ -99,6 +99,7 @@ This policy applies to all code, including code written by subagents spawned via
 - Consecutive `--` SQL comment lines (SQL files) - use `/* */` for multi-line
 - New `var` declarations (JS / TS files) - `rules/typescript.md` requires `const` / `let`
 - New `TODO` / `FIXME` / `XXX` / `HACK` markers in any code file
+- Fancy words in newly added markdown (see `rules/communication.md`, Plain language)
 
 Exit 2 surfaces the offending lines back to Claude as a follow-up message; the model must remove the violations before proceeding. Bypass for genuine exceptions: `SKIP_POST_EDIT_LINT=1` in the env. Use sparingly and document why in the PR description.
 

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -6,7 +6,7 @@
 
 Ask **one** question at a time. Wait for the answer before asking the next.
 
-**why-not-mechanizable:** every bullet in this file is about phrasing and turn cadence of free-form text Claude produces, not patterns in tool input. Hooks operate on tool calls, not on conversational output.
+**why-no-hook:** every bullet in this file is about phrasing and turn cadence of free-form text Claude produces, not patterns in tool input. Hooks operate on tool calls, not on conversational output.
 
 - Do not stack multiple questions in a single turn, even closely related ones. `(review-time: see section note)`
 - Do not bundle a question with "and also confirm X, Y, Z" tacked onto the end - those are separate questions, ask them on later turns. `(review-time: see section note)`
@@ -19,6 +19,15 @@ Long multi-question turns are hard to answer clearly. One question per turn keep
 
 - Keep the question itself short. Context above the question is fine; the question line itself should be one sentence. `(review-time: phrasing length is subjective)`
 - Lead with your recommendation when you have one, then ask for confirmation or pushback. Open-ended "what do you think?" without a recommendation wastes a turn. `(review-time: requires reading what Claude is about to say)`
+
+## Plain language
+
+Fancy words slow the reader down and hide the point. This applies to everything written for a human: replies, PR descriptions, tickets, docs, rules, skills, and personas.
+
+- Prefer the plain word: use (not utilize), combine (not synthesize), settle or agree (not converge), unrelated (not orthogonal), make consistent (not homogenize), important (not salient). A short list of the worst offenders is blocked in newly added markdown by `hooks/post-edit-lint.sh` `(hook)`
+- Words with legitimate technical uses (leverage, canonical, converge, reconcile, distill) are not hook-blocked - if a simpler word says the same thing, use it `(review-time: word choice needs surrounding context)`
+- Keep real terms of art (worktree, frontmatter, idempotent, GitOps reconciliation) and the defined glossary terms in CONTEXT.md and LANGUAGE.md files - precision beats false simplicity `(review-time: term-of-art recognition)`
+- When a precise term is genuinely needed, define it in one plain sentence at first use `(review-time: phrasing judgment)`
 
 ## Skill-level overrides
 

--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -27,7 +27,7 @@ paths:
 
 ## Destructive and privileged operations
 
-**why-not-mechanizable:** each rule needs knowledge external to the command text - who consumes a resource, whether a role is valid at a given scope, what a deploy pipeline actually does. A hook sees only the argv, not the blast radius.
+**why-no-hook:** each rule needs knowledge external to the command text - who consumes a resource, whether a role is valid at a given scope, what a deploy pipeline actually does. A hook sees only the argv, not the blast radius.
 
 - Before destroying or deleting any shared or stateful cloud resource (bucket, database, KV store, secret, DNS zone), enumerate every system that consumes it and confirm with the user - never assume a resource is single-purpose `(review-time: see section note)`
 - Before granting an IAM role, verify the role is assignable at the target scope (project vs folder vs org) before applying - some roles are org/folder-only (e.g. `orgpolicy.policyAdmin`) and an invalid binding can fail the apply and clobber existing bindings `(review-time: see section note)`

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -15,7 +15,7 @@ The distinguishing axis is coordination topology (star vs mesh) plus isolation (
 
 ## When to Parallelize
 
-**why-not-mechanizable:** every condition below requires understanding the task shape ("independent", "meaningful effort", "would take significantly longer"). The harness can't see what the task is until I describe it.
+**why-no-hook:** every condition below requires understanding the task shape ("independent", "meaningful effort", "would take significantly longer"). The harness can't see what the task is until I describe it.
 
 Spawn parallel agents when ALL of these are true:
 
@@ -102,7 +102,7 @@ Panel mode is for read-only parallel work where teammates need to challenge each
 
 - **Independent pass**: each teammate explores its area or forms its position alone `(review-time: protocol step)`
 - **Cross-challenge round**: each teammate sees the others' outputs and sends targeted SendMessage challenges or contradictions - bounded to one pass for research, iterate-to-convergence for grilling and design `(review-time: protocol step, intensity is a judgment call)`
-- **Parent converges**: the main session synthesizes the result (research: the artifact; grill: the next question to the user) - there is no lead teammate, because the parent holds the user relationship and the artifact `(review-time: protocol step)`
+- **Parent decides**: the main session pulls the results together (research: the artifact; grill: the next question to the user) - there is no lead teammate, because the parent holds the user relationship and the artifact `(review-time: protocol step)`
 
 Read-only enforcement differs by surface, deliberately:
 

--- a/rules/rule-authoring.md
+++ b/rules/rule-authoring.md
@@ -1,6 +1,6 @@
 # Rule Authoring Policy
 
-**When to apply:** writing or editing any normative bullet in `rules/*.md`, `CLAUDE.md`, `agents/*.md`, or `skills/**/SKILL.md`.
+**When to apply:** writing or editing any rule bullet in `rules/*.md`, `CLAUDE.md`, `agents/*.md`, or `skills/**/SKILL.md`.
 
 ## Why this exists
 
@@ -20,9 +20,11 @@ Ranked by reliability (earliest catch wins per the shift-left principle):
 
 ## The marker requirement
 
-Every **normative** bullet in an in-scope file ends with a tag. A normative bullet asserts a "do X" or "don't Y" - the rule itself. Prose paragraphs (motivation, examples, prerequisites) carry no tag.
+Every **rule** bullet in an in-scope file ends with a tag. A rule bullet says "do X" or "don't Y" - the rule itself. Prose paragraphs (motivation, examples, prerequisites) carry no tag.
 
 Format: backtick-wrapped, single space before, end of line.
+
+Rule text itself follows the plain-language policy in `rules/communication.md` - a rule the reader has to parse twice does not get followed. `(hook)`
 
 ```markdown
 - No `var` in JS/TS - use `const` or `let` `(hook)`
@@ -36,8 +38,8 @@ Format: backtick-wrapped, single space before, end of line.
 
 - Every `(review-time)` tag MUST include a colon-prefixed justification: `(review-time: <one-line why>)`.
 - The justification answers: *why can't a hook, linter, or CI check catch this?*
-- If many bullets in a single section share the same justification, write the justification once as a `**why-not-mechanizable:**` paragraph immediately under the section heading, then use `(review-time: see section note)` on each bullet.
-- If you can't write a one-line justification, the rule is probably either mechanizable (write the hook instead) or not worth keeping.
+- If many bullets in a single section share the same justification, write the justification once as a `**why-no-hook:**` paragraph immediately under the section heading, then use `(review-time: see section note)` on each bullet.
+- If you can't write a one-line justification, the rule can probably be checked by a hook (write it instead) or is not worth keeping.
 
 ## Multi-layer conventions
 
@@ -48,8 +50,8 @@ Format: backtick-wrapped, single space before, end of line.
 
 - `rules/*.md`
 - `CLAUDE.md`
-- `agents/*.md` (only the normative-guardrail sections; persona prose stays untagged)
-- `skills/**/SKILL.md` (only the normative bullets; procedure / steps / examples stay untagged)
+- `agents/*.md` (only the Guardrails sections; persona prose stays untagged)
+- `skills/**/SKILL.md` (only the rule bullets; procedure / steps / examples stay untagged)
 
 Out of scope: `MEMORY.md`, `keybindings.json`, `settings.json`, `docs/`, `README.md`, generic `scripts/` files.
 
@@ -64,6 +66,6 @@ Claude 5 family models (Fable/Opus 5+) changed which instructions help and which
 ## Lifecycle - moving a rule between layers
 
 - Adding a new rule: pick the layer at authoring time, mark it. If `(review-time)`, write the justification.
-- Mechanising an existing rule (moving up the table): change the tag and add the hook / lint config / CI check in the same PR. PR description notes the layer change in one line.
+- Moving a rule up the table (adding a hook / lint config / CI check for it): change the tag and add the check in the same PR. PR description notes the layer change in one line.
 - Demoting a rule (moving down): rare but valid (e.g., a hook becomes unmaintainable). PR description notes the demotion.
 - Removing a rule: just delete it. No tombstone.

--- a/rules/state-persistence.md
+++ b/rules/state-persistence.md
@@ -15,6 +15,6 @@ All work artifacts must be saved to the project-level `.claude/state/` directory
 
 - Create `.claude/state/` directories if they don't exist before writing `(review-time: simple ops choice, no enforcement value-add)`
 - Use naming convention: `YYYY-MM-DD-descriptive-name.md` (e.g., `2026-03-12-research-auth-refactor.md`) `(review-time: a filename-pattern hook is possible but very high false-positive rate on existing files)`
-- Every non-trivial session should end with a summary saved to `.claude/state/sessions/` `(review-time: subjective threshold "non-trivial")`
+- Every session with real work should end with a summary saved to `.claude/state/sessions/` `(review-time: subjective threshold "real work")`
 - Plans and research are per-project, not global `(review-time: location preference)`
 - Check `.claude/state/` for relevant past work before starting new research `(review-time: workflow guidance)`

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -9,7 +9,7 @@ Follow these disciplines:
 
 ## Before Starting
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 - Verify an approved plan exists (in `.claude/state/plans/` or the current conversation) `(review-time: see section note)`
 - If no plan exists, stop and ask the user to run /plan first `(review-time: see section note)`

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -7,7 +7,7 @@ description: "Monitor the CI pipeline for the current branch via a background Mo
 
 ## Workflow
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 1. **Detect VCS platform**: `.gitlab-ci.yml` -> glab, `.github/` -> gh `(review-time: see section note)`
 2. **Start a Monitor** with the matching script: `(review-time: see section note)`

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -9,7 +9,7 @@ Hard rule: do NOT write any fix until Phase 3 is reached and the user (or the ev
 
 ## Phase 1 - Evidence
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 Gather, do not theorize. Save findings to `.claude/state/research/YYYY-MM-DD-debug-<short-slug>.md`.
 

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -7,7 +7,7 @@ Create or update the diagram for: $ARGUMENTS
 
 ## Step 1 - Pick the format
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 Read `rules/diagrams.md` if uncertain. Default to **mermaid** unless one of these triggers fires - then use **drawio**:
 

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -9,7 +9,7 @@ This skill writes docs that are dual-audience: engineers reading on GitHub AND C
 
 ## Subcommands
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 Parse the first word of `$ARGUMENTS` as the subcommand:
 

--- a/skills/drive-fleet/SKILL.md
+++ b/skills/drive-fleet/SKILL.md
@@ -9,7 +9,7 @@ A two-phase workflow for driving a fleet of MRs/PRs to done in parallel with a m
 
 ## When to use
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 - 2+ independent lanes / multiple MRs, often across sibling repos `(review-time: see section note)`
 - You want a hands-off MANAGER that delegates every edit and only stops when the whole fleet is done `(review-time: see section note)`

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -7,7 +7,7 @@ Fix the GitHub issue: $ARGUMENTS
 
 Follow this workflow:
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the issue, the codebase, and the prior state of the work.
+**why-no-hook:** skill workflow guidance; each step requires understanding the issue, the codebase, and the prior state of the work.
 
 1. **Fetch**: run `gh issue view $ARGUMENTS --json title,body,labels,assignees,comments` to get full issue details `(review-time: see section note)`
 2. **Load agents**: based on the issue domain, load the relevant expert agents from `~/.claude/agents/` (see `rules/agent-routing.md`). Their guardrails apply throughout the fix. `(review-time: see section note)`

--- a/skills/grill-with-docs/SKILL.md
+++ b/skills/grill-with-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill-with-docs
-description: "Runs a grilling session that challenges a plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when the user wants to stress-test a plan against their project's language and documented decisions."
+description: "Runs a grilling session that challenges a plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions are made. Use when the user wants to stress-test a plan against their project's language and documented decisions."
 ---
 
 > Source: [mattpocock/skills - engineering/grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs)
@@ -63,7 +63,7 @@ When the user uses a term that conflicts with the existing language in `CONTEXT.
 
 ### Sharpen fuzzy language
 
-When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' - do you mean the Customer or the User? Those are different things."
+When the user uses vague or overloaded terms, propose one precise term to use everywhere. "You're saying 'account' - do you mean the Customer or the User? Those are different things."
 
 ### Discuss concrete scenarios
 
@@ -81,7 +81,7 @@ Don't couple `CONTEXT.md` to implementation details. Only include terms that are
 
 ### Offer ADRs sparingly
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 Only offer to create an ADR when all three are true:
 
@@ -97,7 +97,7 @@ For a plan with genuine cross-domain tension or competing approaches, convene a 
 
 - Spawn domain-expert teammates via the Agent tool (route per `rules/agent-routing.md`), each with a read-only brief and a distinct stance to argue `(review-time: panel-vs-solo judgment)`
 - Have them debate the plan among themselves via SendMessage - the cross-talk between teammates surfaces contradictions and trade-offs you would miss solo `(review-time: protocol guidance)`
-- Distill their disagreement into the next question and put it to the user - keep the user-facing cadence to one question at a time per `rules/communication.md`; the panel never messages the user directly `(review-time: cadence discipline)`
+- Turn their disagreement into the next question and put it to the user - keep the user-facing cadence to one question at a time per `rules/communication.md`; the panel never messages the user directly `(review-time: cadence discipline)`
 - Skip the panel for single-domain plans - solo grilling is cheaper and a panel adds nothing when there is nothing to contend `(review-time: panel-vs-solo judgment)`
 
 </supporting-info>

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -11,7 +11,7 @@ Surface architectural friction and propose **deepening opportunities** - refacto
 
 ## Glossary
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 Use these terms exactly in every suggestion. Consistent language is the point - don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
 
@@ -67,7 +67,7 @@ Do NOT propose interfaces yet. Ask the user: "Which of these would you like to e
 
 Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them - constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
 
-Side effects happen inline as decisions crystallize:
+Side effects happen inline as decisions are made:
 
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` - same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist. `(review-time: see section note)`
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there. `(review-time: see section note)`

--- a/skills/mr/SKILL.md
+++ b/skills/mr/SKILL.md
@@ -7,7 +7,7 @@ description: "Create a merge request or pull request from the current branch: ve
 
 ## Workflow
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 1. **Run `/verify-done` first**: hard-fail on any failure. Do not proceed to push, title generation, or PR ceremony if lint, typecheck, test, or build is broken. This pre-empts the most common CI failures (lint, format, typecheck) before they cost a CI run. `(review-time: see section note)`
 2. **Detect VCS platform**: check for `.gitlab-ci.yml` (-> glab) or `.github/` (-> gh) `(review-time: see section note)`

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -46,7 +46,7 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 
 ## Boundaries
 
-**why-not-mechanizable:** scope and YAGNI exceptions are subjective complexity judgments; no hook can detect that a finding belongs in a "correctness" pass versus a "complexity" pass.
+**why-no-hook:** scope and YAGNI exceptions are subjective complexity judgments; no hook can detect that a finding belongs in a "correctness" pass versus a "complexity" pass.
 
 - Complexity only - correctness bugs, security holes, and performance go to a normal review pass, not this one `(review-time: see section note)`
 - A single smoke test or `assert`-based self-check is the minimum, not bloat - never flag it for deletion `(review-time: see section note)`

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -5,7 +5,7 @@ description: "Starts Phase 1 (Research) for a topic: reads every relevant file, 
 
 Start Phase 1 (Research) for the following topic: $ARGUMENTS
 
-For non-trivial topics, run **panel mode** (see `rules/parallel-agents.md`): spawn one `Explore` teammate per subsystem, run one bounded cross-check round via SendMessage so teammates flag contradictions across their areas, then synthesize their findings into the artifact yourself. For narrow topics, explore solo. Read all relevant files, check git history for context, and investigate related patterns.
+For bigger topics, run **panel mode** (see `rules/parallel-agents.md`): spawn one `Explore` teammate per subsystem, run one bounded cross-check round via SendMessage so teammates flag contradictions across their areas, then pull their findings together into the artifact yourself. For narrow topics, explore solo. Read all relevant files, check git history for context, and investigate related patterns.
 
 Save the research artifact to `.claude/state/research/YYYY-MM-DD-research-<topic>.md` (use today's date) containing:
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -7,7 +7,7 @@ Review the pull request: $ARGUMENTS
 
 Follow this process:
 
-**why-not-mechanizable:** review workflow guidance; each step requires reading the PR and judging code quality / intent.
+**why-no-hook:** review workflow guidance; each step requires reading the PR and judging code quality / intent.
 
 1. **Fetch PR details**: run `gh pr view $ARGUMENTS --json title,body,files,commits,additions,deletions,baseRefName,headRefName` `(review-time: see section note)`
 2. **Read the diff**: run `gh pr diff $ARGUMENTS` to see all changes `(review-time: see section note)`

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -11,7 +11,7 @@ Run these checks in order. Stop at the first failure.
 
 ### 1. Code Quality
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 - [ ] Run `/verify-done` - stop on first failure (typecheck + lint + tests + build) `(review-time: see section note)`
 - [ ] No debugging artifacts (`console.log`, `debugger`, `.only()`, `TODO` without issue link) `(review-time: see section note)`

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -42,7 +42,7 @@ Follow this workflow:
 - <Explicitly excluded from this work>
 
 ## Open Questions
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 - <Anything unresolved that needs a decision>
 ```

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -9,7 +9,7 @@ Write tests for: $ARGUMENTS
 
 ### For New Features: RED-GREEN-REFACTOR
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 1. **RED**: write a failing test that describes the expected behavior `(review-time: see section note)`
    - Test name reads like a specification: "returns empty array when no users match" `(review-time: see section note)`

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -25,7 +25,7 @@ Look for opportunities to prefactor the code to make the implementation easier -
 
 ### 3. Draft vertical slices
 
-**why-not-mechanizable:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
+**why-no-hook:** skill workflow guidance; each step requires understanding the surrounding context (repo, task shape, prior state).
 
 Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
 

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -20,7 +20,7 @@ Every ticket has a **name** - its heading. In everything the human reads - narra
 
 ## The Map
 
-The map is a single markdown file at `.claude/state/wayfinder/<effort-slug>.md` - the canonical artifact. Its tickets live inside it under `## Tickets`.
+The map is a single markdown file at `.claude/state/wayfinder/<effort-slug>.md` - the single source of truth. Its tickets live inside it under `## Tickets`.
 
 The map is an **index**, not a store. Its Decisions-so-far lists the decisions made; a decision lives in exactly one place - its ticket's `Answer` - so the map never restates it, only gists it. `(review-time: single-source-of-truth discipline)`
 


### PR DESCRIPTION
## What does this PR do?

Makes the repo's wording plain and keeps it that way:

- New **Plain language** section in `rules/communication.md`: prefer the plain word (use, combine, unrelated, consistent); keep real terms of art and the defined glossary terms in CONTEXT.md / LANGUAGE.md; define a precise term in one plain sentence at first use
- `hooks/post-edit-lint.sh` now blocks the worst offenders (utilize, homogenize, crystallize, synthesize, orthogonal, holistic, paradigm, synergy, salient) in newly added markdown lines - same shift-left pattern as the em-dash check, with the existing `SKIP_POST_EDIT_LINT=1` escape; `rules/communication.md` itself is exempt since it names the words as examples
- Renamed the `why-not-mechanizable` marker to `why-no-hook` across all 20 files that use it; `rule-authoring.md` now says "rule bullet" instead of "normative bullet"
- Swept the existing fancy wording out of CONTEXT.md, `parallel-agents`, `state-persistence`, `grill-with-docs`, `research`, `wayfinder`, and `improve-codebase-architecture` (converge/synthesize/crystallise/orthogonal/canonical/distill -> plain equivalents)
- Deliberately kept: ArgoCD "reconciliation" (the actual GitOps term), the CONTEXT.md and LANGUAGE.md glossary vocabularies, and the immutable ADRs

Hook verified: violating file blocked with exit 2, clean file passes, exempt file passes, `bash -n` clean.

Note: the hook is user-scoped, so the word check applies to markdown edits in every repo, not just this one.

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed (hook tested by direct invocation; no test framework in this repo)
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant