### PR TITLE
chore(settings): enable voice input by default on all machines

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,6 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
       "Read(**/.env.example)",
       "Read(**/.env.sample)",
@@ -125,7 +124,8 @@
       "Bash(*DROP DATABASE*)",
       "Bash(*TRUNCATE TABLE*)",
       "mcp__claude_ai_Atlassian__*"
-    ]
+    ],
+    "defaultMode": "auto"
   },
   "hooks": {
     "PreToolUse": [
@@ -291,9 +291,14 @@
     "frontend-design@claude-plugins-official": true
   },
   "effortLevel": "high",
+  "askUserQuestionTimeout": "never",
   "autoUpdatesChannel": "stable",
   "minimumVersion": "2.1.92",
-  "skipAutoPermissionPrompt": false,
   "tui": "fullscreen",
-  "askUserQuestionTimeout": "never"
+  "voice": {
+    "enabled": true,
+    "mode": "hold"
+  },
+  "skipAutoPermissionPrompt": false,
+  "voiceEnabled": true
 }


### PR DESCRIPTION
## What does this PR do?

- Enables voice input by default in every session by persisting it in the tracked `settings.json`
- Sets `voiceEnabled: true` and `voice: { enabled: true, mode: "hold" }` (hold space to record)
- Removes the need to run `/voice` per machine - any machine that syncs this config gets dictation on at startup
- Also reorders `permissions.defaultMode` and `skipAutoPermissionPrompt` (same values, position only - written by the same settings update)

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
