### PR TITLE
feat(hooks): gate prose on files, commit messages and PR bodies

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,6 +30,16 @@ jobs:
       - name: Check always-loaded rule budget
         run: ./scripts/config-budget.sh
 
+  prose:
+    name: Prose Gate
+    runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    steps:
+      - name: Checkout
+        uses: domengabrovsek/github-actions/.github/actions/checkout@main
+
+      - name: Test the prose gate and scan the markdown corpus
+        run: bash hooks/prose-gate.test.sh
+
   # ==============================================
   # Gate
   # ==============================================
@@ -41,6 +51,7 @@ jobs:
     needs:
       - lint
       - budget
+      - prose
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
     timeout-minutes: 1
     steps:
@@ -49,6 +60,7 @@ jobs:
           results=(
             "${{ needs.lint.result }}"
             "${{ needs.budget.result }}"
+            "${{ needs.prose.result }}"
           )
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ These rules apply to every project. Project-level CLAUDE.md files override where
 
 The four rules broken most often. They outrank everything below.
 
-**why-no-hook:** voice, sentence shape, prose volume, and "is this the existing pattern" are judgments about free-form output and about intent. A hook sees tool input, not phrasing or reasoning. The banned-phrase list is the one mechanical slice, and it is hooked.
+**why-no-hook:** voice, sentence shape, prose volume, and "is this the existing pattern" are judgments about intent. `hooks/prose-gate.sh` catches the mechanical slice (word list, filler, chatbot phrasing) on markdown writes, commit messages and PR bodies. It cannot see a chat reply, and the judgment tier lives in the `write-plain` skill.
 
 ### 1. Write plain
 
@@ -16,7 +16,8 @@ Covers replies, PR descriptions, tickets, docs, rules, skills, commit messages.
 - One idea per sentence. Cut any sentence whose only job is introducing the next one `(review-time: see section note)`
 - Asked for a table or a list? Output only that. No prose wrapper, no summary after it `(review-time: see section note)`
 - Say the thing, then stop. No closing paragraph repeating what you just said `(review-time: see section note)`
-- Never write: "to make sure X, let's Y", "it's worth noting", "I should mention", "we'll want to", "it's important to", "in order to", "leverage", "utilize", "delve", "robust", "seamless", "comprehensive" `(hook)`
+- Never write: "to make sure X, let's Y", "it's worth noting", "I should mention", "we'll want to", "it's important to", "in order to", "leverage", "utilize", "delve", "robust", "seamless", "comprehensive", "crucial", "pivotal", "showcase", "facilitate", "numerous", "serves as" `(hook)`
+- Revising a doc, ADR, spec or PR body? Use the `write-plain` skill for the patterns no regex catches `(review-time: see section note)`
 - Length caps: PR body 150 words, review or Slack reply 120, session diary 300, ADR 400. In chat, write the shortest version that answers and expand when asked `(review-time: see section note)`
 
 ### 2. Verify before asserting

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,14 @@ _Avoid_: "global rule", "base rule".
 A rule that enters context only when its trigger fires: `paths:` frontmatter matching a touched file, or a model-invoked skill matching the request. Costs nothing in sessions that never touch its trigger.
 _Avoid_: "lazy rule", "scoped rule".
 
+**Prose gate**:
+The mechanical tier of the writing policy: the word lists, filler phrases and punctuation checks in `hooks/prose-gate.sh`, applied to markdown writes, commit messages and PR bodies. Distinct from the code-structure checks in `hooks/post-edit-lint.sh`, which fire on comment shape and language rules rather than word choice.
+_Avoid_: "the lint hook", "the style check".
+
+**Judgment tier**:
+The half of the writing policy no regex can check: forced triads, synonym cycling, sentences naming a feeling instead of a mechanism. Lives in the `write-plain` skill, so it triggers on prose work rather than loading every session.
+_Avoid_: "soft rules", "style guide".
+
 ## Relationships
 
 - A **Teammate** runs in either **Lane mode** or **Panel mode**.
@@ -75,6 +83,7 @@ _Avoid_: "lazy rule", "scoped rule".
 - **Lane mode** is for mutating work (build/implementation); **Panel mode** is for read-only work (research, grilling, design).
 - An **Advisory persona** can join **Panel mode** only; a **Lane mode** teammate must be a **Writer persona**.
 - An **Always-loaded rule** competes for attention in every session; an **On-demand rule** does not. A rule with a mechanical trigger (file path or unambiguous phrase) belongs on demand.
+- The **Prose gate** and the **Judgment tier** split one policy by what a regex can see. A pattern that fires on correct usage belongs in the **Judgment tier**, not the gate.
 - The distinguishing axis is coordination topology: **Lane mode** is a star (teammates report only to the parent), **Panel mode** is a mesh (teammates also message each other). Worktree isolation follows from this: lanes mutate files so they need worktrees, panels are read-only so they do not.
 
 ## Example dialogue

