### PR TITLE
feat(rules): apply ASD-STE100 sentence shape to written output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,20 @@ These rules apply to every project. Project-level CLAUDE.md files override where
 
 The four rules broken most often. They outrank everything below.
 
-**why-no-hook:** voice, sentence shape, prose volume, and "is this the existing pattern" are judgments about intent. `hooks/prose-gate.sh` catches the mechanical slice (word list, filler, chatbot phrasing) on markdown writes, commit messages and PR bodies. It cannot see a chat reply, and the judgment tier lives in the `write-plain` skill.
+**why-no-hook:** voice, prose volume, and "is this the existing pattern" are judgments about intent. `hooks/prose-gate.sh` catches the mechanical slice (word list, filler, chatbot phrasing, sentence length) on markdown writes, commit messages and PR bodies. It cannot see a chat reply, and the judgment tier lives in the `write-plain` skill.
 
 ### 1. Write plain
 
 Covers replies, PR descriptions, tickets, docs, rules, skills, commit messages.
+Sentence shape follows ASD-STE100 Simplified Technical English (Issue 9), without its approved-word dictionary.
 
 - Active voice, present tense. Name the actor `(review-time: see section note)`
 - One idea per sentence. Cut any sentence whose only job is introducing the next one `(review-time: see section note)`
+- Sentences: 20 words maximum for a step or an instruction, 25 for description. Split anything longer `(hook)`
+- One instruction per sentence. Two actions means two steps `(review-time: needs the step's intent, not its shape)`
+- Noun clusters: three words maximum. "post-edit lint hook" passes, "post-edit lint hook config loader" does not `(review-time: needs part-of-speech tagging a grep cannot do)`
+- Write "because" for cause. Keep "since" for time only `(hook)`
+- Paragraphs: six sentences maximum `(review-time: diff-added lines carry no paragraph boundaries)`
 - Asked for a table or a list? Output only that. No prose wrapper, no summary after it `(review-time: see section note)`
 - Say the thing, then stop. No closing paragraph repeating what you just said `(review-time: see section note)`
 - Never write: "to make sure X, let's Y", "it's worth noting", "I should mention", "we'll want to", "it's important to", "in order to", "leverage", "utilize", "delve", "robust", "seamless", "comprehensive", "crucial", "pivotal", "showcase", "facilitate", "numerous", "serves as" `(hook)`

--- a/hooks/prose-gate.sh
+++ b/hooks/prose-gate.sh
@@ -10,6 +10,11 @@
 # Two tiers. BLOCK words have no defensible use in this repo and exit 2.
 # ADVISORY words have a real but rare use, so they print and pass.
 #
+# Sentence shape follows ASD-STE100 and rides the advisory tier. A sentence
+# over the cap and a causal "since" are the two STE rules a line-oriented
+# check can judge. Noun clusters need part-of-speech tagging, and paragraph
+# length needs boundaries a unified=0 diff throws away.
+#
 # Deliberately unchecked: surface, features, vector, harness. All four are
 # terms of art here, so a check would fire on correct usage. Sentence-case
 # headings and mid-sentence colons are unchecked for the same reason: the
@@ -290,6 +295,47 @@ def scan(rules, sink, word_boundary=True):
 scan(BLOCK, blocks)
 scan(BLOCK_PHRASE, blocks, word_boundary=False)
 scan(ADVISE, advisories)
+
+# ASD-STE100 sentence cap. 20 words for a step, 25 for description; the check
+# uses the looser number because a line carries no step-versus-description
+# marker. Headings, tables, blockquotes and fenced code carry no sentences.
+SENTENCE_CAP = 25
+STRUCTURE = re.compile(r"^\s*(#|\||>)")
+SENTENCE_END = re.compile(r"[.!?]+(?:\s+|$)")
+
+def sentences(line):
+    line = re.sub(r"`[^`]*`", "code", line)
+    line = re.sub(r"\[[^\]]*\]\([^)]*\)", "link", line)
+    line = re.sub(r"https?://\S+", "url", line)
+    return [s for s in SENTENCE_END.split(line) if re.search(r"[A-Za-z]", s)]
+
+long_hits = []
+fenced = False
+for n, line in enumerate(lines, 1):
+    if line.lstrip().startswith("```"):
+        fenced = not fenced
+        continue
+    if fenced or STRUCTURE.match(line):
+        continue
+    for sentence in sentences(line):
+        count = len(sentence.split())
+        if count > SENTENCE_CAP:
+            long_hits.append((n, f"{count}-word sentence",
+                              "split it; the cap is 20 for a step, 25 for description"))
+
+# One report per sentence would take ten rounds on a long file, so show a
+# batch. Five is enough to see the pattern without burying the word list.
+advisories.extend(long_hits[:5])
+
+CAUSAL_SINCE = re.compile(
+    r"\bsince\s+(?:the|it|it\x27s|its|we|you|this|that|they|there|an?)\b",
+    re.IGNORECASE)
+for n, line in enumerate(lines, 1):
+    m = CAUSAL_SINCE.search(line)
+    if m:
+        advisories.append((n, m.group(0),
+                           "write \"because\" for cause; \"since\" marks time"))
+        break
 
 for n, line in enumerate(lines, 1):
     hit = [c for c in CURLY if c in line]

