### PR TITLE
docs(rules): drop stale subagent-context and run_in_background claims

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,6 @@ _Avoid_: "spike task", "POC".
 - **Lane mode** is for mutating work (build/implementation); **Panel mode** is for read-only work (research, grilling, design).
 - An **Advisory persona** can join **Panel mode** only; a **Lane mode** teammate must be a **Writer persona**.
 - The distinguishing axis is coordination topology: **Lane mode** is a star (teammates report only to the parent), **Panel mode** is a mesh (teammates also message each other). Worktree isolation follows from this: lanes mutate files so they need worktrees, panels are read-only so they do not.
-- Background execution (`run_in_background`) is independent of mode - either mode can run in the background.
 
 ## Example dialogue
 
@@ -75,5 +74,4 @@ _Avoid_: "spike task", "POC".
 ## Flagged ambiguities
 
 - "subagent" was used for both the generic spawn mechanism and a named agent - resolved: a named agent is a **Teammate**; "subagent" refers only to the generic Agent-tool spawn.
-- "in the background" was conflated with "spawned as a team" - resolved: background execution is independent of coordination mode.
 - "skill" was used for both sequencing workflows and single practices - resolved: a sequencing skill is an **Orchestrator**, a single-practice skill is a **Reusable discipline**.

--- a/rules/agent-routing.md
+++ b/rules/agent-routing.md
@@ -48,4 +48,4 @@ When a task crosses domains, spawn multiple subagents in **parallel** - send a s
 
 - Subagent guardrails apply within their context. Act on the subagent's summary, not the agent file `(review-time: about Claude's use of the agent's reply)`
 - Multiple subagents may produce conflicting recommendations - surface conflicts to the user, do not silently pick a side `(review-time: requires reading multiple subagent outputs)`
-- Subagents see none of the parent conversation - brief them with self-contained prompts (goal, file paths, constraints, verification command) `(review-time: prompt-quality judgment)`
+- Brief subagents with self-contained prompts (goal, file paths, constraints, verification command) `(review-time: prompt-quality judgment)`

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -63,9 +63,8 @@ Worktree isolation applies to **lane mode** (file-mutating work). Panel mode is 
 - Each teammate works on its own branch - no risk of stepping on other teammates' changes `(review-time: descriptive of the mechanism)`
 - NEVER run file-mutating parallel teammates without worktree isolation - concurrent edits to the same working directory will cause corruption `(review-time: tool-call parameter choice; not currently hook-gated)`
 
-## Background Execution
+## Spawning and Coordination
 
-- Spawn teammates with `run_in_background: true` so they execute concurrently `(review-time: tool-call parameter)`
 - Launch all independent teammates in a single message with multiple Agent tool calls `(review-time: message-shape choice)`
 - In **lane mode**, after spawning, wait for automatic completion notifications - do NOT poll or check repeatedly `(review-time: behavioral discipline)`
 - In **panel mode**, this rule is inverted: actively coordinate via SendMessage during the cross-challenge round rather than waiting silently for notifications `(review-time: behavioral discipline, mode-dependent)`
@@ -84,7 +83,7 @@ After all agents complete:
 
 ## Agent Prompt Quality
 
-Each agent's prompt MUST be self-contained. The agent cannot see the parent conversation. Include:
+Each agent's prompt MUST be self-contained. Include:
 
 - **Goal**: Exactly what the agent must accomplish - be specific and unambiguous `(review-time: prompt-quality)`
 - **Context**: Relevant background (why this change is needed, what the broader task is) `(review-time: prompt-quality)`

--- a/skills/drive-fleet/orchestration.md
+++ b/skills/drive-fleet/orchestration.md
@@ -15,7 +15,7 @@ Setting the `/goal` is a one-time human decision. It pre-authorizes the in-scope
 
 ## The loop
 
-1. **Build lanes in parallel.** One subagent per lane, each in its own git worktree, file-isolated, <=4-5 concurrent. Route by domain: Frontend Staff Engineer / Backend Staff Engineer (Agent `subagent_type`, `run_in_background: true`, `isolation: "worktree"`). Sequential sub-tickets that share files stay inside ONE agent.
+1. **Build lanes in parallel.** One subagent per lane, each in its own git worktree, file-isolated, <=4-5 concurrent. Route by domain: Frontend Staff Engineer / Backend Staff Engineer (Agent `subagent_type`, `isolation: "worktree"`). Sequential sub-tickets that share files stay inside ONE agent.
 2. **Open MRs (the batched gate).** Once lanes are pushed, open MRs via `/mr` - conventional commits, no co-author trailers, stacked-MR dependencies and retargeting. Approve the batch once.
 3. **Poll CI in the background.** One Monitor per branch via `/ci` (emits only on status change, zero cost while running). React on Monitor notifications and agent-completion events - never block the manager turn polling.
 4. **Per red MR - fix subagent.** Spawn a domain-expert subagent in that lane's worktree to diagnose and fix. Infra-flake or clearly-unrelated failure -> retry the job (`glab ci retry` / `gh run rerun`); real failure -> fix and push. Same issue 3x -> escalate to the user.


### PR DESCRIPTION
## What does this PR do?

Claude Code 2.1.232 and 2.1.233 changed the Agent tool surface. Four documents still described the previous harness:

- `run_in_background` was removed as an Agent tool parameter; backgrounding is now implicit. Dropped from `rules/parallel-agents.md`, `skills/drive-fleet/orchestration.md`, and `CONTEXT.md`.
- `subagent_type: "fork"` lets a spawn inherit the parent conversation, so "subagents see none of the parent conversation" is no longer universally true. Dropped the premise from `rules/agent-routing.md` and `rules/parallel-agents.md`, keeping the self-contained-brief rule it used to justify.
- Renamed `## Background Execution` to `## Spawning and Coordination`, since nothing under that heading describes backgrounding anymore.
- Removed the `CONTEXT.md` background-execution relationship line and its flagged-ambiguity entry, both unreachable now the parameter is gone.

Fork is deliberately not documented as a delegation option: `subagent_type` accepts either `"fork"` or a persona, never both, so a fork trades the routing table's domain expertise for session context. The change is subtractive - four insertions, seven deletions, no new rules to maintain.

`docs/adr/0003` is left untouched. Its Consequences section was accurate when written, and ADRs here are point-in-time records rather than living documents.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follows the Agent tool changes in Claude Code 2.1.232 and 2.1.233: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [ ] PR description provides enough context to understand the change
- [ ] Screenshots or logs included where relevant