--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-# Post-edit lint hook backing rules/comments.md and the writing-style
-# policy in CLAUDE.md. Bypass: SKIP_POST_EDIT_LINT=1.
+# Post-edit lint hook backing rules/comments.md, rules/typescript.md,
+# rules/database.md and rules/infrastructure.md: code-structure checks on
+# newly added lines, plus a whole-file em-dash autofix.
+#
+# Prose checks (word lists, scaffolding phrases) live in hooks/prose-gate.sh,
+# which also covers commit messages and PR bodies.
+#
+# Bypass: SKIP_POST_EDIT_LINT=1.
 
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -23,43 +29,6 @@ esac
 if LC_ALL=C grep -q $'\xe2\x80\x94' "$FILE" 2>/dev/null; then
   sed -i '' $'s/\xe2\x80\x94/-/g' "$FILE"
 fi
-
-# --- 1b. Plain-language check in markdown (CLAUDE.md: Read this first) ---
-# Two tiers: BLOCK words that never earn their place, WARN on words that have
-# a defensible technical use. CLAUDE.md and communication.md carry the lists
-# themselves, so checking them would flag their own definitions.
-case "$FILE" in
-  */rules/communication.md|*/CLAUDE.md|*/.claude/state/*) ;;
-  *.md|*.markdown)
-    MD_DIR=$(dirname "$FILE")
-    if git -C "$MD_DIR" rev-parse --git-dir >/dev/null 2>&1 && git -C "$MD_DIR" ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
-      MD_ADDED=$(git -C "$MD_DIR" diff --unified=0 HEAD -- "$FILE" 2>/dev/null | grep -E '^\+[^+]' | sed 's/^\+//')
-    else
-      MD_ADDED=$(cat "$FILE")
-    fi
-
-    # Tier 2: advisory. A plainer word is usually available, but not always.
-    SOFT=$(echo "$MD_ADDED" | grep -inE "\b(robust|comprehensive|leverag(e|es|ed|ing)|in order to)\b" 2>/dev/null || true)
-    if [ -n "$SOFT" ]; then
-      echo "[post-edit-lint] $FILE (advisory)" >&2
-      echo "Plainer word probably available (sturdy, full, use, to):" >&2
-      echo "$SOFT" >&2
-    fi
-
-    # Tier 1: blocking. Fancy words plus the scaffolding phrases that read as
-    # filler in every context they appear in.
-    FANCY=$(echo "$MD_ADDED" | grep -inE "\b(utili[sz]e[sd]?|homogeni[sz]e[sd]?|crystalli[sz]e[sd]?|synthesi[sz]e[sd]?|orthogonal|holistic|paradigm|synerg[a-z]*|salient|delv(e|es|ed|ing)|seamless(ly)?)\b" 2>/dev/null || true)
-    SCAFFOLD=$(echo "$MD_ADDED" | grep -inE "(it['’]?s worth noting|it is worth noting|it['’]?s important to|it is important to|we['’]?ll want to|we will want to|i should mention|to make sure .* let['’]?s)" 2>/dev/null || true)
-
-    if [ -n "$FANCY" ] || [ -n "$SCAFFOLD" ]; then
-      echo "[post-edit-lint] $FILE" >&2
-      echo "CLAUDE.md (Writing style): plain word, active voice, no scaffolding. Say the thing and stop." >&2
-      [ -n "$FANCY" ] && echo "$FANCY" >&2
-      [ -n "$SCAFFOLD" ] && echo "$SCAFFOLD" >&2
-      exit 2
-    fi
-    ;;
-esac
 
 # --- Skip docs/text: prose comment markers cause false positives ---
 case "$FILE" in

--- a/hooks/prose-gate.sh
+++ b/hooks/prose-gate.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# Prose gate backing the "Write plain" policy in CLAUDE.md.
+#
+# One word list, three surfaces, dispatched by the first argument:
+#   file    PostToolUse on Write|Edit  - markdown files only
+#   commit  PreToolUse on git commit   - the whole commit message
+#   pr      PreToolUse on gh pr create - the --body / --body-file text
+#   corpus  CI / test only              - a whole markdown file by path
+#
+# Two tiers. BLOCK words have no defensible use in this repo and exit 2.
+# ADVISORY words have a real but rare use, so they print and pass.
+#
+# Deliberately unchecked: surface, features, vector, harness. All four are
+# terms of art here, so a check would fire on correct usage. Sentence-case
+# headings and mid-sentence colons are unchecked for the same reason: the
+# doc-title convention and the "term: definition" rule format rely on both.
+#
+# Bypass: SKIP_PROSE_GATE=1.
+
+MODE="${1:-file}"
+
+# corpus mode takes a path and reads no stdin; every other mode reads hook JSON.
+# Read it before the bypass check so the writer never hits a closed pipe.
+INPUT=""
+if [ "$MODE" != "corpus" ]; then
+  INPUT=$(cat)
+fi
+
+[ "$SKIP_PROSE_GATE" = "1" ] && exit 0
+
+# ---------------------------------------------------------------------------
+# Extract the text to check, per mode.
+# ---------------------------------------------------------------------------
+LABEL=""
+TEXT=""
+
+case "$MODE" in
+  file)
+    FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+    [ -z "$FILE" ] && exit 0
+    [ ! -f "$FILE" ] && exit 0
+
+    case "$FILE" in
+      *.md|*.markdown) ;;
+      *) exit 0 ;;
+    esac
+
+    # These carry the lists themselves, so checking them flags their own text.
+    case "$FILE" in
+      */CLAUDE.md|*/rules/communication.md) exit 0 ;;
+      */skills/write-plain/SKILL.md) exit 0 ;;
+      */.claude/state/*) exit 0 ;;
+    esac
+
+    LABEL="$FILE"
+    FILE_DIR=$(dirname "$FILE")
+    if git -C "$FILE_DIR" rev-parse --git-dir >/dev/null 2>&1 \
+      && git -C "$FILE_DIR" ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
+      TEXT=$(git -C "$FILE_DIR" diff --unified=0 HEAD -- "$FILE" 2>/dev/null | grep -E '^\+[^+]' | sed 's/^\+//')
+    else
+      TEXT=$(cat "$FILE")
+    fi
+    ;;
+
+  commit)
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+    case "$COMMAND" in
+      *"git commit --help"*|*"git commit -h"*) exit 0 ;;
+      *"git commit"*) ;;
+      *) exit 0 ;;
+    esac
+
+    # Auto-generated or reused messages are not ours to police.
+    if echo "$COMMAND" | grep -qE -- '(--amend|--fixup=|--squash=|--no-edit|-C[[:space:]]+|--reuse-message=)'; then
+      exit 0
+    fi
+
+    LABEL="commit message"
+    TEXT=$(printf '%s' "$COMMAND" | python3 -c '
+import sys, re
+
+cmd = sys.stdin.read()
+
+# A heredoc carries the structured multi-line message when one is used.
+m = re.search(r"<<-?[\x27\"]?(\w+)[\x27\"]?", cmd)
+if m:
+    delim = m.group(1)
+    after = cmd[m.end():]
+    nl = after.find("\n")
+    if nl != -1:
+        out = []
+        for line in after[nl + 1:].split("\n"):
+            if line.strip() == delim:
+                break
+            out.append(line)
+        print("\n".join(out))
+        sys.exit(0)
+
+# Otherwise collect every -m / --message value. The backreference keeps a
+# quote of the other kind inside the message from ending the match early.
+vals = [m.group(2) for m in
+        re.finditer(r"(?:-m|--message)[=\s]+([\x27\"])(.*?)\1", cmd, re.S)]
+if vals:
+    print("\n".join(vals))
+' 2>/dev/null)
+    ;;
+
+  pr)
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+    case "$COMMAND" in
+      *"gh pr create --help"*|*"gh pr create -h"*) exit 0 ;;
+      *"gh pr create"*) ;;
+      *) exit 0 ;;
+    esac
+
+    LABEL="PR body"
+    BODY_FILE=$(printf '%s' "$COMMAND" | python3 -c '
+import sys, re
+cmd = sys.stdin.read()
+m = re.search(r"--body-file[=\s]+[\x27\"]?([^\x27\"\s]+)", cmd)
+print(m.group(1) if m else "")
+' 2>/dev/null)
+
+    if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
+      TEXT=$(cat "$BODY_FILE")
+    else
+      TEXT=$(printf '%s' "$COMMAND" | python3 -c '
+import sys, re
+
+cmd = sys.stdin.read()
+
+m = re.search(r"--body[=\s]+<<-?[\x27\"]?(\w+)[\x27\"]?", cmd)
+if m:
+    delim = m.group(1)
+    after = cmd[m.end():]
+    nl = after.find("\n")
+    if nl != -1:
+        out = []
+        for line in after[nl + 1:].split("\n"):
+            if line.strip() == delim:
+                break
+            out.append(line)
+        print("\n".join(out))
+        sys.exit(0)
+
+vals = [m.group(2) for m in
+        re.finditer(r"(?:-b|--body)[=\s]+([\x27\"])(.*?)\1", cmd, re.S)]
+if vals:
+    print("\n".join(vals))
+' 2>/dev/null)
+    fi
+    ;;
+
+  corpus)
+    FILE="${2:-}"
+    [ -z "$FILE" ] && { echo "[prose-gate] corpus mode needs a file path" >&2; exit 1; }
+    [ ! -f "$FILE" ] && { echo "[prose-gate] no such file: $FILE" >&2; exit 1; }
+
+    case "$FILE" in
+      */CLAUDE.md|CLAUDE.md) exit 0 ;;
+      */rules/communication.md|rules/communication.md) exit 0 ;;
+      */skills/write-plain/SKILL.md|skills/write-plain/SKILL.md) exit 0 ;;
+      */.claude/state/*) exit 0 ;;
+      # Accepted ADRs are immutable, so the corpus pass cannot ask for a
+      # rewrite. New ADRs are still gated by file mode as they are written.
+      */docs/adr/*|docs/adr/*) exit 0 ;;
+    esac
+
+    LABEL="$FILE"
+    TEXT=$(cat "$FILE")
+    ;;
+
+  *)
+    echo "[prose-gate] Unknown mode: $MODE (expected file, commit, pr or corpus)" >&2
+    exit 1
+    ;;
+esac
+
+[ -z "$TEXT" ] && exit 0
+
+# ---------------------------------------------------------------------------
+# Check. Patterns live in one place; the tier decides block versus advise.
+# ---------------------------------------------------------------------------
+RESULT=$(printf '%s' "$TEXT" | LABEL="$LABEL" python3 -c '
+import os, re, sys
+
+text = sys.stdin.read()
+
+BLOCK = [
+    # Fancy words with a plain equivalent.
+    (r"utili[sz]e[sd]?", "use"),
+    (r"homogeni[sz]e[sd]?", "make the same"),
+    (r"crystalli[sz]e[sd]?", "settle"),
+    (r"synthesi[sz]e[sd]?", "combine"),
+    (r"orthogonal", "unrelated"),
+    (r"holistic", "whole"),
+    (r"paradigm", "model"),
+    (r"synerg\w*", "name the actual gain"),
+    (r"salient", "main"),
+    (r"delv(?:e|es|ed|ing)", "look at"),
+    (r"seamless(?:ly)?", "name what does not break"),
+    (r"crucial", "needed, or say why"),
+    (r"enduring", "lasting, or a duration"),
+    (r"fostering", "name what it causes"),
+    (r"garner(?:s|ed|ing)?", "get"),
+    (r"interplay", "how they interact"),
+    (r"intricate", "detailed"),
+    (r"pivotal", "name the effect"),
+    (r"showcas(?:e|es|ed|ing)", "show"),
+    (r"tapestry", "name the thing"),
+    (r"testament", "state what happened"),
+    (r"vibrant", "a neutral description"),
+    (r"facilitat(?:e|es|ed|ing)", "help"),
+    (r"numerous", "many, or the number"),
+    (r"in the event that", "if"),
+    (r"due to the fact that", "because"),
+    # Fancy ways to say "is" or "has".
+    (r"boasts?", "is, or has"),
+    (r"serves as", "is"),
+    (r"stands as", "is"),
+    # Abstract metaphor nouns with a concrete equivalent.
+    (r"substrate", "base"),
+    (r"locus", "place"),
+    (r"vantage", "view"),
+    (r"nexus", "link"),
+    (r"bedrock", "base"),
+    (r"modality", "mode"),
+    (r"gold-plating", "more than the job needs"),
+    (r"flywheel", "name the mechanism"),
+    (r"north star", "the goal"),
+    (r"endgame", "the last phase"),
+]
+
+BLOCK_PHRASE = [
+    # Scaffolding that reads as filler wherever it appears.
+    (r"it[’\x27]?s worth noting", "delete it"),
+    (r"it is worth noting", "delete it"),
+    (r"it[’\x27]?s important to", "delete it"),
+    (r"it is important to", "delete it"),
+    (r"we[’\x27]?ll want to", "say who does what"),
+    (r"we will want to", "say who does what"),
+    (r"i should mention", "just mention it"),
+    (r"to make sure .{0,40}? let[’\x27]?s", "say the action"),
+    # Chatbot and sycophantic artifacts.
+    (r"i hope this helps", "delete it"),
+    (r"let me know if", "delete it"),
+    (r"of course!", "delete it"),
+    (r"certainly!", "delete it"),
+    (r"great question", "answer it"),
+    (r"you[’\x27]?re absolutely right", "answer directly"),
+    (r"found the smoking gun", "state the finding"),
+    # Stacked hedging.
+    (r"(?:could|might|may) potentially", "pick one"),
+    (r"potentially possibly", "pick one"),
+    (r"it (?:could|might) be argued", "argue it or drop it"),
+]
+
+ADVISE = [
+    (r"robust", "sturdy"),
+    (r"comprehensive", "full"),
+    (r"leverag(?:e|es|ed|ing)", "use"),
+    (r"in order to", "to"),
+    (r"landscape", "the concrete word"),
+    (r"additionally", "and, or start the sentence"),
+    (r"enhanc(?:e|es|ed|ement|ements|ing)", "improve, or the number"),
+    (r"wedge", "add"),
+    (r"ratchet", "the real mechanism"),
+    (r"evacuate", "move out"),
+    (r"scaffolding", "the real structure"),
+    (r"primitive", "the real name"),
+]
+
+CURLY = "‘’“”"
+EMOJI = re.compile(
+    "[\U0001F300-\U0001FAFF\u2600-\u27BF\u2B00-\u2BFF\uFE0F]"
+)
+
+lines = text.split("\n")
+blocks, advisories = [], []
+
+def scan(rules, sink, word_boundary=True):
+    for pat, fix in rules:
+        rx = (r"\b" + pat + r"\b") if word_boundary else pat
+        for n, line in enumerate(lines, 1):
+            m = re.search(rx, line, re.IGNORECASE)
+            if m:
+                sink.append((n, m.group(0), fix))
+                break
+
+scan(BLOCK, blocks)
+scan(BLOCK_PHRASE, blocks, word_boundary=False)
+scan(ADVISE, advisories)
+
+for n, line in enumerate(lines, 1):
+    hit = [c for c in CURLY if c in line]
+    if hit:
+        blocks.append((n, "".join(hit), "straight quotes"))
+        break
+
+for n, line in enumerate(lines, 1):
+    if line.lstrip().startswith("#"):
+        m = EMOJI.search(line)
+        if m:
+            blocks.append((n, m.group(0), "drop the emoji"))
+            break
+
+label = os.environ.get("LABEL", "text")
+
+if advisories:
+    print("ADVISE", file=sys.stderr)
+    for n, word, fix in sorted(advisories):
+        print(f"  line {n}: {word!r} -> {fix}", file=sys.stderr)
+
+if blocks:
+    print("BLOCK", file=sys.stderr)
+    for n, word, fix in sorted(blocks):
+        print(f"  line {n}: {word!r} -> {fix}", file=sys.stderr)
+    sys.exit(2)
+
+sys.exit(0)
+' 2>&1)
+STATUS=$?
+
+if echo "$RESULT" | grep -q '^ADVISE$'; then
+  echo "[prose-gate] $LABEL (advisory)" >&2
+  echo "$RESULT" | sed -n '/^ADVISE$/,/^BLOCK$/p' | grep -v '^ADVISE$' | grep -v '^BLOCK$' >&2
+fi
+
+if [ "$STATUS" -eq 2 ]; then
+  echo "[prose-gate] $LABEL" >&2
+  echo "CLAUDE.md (Write plain): plain word, no filler, no chatbot phrasing." >&2
+  echo "$RESULT" | sed -n '/^BLOCK$/,$p' | grep -v '^BLOCK$' >&2
+  echo "(Bypass: SKIP_PROSE_GATE=1)" >&2
+  exit 2
+fi
+
+exit 0

--- a/hooks/prose-gate.test.sh
+++ b/hooks/prose-gate.test.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Tests for hooks/prose-gate.sh.
+#
+# Two parts:
+#   fixtures  strings that must block, and strings that must pass
+#   corpus    every markdown file in the repo must pass
+#
+# The corpus pass is the regression guard that matters. The tier split was
+# chosen because these words had zero hits in this repo; the corpus pass is
+# what keeps that true, and what catches a new pattern that starts firing on
+# writing we consider correct.
+#
+# Usage: bash hooks/prose-gate.test.sh
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT/hooks/prose-gate.sh"
+cd "$ROOT"
+
+PASSED=0
+FAILED=0
+
+fail() {
+  echo "  FAIL: $1" >&2
+  FAILED=$((FAILED + 1))
+}
+
+ok() {
+  PASSED=$((PASSED + 1))
+}
+
+# run_commit <text> -> exit status of the gate on that commit message
+run_commit() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+print(json.dumps({"tool_input": {"command": "git commit -m " + json.dumps(sys.stdin.read())}}))
+' | "$GATE" commit >/dev/null 2>&1
+  echo $?
+}
+
+# ---------------------------------------------------------------------------
+# Must block
+# ---------------------------------------------------------------------------
+echo "== must block =="
+MUST_BLOCK=(
+  "feat: a pivotal refactor"
+  "feat: this will facilitate the rollout"
+  "fix: numerous edge cases"
+  "docs: showcase the new flow"
+  "docs: a testament to the design"
+  "feat: crucial change to the loader"
+  "refactor: the intricate interplay of modules"
+  "feat: utilize the shared client"
+  "feat: a seamless migration"
+  "refactor: delve into the parser"
+  "docs: the enduring landscape of vibrant tapestry"
+  "feat: it serves as the entry point"
+  "feat: the module boasts three exports"
+  "refactor: move the substrate to a new nexus"
+  "docs: the bedrock of the endgame"
+  "docs: our north star for the flywheel"
+  "chore: in the event that the build fails"
+  "chore: skipped due to the fact that CI was red"
+  "docs: it is important to run the gate first"
+  "docs: it's worth noting the ordering constraint"
+  "fix: done. Let me know if you need anything else"
+  "fix: I hope this helps"
+  "docs: Great question, here is the answer"
+  "fix: this could potentially break the loader"
+  "docs: a holistic paradigm with real synergy"
+  "refactor: extract the salient orthogonal parts"
+)
+
+for t in "${MUST_BLOCK[@]}"; do
+  st=$(run_commit "$t")
+  if [ "$st" = "2" ]; then ok; else fail "expected block, got exit $st: $t"; fi
+done
+
+# ---------------------------------------------------------------------------
+# Must pass - terms of art and ordinary engineering prose
+# ---------------------------------------------------------------------------
+echo "== must pass =="
+MUST_PASS=(
+  "feat(hooks): add the prose gate"
+  "refactor(rules): cut the always-loaded rule surface"
+  "feat: reduce the attack surface of the upload path"
+  "feat: add three features behind a flag"
+  "fix: the feature flag defaulted to on"
+  "fix: normalise the vector before comparing"
+  "test: add a harness for the retry path"
+  "docs: describe the injection surface"
+  "fix: guard against a null pointer in the parser"
+  "perf: cut p99 from 840ms to 120ms"
+  "refactor: move the loader into its own module"
+  "chore: pin the node version to 22.11.0"
+  "fix: the compiler validates queries at build time"
+  "docs: record why the ordering constraint exists"
+)
+
+for t in "${MUST_PASS[@]}"; do
+  st=$(run_commit "$t")
+  if [ "$st" = "0" ]; then ok; else fail "expected pass, got exit $st: $t"; fi
+done
+
+# ---------------------------------------------------------------------------
+# Advisory words warn but never block
+# ---------------------------------------------------------------------------
+echo "== advisory passes =="
+ADVISORY=(
+  "feat: a robust retry policy"
+  "docs: a comprehensive guide"
+  "refactor: leverage the shared client"
+  "chore: bump deps in order to fix the audit"
+  "refactor: replace the scaffolding with a real loader"
+)
+
+for t in "${ADVISORY[@]}"; do
+  st=$(run_commit "$t")
+  if [ "$st" = "0" ]; then ok; else fail "advisory must not block, got exit $st: $t"; fi
+done
+
+# ---------------------------------------------------------------------------
+# Bypass and mode plumbing
+# ---------------------------------------------------------------------------
+echo "== plumbing =="
+st=$(SKIP_PROSE_GATE=1 bash -c 'printf "%s" "$0" | python3 -c "
+import json, sys
+print(json.dumps({\"tool_input\": {\"command\": \"git commit -m \" + json.dumps(sys.stdin.read())}}))
+" | '"$GATE"' commit >/dev/null 2>&1; echo $?' "feat: a pivotal refactor")
+if [ "$st" = "0" ]; then ok; else fail "SKIP_PROSE_GATE=1 should bypass, got exit $st"; fi
+
+echo '{"tool_input":{"command":"git commit --amend --no-edit"}}' | "$GATE" commit >/dev/null 2>&1
+if [ $? = 0 ]; then ok; else fail "amend/no-edit should be skipped"; fi
+
+echo '{"tool_input":{"command":"npm test"}}' | "$GATE" commit >/dev/null 2>&1
+if [ $? = 0 ]; then ok; else fail "non-commit command should be ignored"; fi
+
+echo '{"tool_input":{"command":"gh pr create --title x --body \"a pivotal change\""}}' | "$GATE" pr >/dev/null 2>&1
+if [ $? = 2 ]; then ok; else fail "pr mode should block a pivotal body"; fi
+
+echo '{"tool_input":{"file_path":"/nonexistent/file.md"}}' | "$GATE" file >/dev/null 2>&1
+if [ $? = 0 ]; then ok; else fail "missing file should exit 0"; fi
+
+echo '{"tool_input":{}}' | "$GATE" badmode >/dev/null 2>&1
+if [ $? = 1 ]; then ok; else fail "unknown mode should exit 1"; fi
+
+# ---------------------------------------------------------------------------
+# Corpus - every markdown file in the repo must pass
+# ---------------------------------------------------------------------------
+echo "== corpus =="
+CORPUS_FAILED=0
+while IFS= read -r f; do
+  out=$("$GATE" corpus "$f" 2>&1)
+  if [ $? -eq 2 ]; then
+    echo "  FAIL: $f" >&2
+    echo "$out" | grep "line " | sed 's/^/      /' >&2
+    CORPUS_FAILED=$((CORPUS_FAILED + 1))
+  fi
+done < <(find . -path ./.git -prune -o -name '*.md' -print | sort)
+
+if [ "$CORPUS_FAILED" -eq 0 ]; then
+  ok
+else
+  FAILED=$((FAILED + CORPUS_FAILED))
+  echo "  $CORPUS_FAILED markdown file(s) trip the block tier." >&2
+  echo "  Reword them, or move the pattern to the advisory tier in prose-gate.sh." >&2
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "passed: $PASSED   failed: $FAILED"
+[ "$FAILED" -eq 0 ] || exit 1
+echo "OK"

--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,6 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
       "Read(**/.env.example)",
       "Read(**/.env.sample)",
