### PR TITLE
ci: route workflows to air self-hosted runner

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   lint:
     name: Lint Markdown
-    runs-on: ubuntu-latest
+    runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
     if: always()
     needs:
       - lint
-    runs-on: ubuntu-latest
+    runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
     timeout-minutes: 1
     steps:
       - name: Check results


### PR DESCRIPTION
Routes all CI jobs to the air self-hosted runner via the CI_RUNNER variable switch (ubuntu-latest fallback).