--- a/hooks/prose-gate.test.sh
+++ b/hooks/prose-gate.test.sh
@@ -121,6 +121,46 @@ for t in "${ADVISORY[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
+# Sentence shape - advisory, never blocks
+# ---------------------------------------------------------------------------
+echo "== sentence shape =="
+STE_DIR=$(mktemp -d -t prose-gate-ste)
+STE_FIXTURE="$STE_DIR/fixture.md"
+
+cat > "$STE_FIXTURE" <<'STE'
+# A heading long enough to trip the cap if headings were ever counted at all by the check
+
+The post-edit lint hook reads the added lines from the diff and then walks every check in turn before it decides whether to block the write or only warn.
+
+We skipped the retry since the queue was already drained.
+
+```
+this fenced line is long enough to trip the cap if fenced code were ever counted by the sentence check at all
+```
+
+| a column header long enough to trip the cap if tables were counted | b |
+| --- | --- |
+
+Short line. This one passes.
+STE
+
+STE_OUT=$("$GATE" corpus "$STE_FIXTURE" 2>&1)
+STE_STATUS=$?
+rm -rf "$STE_DIR"
+
+if [ "$STE_STATUS" = "0" ]; then ok; else fail "sentence shape must not block, got exit $STE_STATUS"; fi
+
+if echo "$STE_OUT" | grep -q "line 3: .*-word sentence"; then ok; else fail "expected a long-sentence advisory on line 3"; fi
+
+if echo "$STE_OUT" | grep -q "line 5: .since the."; then ok; else fail "expected a causal \"since\" advisory on line 5"; fi
+
+if echo "$STE_OUT" | grep -qE "line (1|7|8|11): "; then
+  fail "headings, fenced code and tables must be exempt from the cap"
+else
+  ok
+fi
+
+# ---------------------------------------------------------------------------
 # Bypass and mode plumbing
 # ---------------------------------------------------------------------------
 echo "== plumbing =="


### PR DESCRIPTION
## What does this PR do?

Adopts the checkable subset of [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) (Issue 9) so output stops arriving as walls of dense prose.

`CLAUDE.md` rule 1 gains five constraints:

- Sentence cap: 20 words for a step, 25 for description `(hook)`
- One instruction per sentence `(review-time)`
- Noun clusters: three words maximum `(review-time)`
- "because" for cause, "since" for time only `(hook)`
- Paragraphs: six sentences maximum `(review-time)`

`hooks/prose-gate.sh` gains the two mechanical ones in its advisory tier, so they reach markdown writes, commit messages and PR bodies alongside the word list. File mode checks added lines only, so unmodified files stay silent. Headings, tables, blockquotes and fenced code are exempt from the cap.

Two constraints stay `(review-time)` on purpose: noun clusters need part-of-speech tagging a grep cannot do, and paragraph length needs boundaries a `unified=0` diff discards.

The approved-word dictionary is out of scope. It is the part of STE that would flag most software vocabulary.

## Category

- [x] Feature

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

Hook output on a fixture:

```
[prose-gate] fixture.md (advisory)
  line 3: '29-word sentence' -> split it; the cap is 20 for a step, 25 for description
  line 5: 'since the' -> write "because" for cause; "since" marks time
```

`hooks/prose-gate.test.sh`: 56 passed, 0 failed. `scripts/config-budget.sh`: 3732 words, 94/100 review-time bullets, within budget.