@@ -125,8 +124,10 @@
       "Bash(*DROP DATABASE*)",
       "Bash(*TRUNCATE TABLE*)",
       "mcp__claude_ai_Atlassian__*"
-    ]
+    ],
+    "defaultMode": "auto"
   },
+  "model": "opus[1m]",
   "hooks": {
     "PreToolUse": [
       {
@@ -191,6 +192,18 @@
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/pre-commit-conventional-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\"",
             "if": "Bash(git commit *)",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/prose-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/prose-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\" commit",
+            "if": "Bash(git commit *)",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/prose-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/prose-gate.sh\"; [ -x \"$HOOK\" ] && exec \"$HOOK\" pr",
+            "if": "Bash(gh pr create *)",
+            "timeout": 15
           }
         ]
       }
@@ -212,6 +225,11 @@
           {
             "type": "command",
             "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/post-edit-lint.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/post-edit-lint.sh\"; if [ -x \"$HOOK\" ]; then \"$HOOK\"; fi",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "HOOK=\"$CLAUDE_PROJECT_DIR/hooks/prose-gate.sh\"; [ -x \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/prose-gate.sh\"; if [ -x \"$HOOK\" ]; then \"$HOOK\" file; fi",
             "timeout": 15
           }
         ]
@@ -290,10 +308,10 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
   },
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
+  "askUserQuestionTimeout": "never",
   "autoUpdatesChannel": "stable",
   "minimumVersion": "2.1.92",
