### PR TITLE
chore(settings): default new sessions to auto permission mode

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -4,6 +4,7 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
+    "defaultMode": "auto",
     "allow": [
       "Read(**/.env.example)",
       "Read(**/.env.sample)",


### PR DESCRIPTION
## What does this PR do?

- Sets `permissions.defaultMode` to `auto` in `settings.json`, so every new session starts in auto mode instead of the default prompt-per-action mode
- No other settings touched: the existing `permissions.deny` list (secret-file reads, `sudo`, `rm -rf`, force-push, `gh pr merge`) still applies on top of auto mode as hard denials
- `skipAutoPermissionPrompt` is deliberately left at `false`, so the one-time auto-mode opt-in dialog still shows and gets accepted interactively rather than pre-accepted in config

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
