### PR TITLE
docs(rules): forbid historical narrative in code comments

### DIFF
--- a/rules/comments.md
+++ b/rules/comments.md
@@ -32,6 +32,7 @@ This rule is mechanically enforced by `hooks/post-edit-lint.sh`.
 ## Forbidden
 
 - **WHAT-restating comments** - anything that paraphrases the next line of code (`// Increment counter` above `counter++`). `(review-time: requires semantic comparison of comment text and the next statement)`
+- **Historical narrative** - how the code came to be this way: what the previous tool or approach did, who applied something, what used to fail, what was tried first. A comment states why the code is the way it is *now*. History belongs in the commit message and PR description, where `git blame` leads a reader who actually wants it. `(review-time: requires judging whether a clause states a present constraint or recounts past events)`
 - **Ticket / PR / issue / ADR references in any comment**: `JIRA-123`, `#456`, `Fixes owner/repo#789`, `ADR-0042`, `Per ADR 0030`, etc. These belong in PR descriptions, ADR files, and `git blame`. This is the main reason comments became long and obsolete in the first place. `(hook)`
 - **Em dashes** anywhere - use a regular hyphen. `(hook)`
 - **TODOs, FIXMEs, XXX markers** without an open tracker entry - open the ticket, fix the code now, or accept it isn't getting fixed. `(hook)`
@@ -103,4 +104,4 @@ This policy applies to all code, including code written by subagents spawned via
 
 Exit 2 surfaces the offending lines back to Claude as a follow-up message; the model must remove the violations before proceeding. Bypass for genuine exceptions: `SKIP_POST_EDIT_LINT=1` in the env. Use sparingly and document why in the PR description.
 
-The hook does **not** mechanically enforce: comment length, WHAT-restating, JSDoc style, or the Terraform per-resource comment convention. Those are review-time judgments.
+The hook does **not** mechanically enforce: comment length, WHAT-restating, historical narrative, JSDoc style, or the Terraform per-resource comment convention. Those are review-time judgments.


### PR DESCRIPTION
## Summary

- Adds **Historical narrative** to the Forbidden list in `rules/comments.md`.
- Adds it to the list of things `post-edit-lint.sh` does not mechanically catch.

## Why

The Forbidden list already covered WHAT-restating, tracker refs, em dashes and TODO markers. Nothing stopped a comment from recounting *how* the code got here instead of *why* it is that way now.

That gap produced this, on a Terraform IAM binding:

```hcl
# Creating a Cloud Scheduler job that authenticates as the invoker SA requires
# actAs on that SA. None of the applier's project roles carry it -
# serviceAccountAdmin manages service accounts but cannot act as them - so CI
# has never been able to create these jobs; the staging one was applied by a
# human in gcp-admins, which does hold serviceAccountUser. Granted on this one
# SA rather than project-wide, which would let the applier impersonate the app
# runtime SA too.
```

Half of it is archaeology. Who applied the staging equivalent, and the fact that CI had never managed it, tell a reader nothing about whether the binding can change. They also rot: once nobody remembers the incident, the sentences are noise that still has to be read.

Rewritten to the present constraint and the scoping reason:

```hcl
/* Creating a Scheduler job that authenticates as the invoker SA is authorised
   against actAs on that SA, and none of the applier's project roles grant it -
   serviceAccountAdmin manages service accounts but cannot act as them. Scoped
   to this SA: project-wide would also let the applier impersonate the runtime
   SA, which holds the per-org PHI bucket grants. */
```

The history did not disappear, it moved to the commit message and PR description, which is where `git blame` leads anyone who wants it.

## Enforcement layer

Tagged `(review-time: requires judging whether a clause states a present constraint or recounts past events)`. It is not hook-checkable - "the previous tool did X" and "X is required because Y" are grammatically similar and only distinguishable by reading the surrounding code, so a regex would fire on legitimate comments explaining a workaround.

Per `rules/rule-authoring.md`, that justification is why this stays at the weakest layer rather than getting a hook.
