### PR TITLE
fix(hooks): audit the live config dir in symlink-check

### DIFF
--- a/hooks/symlink-check.sh
+++ b/hooks/symlink-check.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 # SessionStart hook (matcher: startup).
-# Warns to stderr when expected ~/.claude/* symlinks to the dotfiles repo are
-# missing, replaced by a real file, or pointing to the wrong target. Non-blocking.
+# Warns to stderr when the expected symlinks from the live config dir to the
+# dotfiles repo are missing, replaced by a real file, or pointing to the wrong
+# target. Non-blocking.
+#
+# The dir checked resolves from $CLAUDE_CONFIG_DIR (default ~/.claude), the same
+# way scripts/setup-symlinks.sh picks its target, so a second account's dir is
+# audited by its own sessions instead of being skipped.
+#
 # Bypass with SKIP_SYMLINK_CHECK=1 in the environment.
 
 [ "$SKIP_SYMLINK_CHECK" = "1" ] && exit 0
 
 REPO="${CLAUDE_DOTFILES_REPO:-$HOME/dev/claude}"
 [ -d "$REPO" ] || exit 0
+
+LIVE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+[ -d "$LIVE_DIR" ] || exit 0
 
 EXPECTED=(
   "CLAUDE.md|$REPO/CLAUDE.md"
@@ -25,7 +34,7 @@ ISSUES=()
 for ENTRY in "${EXPECTED[@]}"; do
   NAME="${ENTRY%%|*}"
   WANT="${ENTRY##*|}"
-  LIVE="$HOME/.claude/$NAME"
+  LIVE="$LIVE_DIR/$NAME"
 
   if [ ! -e "$LIVE" ] && [ ! -L "$LIVE" ]; then
     ISSUES+=("MISSING:       $LIVE  (expected -> $WANT)")
@@ -40,13 +49,13 @@ for ENTRY in "${EXPECTED[@]}"; do
 done
 
 if [ ${#ISSUES[@]} -gt 0 ]; then
-  echo "[symlink-check] dotfiles symlinks have drifted from $REPO:" >&2
+  echo "[symlink-check] $LIVE_DIR symlinks have drifted from $REPO:" >&2
   for ISSUE in "${ISSUES[@]}"; do echo "  - $ISSUE" >&2; done
   echo "" >&2
   echo "Fix each path with:" >&2
   echo "  unlink <path> 2>/dev/null; rm -rf <path> 2>/dev/null; ln -s <expected-target> <path>" >&2
   echo "" >&2
-  echo "(Override repo location: CLAUDE_DOTFILES_REPO=/path/to/repo. Bypass this check: SKIP_SYMLINK_CHECK=1.)" >&2
+  echo "(Override repo location: CLAUDE_DOTFILES_REPO=/path/to/repo. Override config dir: CLAUDE_CONFIG_DIR=/path/to/dir. Bypass this check: SKIP_SYMLINK_CHECK=1.)" >&2
 fi
 
 exit 0


### PR DESCRIPTION
## What does this PR do?

- `hooks/symlink-check.sh` now resolves the dir it audits from `$CLAUDE_CONFIG_DIR` (default `~/.claude`), matching how `scripts/setup-symlinks.sh` has picked its target since #95
- Adds a `[ -d "$LIVE_DIR" ] || exit 0` guard so an unset or stale `CLAUDE_CONFIG_DIR` exits quietly instead of reporting every entry as missing
- Names the resolved dir in the warning header and documents the `CLAUDE_CONFIG_DIR` override in the footer

The setup script was parameterized for a second config dir, but the checker kept a hardcoded `$HOME/.claude`. Sessions running against a second account's dir audited the wrong path, so drift there was invisible: the `scripts` entry added in #109 was missing from a second dir for weeks and only turned up by hand.

## Category

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

- Parameterized the setup script: https://github.com/domengabrovsek/claude/pull/95
- Added the `scripts` entry this went on to miss: https://github.com/domengabrovsek/claude/pull/109

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

Tested against four cases, `bash -n` clean:

| Case | Result |
| --- | --- |
| Default, no `CLAUDE_CONFIG_DIR` (healthy `~/.claude`) | silent, exit 0 - unchanged behavior |
| `CLAUDE_CONFIG_DIR` set to a healthy second dir | silent, exit 0 - previously audited `~/.claude` by mistake |
| `CLAUDE_CONFIG_DIR` set to a drifted dir | all three classes reported: `MISSING`, `WRONG-TARGET`, `NOT-A-SYMLINK` |
| `CLAUDE_CONFIG_DIR` pointing at a nonexistent path | silent, exit 0 - guard prevents an all-missing false alarm |

Drifted-dir output:

```
[symlink-check] /tmp/fakecfg1 symlinks have drifted from /path/to/repo:
  - MISSING:       /tmp/fakecfg1/settings.json  (expected -> /path/to/repo/settings.json)
  - WRONG-TARGET:  /tmp/fakecfg1/rules -> /etc/hosts  (expected -> /path/to/repo/rules)
  - NOT-A-SYMLINK: /tmp/fakecfg1/skills  is a real file (expected -> /path/to/repo/skills)
```

No tests added: this repo has no test suite or CI workflows, and the hook is a shell script exercised by the manual matrix above.
