### PR TITLE
fix(ci): pin notify reusable workflow to @main

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   notify:
-    uses: domengabrovsek/github-actions/.github/workflows/notify.yml@master
+    uses: domengabrovsek/github-actions/.github/workflows/notify.yml@main
     with:
       api_url: ${{ vars.TELEGRAM_API_URL }}
       chat_id: ${{ vars.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
- The `github-actions` `master` branch is stale: its tip is the #36 revert and it no longer carries the `.github/workflows` tree.
- As a result `notify.yml@master` is unresolvable, so every PR's Notifications run fails with a "workflow file issue" error.
- The reusable workflows live on `main`, which is what the rest of the fleet already pins.
- Repoints this repo's `notifications.yml` from `@master` to `@main`.