-  "skipAutoPermissionPrompt": false,
   "tui": "fullscreen",
-  "askUserQuestionTimeout": "never"
+  "skipAutoPermissionPrompt": false
 }

--- a/skills/write-plain/SKILL.md
+++ b/skills/write-plain/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: write-plain
+description: "Edits prose to cut the patterns that read as machine-written: puffery, vague attribution, forced triads, synonym cycling, inline-header lists, and sentences that name a feeling instead of a mechanism. Use when writing or revising a doc, ADR, spec, research artifact, PR description, or any prose longer than a few lines."
+---
+
+> Source: [cursor/plugins - pstack/skills/unslop](https://github.com/cursor/plugins/blob/main/pstack/skills/unslop/SKILL.md). Adapted, not vendored verbatim; see "What this skill leaves out" below.
+
+The mechanical half of this policy is a hook, not a skill. `hooks/prose-gate.sh` blocks the word list, the filler phrases, the chatbot artifacts, curly quotes and emoji headings on every markdown write, commit message and PR body. Nothing in this file repeats that list.
+
+This skill covers what a regex cannot see.
+
+## Process
+
+1. Read the draft against the patterns below.
+2. Rewrite. Keep the meaning, keep the register.
+3. Ask what a reader does with each sentence. If a sentence supports no action, no decision, and no fact, cut it.
+
+## Patterns
+
+### Say what it does, not how it feels
+
+"The database stays close at hand", "SQL you can read", "types that follow your schema" all name a feeling. Name the mechanism or a number instead: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build".
+
+Two checks:
+
+- Restate the sentence as an instruction, a fact, or a number. If you cannot, cut it.
+- If the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+
+### Puffery and promotion
+
+"a pivotal moment", "a testament to", "the evolving landscape", "setting the stage for". Cut the frame, state what happened. Same for "nestled", "breathtaking", "groundbreaking", "renowned", "must-visit" in any description that should be neutral.
+
+### Vague attribution
+
+"Experts believe", "industry reports suggest", "some critics argue". Name the source with a link, or delete the claim. This is the prose form of the rule in `CLAUDE.md` section 2: cite the file, the command output, or the query.
+
+### Superficial -ing clauses
+
+A trailing "..., highlighting the need for X", "..., ensuring reliability", "..., reflecting the team's priorities" adds no information. Delete it, or replace it with the specific consequence.
+
+### Forced triads
+
+Three items because three sounds complete, not because there are three. Use the real number. Two is a fine list. So is five.
+
+### Synonym cycling
+
+Protagonist, main character, central figure, hero across one section. Pick the term and repeat it. In this repo the glossary in `CONTEXT.md` decides which term wins; check it before inventing a second name for something already named.
+
+### False ranges
+
+"from X to Y" where X and Y sit on no shared scale: "from authentication to deployment". List the items instead.
+
+### Inline-header lists
+
+The tell is a bold label whose colon restates the line: "**Performance:** Performance improved by 20%". Convert to prose.
+
+A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail is fine and not a tell: "**Schema in TypeScript.** Tables live in one file."
+
+### Not just X, but Y
+
+State the point directly. The construction promises a reversal it rarely delivers.
+
+### Stacked hedging
+
+"could potentially possibly be argued that it might" is one hedge wearing four coats. Pick one, or drop all of them and make the claim.
+
+### Colons as connectors
+
+A colon before a list or an example is correct. A colon splicing two independent clauses is a crutch: it implies a relationship the sentence never states. Rewrite so the point stands without it.
+
+This one is judgment, not a rule, because the `term: definition` shape used throughout `rules/` is a legitimate colon and a regex cannot tell the two apart.
+
+### Generic conclusions
+
+"The future looks bright", "this sets us up well". State the next specific step or end the document. A closing paragraph that repeats the opening is already banned by `CLAUDE.md` section 1.
+
+## What this skill leaves out
+
+Recorded so a future re-vendor does not silently reintroduce these.
+
+- **The "Adding soul" section.** Two of its six items already exist here in stronger form: "have opinions" is `rules/communication.md` (lead with your recommendation), "be specific" is `CLAUDE.md` section 2 (cite the file and line). The other four ("vary rhythm", "let some mess in", "acknowledge complexity", "use I") contradict the length caps and the one-idea-per-sentence rule in `CLAUDE.md` section 1. The output surfaces here are commit messages, ADRs, PR bodies and chat replies, where terse is the correct register.
+- **Sentence-case headings.** The convention here is title case for document titles and sentence case for ADR decision statements, which are sentences. Adopting the upstream rule would rename 36 headings for no gain in clarity.
+- **Four words from the upstream lists.** `surface`, `features`, `vector` and `harness` are terms of art in this repo, so `hooks/prose-gate.sh` does not check them.


### PR DESCRIPTION
## What does this PR do?

Adapts the [cursor/plugins unslop skill](https://github.com/cursor/plugins/blob/main/pstack/skills/unslop/SKILL.md) as two layers, not one always-loaded rule file. About 14 of its 31 items already existed here, so only the delta landed.

- `hooks/prose-gate.sh` holds the mechanical tier: one word list, four modes (`file`, `commit`, `pr`, `corpus`)
- `hooks/post-edit-lint.sh` hands over its markdown prose block, keeps the code-structure checks
- `skills/write-plain` carries what no regex sees: forced triads, synonym cycling, feeling-instead-of-mechanism
- Zero always-loaded words. Budget 3635 of 3800

Every blocking word scored zero hits here. Four stay unchecked as terms of art:

| word | hits | usage |
| --- | --- | --- |
| `surface` | 33 | "rule surface", "attack surface" |
| `features` | 35 | the plain noun, never verb-for-"has" |
| `vector` | 3 | maths and security |
| `harness` | 2 | test harness |

Sentence-case headings (36 hits) and mid-sentence colons (327, the `term: definition` shape) moved to the skill as judgment. "Adding soul" was dropped: two items already exist in stronger form, four contradict the length caps. The skill records both so a re-vendor does not undo them.

Chat replies are not covered. `Stop` blocks but feeds no text back per the [hook reference](https://code.claude.com/docs/en/hooks), so a blocked reply cannot explain itself. Separate PR after a spike. `CLAUDE.md` claimed a hook cannot see phrasing; now false for commits and PR bodies, so it is corrected.

## Category

- [x] Feature

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

52 fixture cases plus a corpus pass over all 89 markdown files, wired into CI as a `Gate` dependency. Accepted ADRs are exempt from the corpus pass because they are immutable.

```
$ bash hooks/prose-gate.test.sh
passed: 52   failed: 0
OK
```
