### PR TITLE
fix(ci,hooks): point repo gate and fallback paths at agent-config

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   notify:
-    if: github.repository == 'domengabrovsek/claude'
+    if: github.repository == 'domengabrovsek/agent-config'
     uses: domengabrovsek/github-actions/.github/workflows/notify.yml@main
     with:
       api_url: ${{ vars.TELEGRAM_API_URL }}

--- a/hooks/symlink-check.sh
+++ b/hooks/symlink-check.sh
@@ -12,7 +12,7 @@
 
 [ "$SKIP_SYMLINK_CHECK" = "1" ] && exit 0
 
-REPO="${CLAUDE_DOTFILES_REPO:-$HOME/dev/claude}"
+REPO="${AGENT_CONFIG_REPO:-${CLAUDE_DOTFILES_REPO:-$HOME/dev/personal/agent-config}}"
 [ -d "$REPO" ] || exit 0
 
 LIVE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"

--- a/scripts/setup-hosts.sh
+++ b/scripts/setup-hosts.sh
@@ -99,7 +99,7 @@ else
   if [ -d "$CANDIDATE/.git" ] || git -C "$CANDIDATE" rev-parse --git-dir >/dev/null 2>&1; then
     REPO="$CANDIDATE"
   else
-    REPO="$HOME/dev/claude"
+    REPO="$HOME/dev/personal/agent-config"
   fi
 fi
 


### PR DESCRIPTION
## What does this PR do?

Catches three references the rename to `agent-config` missed. Both were silently broken, not merely stale.

- `.github/workflows/notifications.yml` gated the notify job on `github.repository == 'domengabrovsek/claude'`. That stopped matching at the rename, so every PR notification skipped. Visible as `notify: SKIPPED` on #131 and #132
- `hooks/symlink-check.sh` fell back to `$HOME/dev/claude`, a path that never existed on this layout. With neither override variable set, the `[ -d "$REPO" ] || exit 0` guard fired and the hook audited nothing while still reporting success. It now also accepts `AGENT_CONFIG_REPO`, matching the precedence `scripts/setup-hosts.sh` already uses
- `scripts/setup-hosts.sh` carried the same dead `$HOME/dev/claude` last-resort fallback

The symlink hook stays inert until the local checkout directory is renamed to match. That move is manual, because live symlinks under `~/.claude/` point at the current path.

## Category

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

Follows #132.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant
