### PR TITLE
fix: repair broken shared paths and two silent hook failures

### DIFF
--- a/hooks/post-edit-typecheck.sh
+++ b/hooks/post-edit-typecheck.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-# Post-edit hook: run typecheck and lint for .ts/.tsx files
-# Uses npm scripts if available, falls back to npx tsc / npm run lint
+# Post-edit hook: run typecheck and lint for .ts/.tsx files.
+# Uses npm scripts if available, falls back to a locally installed tsc.
+#
+# Exit 2 with the report on stderr is the only code Claude Code feeds back to
+# the model; any other nonzero is a silent non-blocking error, which would drop
+# the very type errors this hook exists to surface.
+#
+# Bypass: SKIP_POST_EDIT_TYPECHECK=1.
 
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -11,35 +17,68 @@ case "$FILE" in
   *) exit 0 ;;
 esac
 
-# Walk up to find the nearest package.json
+[ "$SKIP_POST_EDIT_TYPECHECK" = "1" ] && exit 0
+
+case "$FILE" in
+  */node_modules/*|*/dist/*|*/build/*) exit 0 ;;
+esac
+
+# Walk up to find the nearest package.json. A relative path would make
+# `dirname` return "." forever, so anchor it before the walk.
 DIR=$(dirname "$FILE")
-while [[ "$DIR" != "/" && "$DIR" != "." ]]; do
-  if [[ -f "$DIR/package.json" ]]; then
-    cd "$DIR"
+case "$DIR" in
+  /*) ;;
+  *) DIR="$PWD/$DIR" ;;
+esac
 
-    # Typecheck: prefer npm script, fall back to npx tsc
-    HAS_TYPECHECK=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.typecheck ? 0 : 1)" 2>/dev/null && echo yes || echo no)
-    if [[ "$HAS_TYPECHECK" == "yes" ]]; then
-      npm run typecheck 2>&1
-    else
-      npx tsc --noEmit 2>&1
-    fi
-    TC_EXIT=$?
-
-    # Lint: prefer lint:fix, fall back to lint
-    HAS_LINT_FIX=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.['lint:fix'] ? 0 : 1)" 2>/dev/null && echo yes || echo no)
-    HAS_LINT=$(node -e "const p = require('./package.json'); process.exit(p.scripts?.lint ? 0 : 1)" 2>/dev/null && echo yes || echo no)
-    if [[ "$HAS_LINT_FIX" == "yes" ]]; then
-      npm run lint:fix 2>&1
-    elif [[ "$HAS_LINT" == "yes" ]]; then
-      npm run lint 2>&1
-    fi
-    LF_EXIT=$?
-
-    if [[ $TC_EXIT -ne 0 ]]; then
-      exit $TC_EXIT
-    fi
-    exit $LF_EXIT
+PROJECT_ROOT=""
+while [ "$DIR" != "/" ] && [ -n "$DIR" ]; do
+  if [ -f "$DIR/package.json" ]; then
+    PROJECT_ROOT="$DIR"
+    break
   fi
   DIR=$(dirname "$DIR")
 done
+
+[ -z "$PROJECT_ROOT" ] && exit 0
+cd "$PROJECT_ROOT" || exit 0
+
+has_script() {
+  node -e "const p=require('./package.json'); process.exit(p.scripts?.['$1'] ? 0 : 1)" 2>/dev/null
+}
+
+REPORT=""
+
+# Typecheck: prefer the npm script. Fall back to tsc only when the project is
+# actually a TypeScript project (a tsconfig) and tsc is already installed;
+# bare `npx tsc` would download the compiler to typecheck a project that never
+# asked for one.
+if has_script typecheck; then
+  OUT=$(npm run typecheck --silent 2>&1) || REPORT="$REPORT
+typecheck failed:
+$OUT"
+elif [ -f "tsconfig.json" ] && [ -x "node_modules/.bin/tsc" ]; then
+  OUT=$(node_modules/.bin/tsc --noEmit 2>&1) || REPORT="$REPORT
+typecheck failed:
+$OUT"
+fi
+
+# Lint: prefer lint:fix, fall back to lint.
+if has_script "lint:fix"; then
+  OUT=$(npm run lint:fix --silent 2>&1) || REPORT="$REPORT
+lint failed:
+$OUT"
+elif has_script lint; then
+  OUT=$(npm run lint --silent 2>&1) || REPORT="$REPORT
+lint failed:
+$OUT"
+fi
+
+if [ -n "$REPORT" ]; then
+  echo "[post-edit-typecheck] $FILE" >&2
+  echo "$REPORT" | tail -40 >&2
+  echo "(Bypass: SKIP_POST_EDIT_TYPECHECK=1)" >&2
+  exit 2
+fi
+
+exit 0

--- a/hooks/prose-gate.test.sh
+++ b/hooks/prose-gate.test.sh
@@ -3,7 +3,7 @@
 #
 # Two parts:
 #   fixtures  strings that must block, and strings that must pass
-#   corpus    every markdown file in the repo must pass
+#   corpus    every tracked markdown file must pass
 #
 # The corpus pass is the regression guard that matters. The tier split was
 # chosen because these words had zero hits in this repo; the corpus pass is
@@ -186,8 +186,18 @@ echo '{"tool_input":{}}' | "$GATE" badmode >/dev/null 2>&1
 if [ $? = 1 ]; then ok; else fail "unknown mode should exit 1"; fi
 
 # ---------------------------------------------------------------------------
-# Corpus - every markdown file in the repo must pass
+# Corpus - every tracked markdown file must pass
 # ---------------------------------------------------------------------------
+# Tracked files only. Vendored markdown under node_modules is not this repo's
+# prose, and scanning it turns a dependency install into a red test run.
+list_corpus() {
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git ls-files '*.md' | sort
+  else
+    find . -path ./.git -prune -o -path ./node_modules -prune -o -name '*.md' -print | sort
+  fi
+}
+
 echo "== corpus =="
 CORPUS_FAILED=0
 while IFS= read -r f; do
@@ -197,7 +207,7 @@ while IFS= read -r f; do
     echo "$out" | grep "line " | sed 's/^/      /' >&2
     CORPUS_FAILED=$((CORPUS_FAILED + 1))
   fi
-done < <(find . -path ./.git -prune -o -name '*.md' -print | sort)
+done < <(list_corpus)
 
 if [ "$CORPUS_FAILED" -eq 0 ]; then
   ok

--- a/hooks/watch-pr-checks.sh
+++ b/hooks/watch-pr-checks.sh
@@ -4,6 +4,7 @@
 # If no argument, detects the PR for the current branch.
 
 PR_REF="${1:-}"
+DEADLINE_SECONDS="${PR_CHECK_DEADLINE_SECONDS:-1800}"
 
 # If no PR ref given, try to get it from the current branch
 if [ -z "$PR_REF" ]; then
@@ -16,35 +17,36 @@ fi
 
 PR_TITLE=$(gh pr view "$PR_REF" --json title -q '.title' 2>/dev/null || echo "PR #$PR_REF")
 
-# Poll every 30 seconds, max 60 attempts (30 minutes)
-MAX_ATTEMPTS=60
-ATTEMPT=0
+notify() {
+  osascript -e "display notification \"$1\" with title \"$2\" sound name \"$3\""
+}
 
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-  ATTEMPT=$((ATTEMPT + 1))
-  sleep 30
+# `gh pr checks --watch` blocks until every check settles, then exits 0 when
+# they all passed and nonzero when any failed. Polling the table instead loses
+# the failure case: gh also exits nonzero while checks are still pending.
+gh pr checks "$PR_REF" --watch --fail-fast --interval 30 >/dev/null 2>&1 &
+WATCH_PID=$!
 
-  # Get check status
-  CHECKS=$(gh pr checks "$PR_REF" 2>/dev/null)
-  if [ $? -ne 0 ]; then
-    continue
-  fi
-
-  # Count statuses
-  PENDING=$(echo "$CHECKS" | grep -c "pending\|queued\|in_progress" 2>/dev/null || echo "0")
-  FAILED=$(echo "$CHECKS" | grep -c "fail" 2>/dev/null || echo "0")
-
-  # If nothing is pending, checks are done
-  if [ "$PENDING" -eq 0 ]; then
-    if [ "$FAILED" -gt 0 ]; then
-      osascript -e "display notification \"$FAILED check(s) failed on: $PR_TITLE\" with title \"PR Checks Failed\" sound name \"Basso\""
-    else
-      osascript -e "display notification \"All checks passed on: $PR_TITLE\" with title \"PR Checks Passed\" sound name \"Glass\""
-    fi
+# Stock macOS ships no `timeout`, so bound the wait by polling the child.
+ELAPSED=0
+while kill -0 "$WATCH_PID" 2>/dev/null; do
+  if [ "$ELAPSED" -ge "$DEADLINE_SECONDS" ]; then
+    kill "$WATCH_PID" 2>/dev/null
+    wait "$WATCH_PID" 2>/dev/null
+    notify "Timed out waiting for checks on: $PR_TITLE" "PR Checks Timeout" "default"
     exit 0
   fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
 done
 
-# Timeout
-osascript -e "display notification \"Timed out waiting for checks on: $PR_TITLE\" with title \"PR Checks Timeout\""
+wait "$WATCH_PID"
+STATUS=$?
+
+if [ "$STATUS" -eq 0 ]; then
+  notify "All checks passed on: $PR_TITLE" "PR Checks Passed" "Glass"
+else
+  notify "Checks failed on: $PR_TITLE" "PR Checks Failed" "Basso"
+fi
+
 exit 0

--- a/scripts/setup-hosts.sh
+++ b/scripts/setup-hosts.sh
@@ -489,6 +489,7 @@ skills|skills
 scripts|scripts
 docs|docs
 references|references
+templates|templates
 statusline.sh|scripts/statusline.sh
 pull_request_template.md|.github/pull_request_template.md
 EOF

--- a/skills/rulebook/SKILL.md
+++ b/skills/rulebook/SKILL.md
@@ -5,26 +5,28 @@ description: "Routes agent hosts to the applicable detailed standards in this re
 
 # Rulebook
 
-Load detailed standards for the current task from `references/`. Read only the relevant files from the routing table. Do not read every rule by default.
+Load detailed standards for the current task from `rules/`. Read only the relevant files from the routing table. Do not read every rule by default.
+
+The `rules/` tree sits beside the `skills/` tree in the agent-config checkout, so it resolves as `../../rules/` from this file. Claude Code also reaches it at `~/.claude/rules/`.
 
 ## Routing
 
 | Task or context | Read |
 | --- | --- |
-| Any implementation | `references/engineering-principles.md` |
-| Editing code comments | `references/comments.md` |
-| Editing TypeScript | `references/typescript.md` |
-| Editing or designing tests | `references/tests.md` |
-| Editing migrations, schemas, queries, or database code | `references/database.md` |
-| Editing infrastructure, CI/CD, containers, or running infrastructure commands | `references/infrastructure.md` |
-| Creating or updating diagrams | `references/diagrams.md` |
-| Writing or editing rules, agent instructions, personas, or skills | `references/rule-authoring.md` and `references/communication.md` |
-| Committing, branching, pushing, or opening a pull request | `references/git-conventions.md` |
-| Using teammates or splitting parallel work | `references/agent-routing.md` and `references/parallel-agents.md` |
-| Saving research, plans, specs, or session diaries | `references/state-persistence.md` |
-| Working from a Jira reference | `references/jira.md` |
-| Answering about a library, framework, SDK, API, CLI, or cloud service | `references/context7.md` |
-| User communication not already covered by shared guidance | `references/communication.md` |
+| Any implementation | `rules/engineering-principles.md` |
+| Editing code comments | `rules/comments.md` |
+| Editing TypeScript | `rules/typescript.md` |
+| Editing or designing tests | `rules/tests.md` |
+| Editing migrations, schemas, queries, or database code | `rules/database.md` |
+| Editing infrastructure, CI/CD, containers, or running infrastructure commands | `rules/infrastructure.md` |
+| Creating or updating diagrams | `rules/diagrams.md` |
+| Writing or editing rules, agent instructions, personas, or skills | `rules/rule-authoring.md` and `rules/communication.md` |
+| Committing, branching, pushing, or opening a pull request | `rules/git-conventions.md` |
+| Using teammates or splitting parallel work | `rules/agent-routing.md` and `rules/parallel-agents.md` |
+| Saving research, plans, specs, or session diaries | `rules/state-persistence.md` |
+| Working from a Jira reference | the `jira` skill |
+| Answering about a library, framework, SDK, API, CLI, or cloud service | `rules/context7.md` |
+| User communication not already covered by shared guidance | `rules/communication.md` |
 
 Read combinations when the task crosses rows. For example, a TypeScript database change with tests needs the implementation, TypeScript, database, and test rules.
 

--- a/tests/setup-hosts.sh
+++ b/tests/setup-hosts.sh
@@ -61,7 +61,7 @@ new_case() {
   TEST_REPO="$CASE_DIR/repo"
   mkdir -p "$TEST_HOME" "$TEST_REPO/.github" "$TEST_REPO/scripts"
   TEST_REPO=$(cd "$TEST_REPO" && pwd)
-  for PATH_NAME in agents hooks rules skills scripts docs references; do
+  for PATH_NAME in agents hooks rules skills scripts docs references templates; do
     mkdir -p "$TEST_REPO/$PATH_NAME"
   done
   : > "$TEST_REPO/CLAUDE.md"
@@ -147,6 +147,7 @@ skills|skills
 scripts|scripts
 docs|docs
 references|references
+templates|templates
 statusline.sh|scripts/statusline.sh
 pull_request_template.md|.github/pull_request_template.md
 EOF


### PR DESCRIPTION
## What does this PR do?

Fixes five defects found in a repo review. Each is one file, and each has evidence behind it.

- **`rulebook` routed at a directory that does not exist.** All 14 rows pointed at `references/<name>.md`, a layout inherited from the vendored upstream. The files live in `rules/`. `AGENTS.md` sends Codex and Pi through this skill for detailed standards, so those two hosts could not load any rule. The Jira row pointed at a rule file that never existed here and now names the `jira` skill.
- **`templates/` was never linked.** The `document` skill reads `~/.claude/templates/adr.md` and `~/.claude/templates/docs-readme.md`; the Claude manifest in `setup-hosts.sh` had no `templates` row, so both paths were absent on disk.
- **The prose corpus walked `node_modules`.** It pruned `.git` only, so any dependency install turned 39 vendored readmes into failures, with zero failures from this repo's own files. CI passed only because the `prose` job installs nothing, which a self-hosted runner that retains its workspace would break. The corpus is now the tracked file list.
- **`watch-pr-checks.sh` could not report a failure.** `gh pr checks` exits nonzero when a check fails, and the poll loop treated every nonzero exit as still-pending, so the failure branch was unreachable and a red PR reported a timeout 30 minutes later. Replaced with `gh pr checks --watch --fail-fast`. The 30-minute bound is kept by polling the child, since stock macOS ships no `timeout(1)`.
- **`post-edit-typecheck.sh` discarded the errors it exists to catch.** It exited with npm's raw status and wrote findings to stdout; only exit 2 with stderr reaches the model. It now matches `post-edit-lint.sh`. The `tsc` fallback also requires a `tsconfig.json` and a locally installed compiler, so editing a `.ts` file in a project with neither no longer invokes `npx`.

## Category

- [x] Bugfix

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

- `tests/setup-hosts.sh`: 131 passed, 0 failed (was 130; the new assertion covers the `templates` link)
- `npm test`: 40 passed
- `hooks/prose-gate.test.sh`: exit 0 with `node_modules` present, was exit 1
- `scripts/config-budget.sh`: within budget
- `shellcheck`: both rewritten hooks clean
- `watch-pr-checks.sh` driven against stubbed `gh` for all three outcomes: pass, fail, timeout
- `post-edit-typecheck.sh` driven for four cases: no typecheck script, failing script (exit 2 with the report on stderr), passing script, non-TypeScript file
