### PR TITLE
feat(rules): load infrastructure rules for ansible trees

### DIFF
--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -10,11 +10,19 @@ paths:
   - "**/kubernetes/**"
   - "**/helm/**"
   - "**/manifests/**"
+  - "**/ansible/**"
+  - "**/ansible.cfg"
+  - "**/playbooks/**"
+  - "**/roles/**/tasks/**"
+  - "**/roles/**/handlers/**"
+  - "**/group_vars/**"
+  - "**/host_vars/**"
+  - "**/site.yml"
 ---
 
 # Infrastructure Conventions
 
-**When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, or CI/CD workflow files - and when running any infra command that applies, destroys, or grants access (`terraform apply/destroy`, `gcloud`, `gsutil`, `aws`, `kubectl delete`).
+**When to apply:** editing Terraform, Dockerfiles, docker-compose, Kubernetes manifests, Ansible playbooks or roles, or CI/CD workflow files - and when running any infra command that applies, destroys, or grants access (`terraform apply/destroy`, `ansible-playbook`, `gcloud`, `gsutil`, `aws`, `kubectl delete`).
 
 - Infrastructure as Code only - no manual changes to cloud resources `(review-time: process, not detectable in code)`
 - No `latest` tags for Docker images - always use specific version tags `(hook)`


### PR DESCRIPTION
## What does this PR do?

- Adds Ansible-structural globs to `rules/infrastructure.md` frontmatter so the infrastructure rules load when working in an Ansible tree
- The path-scoping introduced in #108 matched Terraform, Docker, Kubernetes and CI paths, so an Ansible repo (`roles/`, `playbooks/`, `group_vars/`) never triggered these rules at all
- Updates the "When to apply" line to name Ansible playbooks/roles and `ansible-playbook` alongside the other infra commands

Added globs:

```yaml
  - "**/ansible/**"
  - "**/ansible.cfg"
  - "**/playbooks/**"
  - "**/roles/**/tasks/**"
  - "**/roles/**/handlers/**"
  - "**/group_vars/**"
  - "**/host_vars/**"
  - "**/site.yml"
```

Scoping notes:

- Deliberately narrower than a blanket `**/*.yml`, which would pull the infra rules into every YAML file (OpenAPI specs, app config, Home Assistant automations) and undo the context saving #108 was after
- `roles/` is matched only through its `tasks/` and `handlers/` subdirectories, so an RBAC-style `src/roles/` directory does not trigger a false load
- `**/inventory/**` was considered and dropped: it collides with domain code such as an e-commerce inventory module. Ansible inventories are already covered by `**/ansible/**` in the common layout
- Covers both layouts: Ansible under a subdirectory (`ansible/roles/...`) and Ansible at repo root (`roles/...`, `group_vars/...`)

## Category

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follow-up to path-scoped rules: https://github.com/domengabrovsek/claude/pull/108

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant

Verified against a real Ansible homelab repo: `ansible/roles/<role>/tasks/main.yml`, `ansible/site.yml` and `ansible/group_vars/all.yml` all match, where none of them did before.

No tests: this repo has no test suite or CI workflows, and the change is rule frontmatter consumed by the harness.
