### PR TITLE
chore: sync pi settings, thread review replies, drop employer repo names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Per-session work artifacts (plans, research, specs, session diaries).
 # Per rules/state-persistence.md these live in .claude/state/; in this
 # meta-config repo they are personal notes and do not belong in git
-# history. In domain repos (pentla-api, etc.) the same files are
-# typically committed because plans/specs are shared decisions.
+# history. In domain repos (an API or frontend service) the same files
+# are typically committed because plans/specs are shared decisions.
 .claude/state/
 
 # Agent worktrees and other session-local runtime dirs under .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Load `rulebook` whenever the task needs detailed language, test, database, infra
 - Run the repository's complete quality gate before pushing.
 - Rebase onto the current target branch before opening a pull request.
 - Never force-push or merge a pull request without fresh, explicit user approval.
+- Reply within the relevant review thread. `(review-time: thread context)`
 - Keep commits focused and reviewable. Split unrelated work and very large changes.
 - Feature implementation normally ends with a commit, push, and pull request.
 - Stop earlier only when the user or parent workflow explicitly scopes the handoff.

--- a/pi/settings.json
+++ b/pi/settings.json
@@ -1,5 +1,8 @@
 {
   "theme": "dark",
+  "tuiMode": "fullscreen",
+  "fullscreenExitOutput": "resume-hint",
+  "defaultThinkingLevel": "xhigh",
   "compaction": {
     "enabled": false
   },
@@ -18,6 +21,7 @@
     "npm:pi-mcp-adapter@2.31.0",
     "npm:pi-intercom@0.12.1"
   ],
-  "defaultProvider": "ollama-cloud",
-  "defaultModel": "glm-5.3-flash"
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-opus-5",
+  "lastChangelogVersion": "0.85.0"
 }

--- a/pi/settings.json
+++ b/pi/settings.json
@@ -22,6 +22,5 @@
     "npm:pi-intercom@0.12.1"
   ],
   "defaultProvider": "anthropic",
-  "defaultModel": "claude-opus-5",
-  "lastChangelogVersion": "0.85.0"
+  "defaultModel": "claude-opus-5"
 }

--- a/rules/infrastructure.md
+++ b/rules/infrastructure.md
@@ -81,7 +81,7 @@ Bad description, carries tracker refs:
 
 ```hcl
 variable "platform_admin_email" {
-  description = "Per ADR 0031: email for the platform admin. See pentla-api PR #1397."
+  description = "Per ADR 0031: email for the platform admin. See api-service PR #1397."
   type        = string
 }
 ```

--- a/rules/rule-authoring.md
+++ b/rules/rule-authoring.md
@@ -22,7 +22,7 @@ Ranked by reliability (earliest catch wins per the shift-left principle):
 | --- | --- | --- |
 | `(hook)` | `~/.claude/hooks/*.sh` via `~/.claude/settings.json` | ~1s, fed back to Claude as a tool result |
 | `(lint)` | Repo `biome.json` / `eslint.config.js` / `.markdownlint*` | `npm run check` run |
-| `(CI)` | `.github/workflows/`, pentla-shared reusables | PR cycle |
+| `(CI)` | `.github/workflows/` and shared reusable workflows | PR cycle |
 | `(persona)` | A `~/.claude/agents/*.md` persona file's guardrail section | Subagent compliance, not global |
 | `(review-time: <why>)` | Human attention or Claude attention at review or response time | Open-ended |
 


### PR DESCRIPTION
## What does this PR do?

- Syncs the active Pi interface, model, and changelog settings into version control
- Adds a shared rule requiring review replies to stay inside their relevant thread
- Replaces three mentions of a private employer repo with generic examples: a bad-comment sample in `rules/infrastructure.md`, a `.gitignore` aside, and a CI enforcement-tier cell in `rules/rule-authoring.md`
- Rewrites the two existing commits to author from the personal address instead of a former work address

The generated usage report remains untracked because it is unrelated.

Both earlier commits were rewritten, so this branch was force-pushed. Trees are unchanged; only author and committer metadata differs.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant
