### PR TITLE
chore: follow the repo rename to agent-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Claude Code uses selective links under `~/.claude/` plus a second account dir (d
 
 ```bash
 # Clone the repo - the setup script auto-detects its own location
-git clone git@github.com:domengabrovsek/claude.git
-cd claude
+git clone git@github.com:domengabrovsek/agent-config.git
+cd agent-config
 
 # Report drift without changing anything
 bash scripts/setup-hosts.sh --check
@@ -42,8 +42,6 @@ A machine that does not use every default dir records its own scope in `~/.agent
 `HARNESS_SKIP_HOSTS` applies only under `--host all`; an explicit `--host codex` always runs. `AGENT_HOSTS_ENV` relocates the file.
 
 Without this, an argument-free `--check` re-derives the two-dir defaults and reports permanent drift on dirs the machine never adopted. That matters because the `drift-check` extension calls the script with no arguments and no environment, so the scope has to be a recorded fact rather than a shell prefix someone remembers to type.
-
-This repo is a fork of [`domengabrovsek/claude`](https://github.com/domengabrovsek/claude) carrying the multi-harness direction. `main` is the live personal config; the `upstream-main` branch mirrors upstream, upstream-bound PR branches cut from it, and upstream work merges into `main` periodically. See [ADR 0010](docs/adr/0010-fork-lineage-with-personal-main-and-upstream-mirror.md).
 
 For Codex, the bootstrap adds the shared-instruction fallback and a built-in TUI status line only when each setting is absent. It preserves an existing custom status line.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bash scripts/setup-hosts.sh --apply
 bash scripts/setup-hosts.sh --apply --adopt
 
 # Strip ephemeral state Claude Code and Pi write to settings.json at runtime
-git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState, .lastChangelogVersion)" 2>/dev/null || cat'
+git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState, .lastChangelogVersion, .autoMode)" 2>/dev/null || cat'
 git config filter.strip-ephemeral-state.smudge cat
 ```
 

--- a/pi/extensions/statusline.ts
+++ b/pi/extensions/statusline.ts
@@ -1,6 +1,6 @@
 /**
  * statusline - pi footer styled after the Claude Code statusline
- * (~/.claude/statusline.sh, from the domengabrovsek/claude config repo).
+ * (~/.claude/statusline.sh, from the domengabrovsek/agent-config config repo).
  *
  * Replaces the built-in footer with one priority-ordered line:
  *


### PR DESCRIPTION
## What does this PR do?

Follows the repo rename from `claude` to `agent-config`, which matches the host-neutral scope now that Codex and Pi are supported alongside Claude Code.

- Points the clone URL and `cd` target at `agent-config`
- Updates the repo name in the `pi/extensions/statusline.ts` header comment
- Deletes the fork-lineage paragraph. It arrived unadapted in #130, where it was true of the source repo. Here it claimed this repo forked itself, linked an `ADR 0010` that was never written, and described an `upstream-main` branch that exists neither locally nor on origin
- Adds `.autoMode` to the `strip-ephemeral-state` clean filter

The filter change matters: `~/.claude/settings.json` symlinks into this repo, so an auto-mode scan during a work session wrote an employer's cloud layout, CI secret names, and internal hostnames into a public repo's working tree. `.gitattributes` already routed `settings.json` through the filter, so this extends the deletion list rather than adding a mechanism. Verified by injecting a canary block: the working file carried it, `git diff` did not.

Renaming the local checkout directory is a separate manual step, since live symlinks under `~/.claude/` point at the old path.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follows #130. Related cleanup in #131.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant
