### PR TITLE
fix: one link manifest, and shell tests that run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,6 +43,7 @@ jobs:
   tests:
     name: Extension Tests
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: domengabrovsek/github-actions/.github/actions/checkout@main
@@ -54,6 +55,20 @@ jobs:
 
       - name: Run pi extension tests
         run: npm test
+
+  shell-tests:
+    name: Shell Tests
+    runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: domengabrovsek/github-actions/.github/actions/checkout@main
+
+      - name: Test the multi-host bootstrap
+        run: bash tests/setup-hosts.sh
+
+      - name: Test the drift check
+        run: bash tests/symlink-check.sh
 
   # ==============================================
   # Gate
@@ -68,6 +83,7 @@ jobs:
       - budget
       - prose
       - tests
+      - shell-tests
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
     timeout-minutes: 1
     steps:
@@ -78,6 +94,7 @@ jobs:
             "${{ needs.budget.result }}"
             "${{ needs.prose.result }}"
             "${{ needs.tests.result }}"
+            "${{ needs.shell-tests.result }}"
           )
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then

--- a/hooks/symlink-check.sh
+++ b/hooks/symlink-check.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # SessionStart hook (matcher: startup).
-# Warns to stderr when the expected symlinks from the live config dir to the
-# dotfiles repo are missing, replaced by a real file, or pointing to the wrong
-# target. Non-blocking.
+# Warns to stderr when this Claude config dir has drifted from the checkout.
+# Non-blocking.
 #
-# The dir checked resolves from $CLAUDE_CONFIG_DIR (default ~/.claude), the same
-# way scripts/setup-symlinks.sh picks its target, so a second account's dir is
-# audited by its own sessions instead of being skipped.
+# scripts/setup-hosts.sh is the single drift oracle. This hook invokes its
+# --check mode and translates the result, the same way the pi drift-check
+# extension does; a second copy of the link manifest here would silently
+# diverge from the one the bootstrap actually creates.
+#
+# The dir checked resolves from $CLAUDE_CONFIG_DIR (default ~/.claude), so a
+# second account's dir is audited by its own sessions instead of being skipped.
 #
 # Bypass with SKIP_SYMLINK_CHECK=1 in the environment.
 
@@ -15,47 +18,31 @@
 REPO="${AGENT_CONFIG_REPO:-${CLAUDE_DOTFILES_REPO:-$HOME/dev/personal/agent-config}}"
 [ -d "$REPO" ] || exit 0
 
+SETUP="$REPO/scripts/setup-hosts.sh"
+[ -f "$SETUP" ] || exit 0
+
 LIVE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 [ -d "$LIVE_DIR" ] || exit 0
 
-EXPECTED=(
-  "CLAUDE.md|$REPO/CLAUDE.md"
-  "settings.json|$REPO/settings.json"
-  "agents|$REPO/agents"
-  "hooks|$REPO/hooks"
-  "rules|$REPO/rules"
-  "skills|$REPO/skills"
-  "scripts|$REPO/scripts"
-  "statusline.sh|$REPO/scripts/statusline.sh"
-  "pull_request_template.md|$REPO/.github/pull_request_template.md"
-)
-
-ISSUES=()
-for ENTRY in "${EXPECTED[@]}"; do
-  NAME="${ENTRY%%|*}"
-  WANT="${ENTRY##*|}"
-  LIVE="$LIVE_DIR/$NAME"
-
-  if [ ! -e "$LIVE" ] && [ ! -L "$LIVE" ]; then
-    ISSUES+=("MISSING:       $LIVE  (expected -> $WANT)")
-  elif [ ! -L "$LIVE" ]; then
-    ISSUES+=("NOT-A-SYMLINK: $LIVE  is a real file (expected -> $WANT)")
-  else
-    GOT=$(readlink "$LIVE")
-    if [ "$GOT" != "$WANT" ]; then
-      ISSUES+=("WRONG-TARGET:  $LIVE -> $GOT  (expected -> $WANT)")
-    fi
-  fi
-done
-
-if [ ${#ISSUES[@]} -gt 0 ]; then
-  echo "[symlink-check] $LIVE_DIR symlinks have drifted from $REPO:" >&2
-  for ISSUE in "${ISSUES[@]}"; do echo "  - $ISSUE" >&2; done
-  echo "" >&2
-  echo "Fix each path with:" >&2
-  echo "  unlink <path> 2>/dev/null; rm -rf <path> 2>/dev/null; ln -s <expected-target> <path>" >&2
-  echo "" >&2
-  echo "(Override repo location: CLAUDE_DOTFILES_REPO=/path/to/repo. Override config dir: CLAUDE_CONFIG_DIR=/path/to/dir. Bypass this check: SKIP_SYMLINK_CHECK=1.)" >&2
+# Scope the oracle to this one dir and this one host. An explicit --host wins
+# over a HARNESS_SKIP_HOSTS entry in the machine scope file, which is what we
+# want: a session running from this dir always audits the dir it runs from.
+if OUTPUT=$(CLAUDE_CONFIG_DIRS="$LIVE_DIR" bash "$SETUP" --check --host claude 2>/dev/null); then
+  exit 0
 fi
+
+# Same failure states the pi drift-check extension recognises.
+ISSUES=$(printf '%s\n' "$OUTPUT" | grep -E '[[:space:]](MISSING|MISSING-SRC|CONFLICT|WRONG-LINK|REFUSED|FAILED)[[:space:]]')
+
+[ -z "$ISSUES" ] && exit 0
+
+echo "[symlink-check] $LIVE_DIR has drifted from $REPO:" >&2
+printf '%s\n' "$ISSUES" | sed 's/^/  - /' >&2
+echo "" >&2
+echo "Converge with:" >&2
+echo "  bash $SETUP --apply --host claude" >&2
+echo "  (add --adopt to move a conflicting real path to a timestamped backup)" >&2
+echo "" >&2
+echo "(Override repo location: AGENT_CONFIG_REPO=/path/to/repo. Override config dir: CLAUDE_CONFIG_DIR=/path/to/dir. Bypass this check: SKIP_SYMLINK_CHECK=1.)" >&2
 
 exit 0

--- a/tests/symlink-check.sh
+++ b/tests/symlink-check.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Tests for hooks/symlink-check.sh. Every scenario uses a disposable HOME and
+# a fake checkout; the caller's own config dir is never read.
+
+set -u
+
+PROJECT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+HOOK="$PROJECT_DIR/hooks/symlink-check.sh"
+# Both paths are normalised: TMPDIR often carries a trailing slash, and the
+# bootstrap normalises its own repo path before comparing link targets.
+TMP_ROOT=$(cd "${TMPDIR:-/tmp}" && pwd)
+TEST_ROOT=$(cd "$(mktemp -d "$TMP_ROOT/symlink-check-test.XXXXXX")" && pwd)
+PASSED=0
+FAILED=0
+
+cleanup() {
+  case "$TEST_ROOT" in
+    "$TMP_ROOT"/symlink-check-test.*) rm -rf "$TEST_ROOT" ;;
+    *) echo "Refusing to clean unexpected test path: $TEST_ROOT" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+pass() {
+  PASSED=$((PASSED + 1))
+  echo "ok - $1"
+}
+
+fail() {
+  FAILED=$((FAILED + 1))
+  echo "not ok - $1" >&2
+}
+
+# A fake checkout carrying only what the Claude manifest links.
+FAKE_REPO="$TEST_ROOT/repo"
+mkdir -p "$FAKE_REPO/scripts" "$FAKE_REPO/.github"
+cp "$PROJECT_DIR/scripts/setup-hosts.sh" "$FAKE_REPO/scripts/setup-hosts.sh"
+for NAME in agents hooks rules skills docs references templates; do
+  mkdir -p "$FAKE_REPO/$NAME"
+done
+: > "$FAKE_REPO/CLAUDE.md"
+: > "$FAKE_REPO/settings.json"
+: > "$FAKE_REPO/scripts/statusline.sh"
+: > "$FAKE_REPO/.github/pull_request_template.md"
+
+# The manifest the bootstrap creates, read from the bootstrap itself so this
+# test cannot become the third copy of the list it exists to prevent.
+manifest() {
+  sed -n "/^CLAUDE.md|CLAUDE.md$/,/^EOF$/p" "$FAKE_REPO/scripts/setup-hosts.sh" | grep -v '^EOF$'
+}
+
+link_all() {
+  local dir="$1" entry relative
+  mkdir -p "$dir"
+  while IFS='|' read -r entry relative; do
+    [ -n "$entry" ] || continue
+    ln -sfn "$FAKE_REPO/$relative" "$dir/$entry"
+  done <<EOF
+$(manifest)
+EOF
+}
+
+run_hook() {
+  AGENT_CONFIG_REPO="$FAKE_REPO" \
+  CLAUDE_DOTFILES_REPO="" \
+  CLAUDE_CONFIG_DIR="$1" \
+  SKIP_SYMLINK_CHECK="${SKIP:-}" \
+  AGENT_HOSTS_ENV="$TEST_ROOT/absent-hosts.env" \
+    bash "$HOOK" 2>"$TEST_ROOT/err"
+}
+
+assert_silent() {
+  local name="$1"
+  run_hook "$2"
+  if [ -s "$TEST_ROOT/err" ]; then
+    sed -n '1,20p' "$TEST_ROOT/err" >&2
+    fail "$name"
+  else
+    pass "$name"
+  fi
+}
+
+assert_reports() {
+  local name="$1" dir="$2" needle="$3"
+  [ -n "$needle" ] || { fail "$name (empty needle)"; return; }
+  run_hook "$dir"
+  if grep -q -- "$needle" "$TEST_ROOT/err"; then pass "$name"; else
+    sed -n '1,20p' "$TEST_ROOT/err" >&2
+    fail "$name"
+  fi
+}
+
+# A fully linked dir is silent.
+CONVERGED="$TEST_ROOT/home/.claude-converged"
+link_all "$CONVERGED"
+assert_silent "converged dir reports nothing" "$CONVERGED"
+
+# Every manifest entry is audited. The old hand-maintained list omitted docs,
+# references and templates, so a dir missing only those looked converged.
+for entry in docs references templates; do
+  PARTIAL="$TEST_ROOT/home/.claude-no-$entry"
+  link_all "$PARTIAL"
+  rm -f "$PARTIAL/$entry"
+  assert_reports "missing $entry is reported" "$PARTIAL" "/$entry MISSING"
+done
+
+# A link pointing at the wrong target is drift, not convergence.
+WRONG="$TEST_ROOT/home/.claude-wrong"
+link_all "$WRONG"
+ln -sfn "$FAKE_REPO/rules" "$WRONG/skills"
+assert_reports "wrong link target is reported" "$WRONG" "WRONG-LINK"
+
+# A real file where a link belongs needs --adopt, so it must surface.
+REAL="$TEST_ROOT/home/.claude-real"
+link_all "$REAL"
+rm -f "$REAL/CLAUDE.md"
+echo "real file" > "$REAL/CLAUDE.md"
+assert_reports "real path conflict is reported" "$REAL" "CONFLICT"
+
+# The convergence hint names the bootstrap rather than raw ln commands.
+assert_reports "drift output names the bootstrap" "$WRONG" "setup-hosts.sh --apply --host claude"
+
+# Escape hatches stay quiet.
+SKIP=1 assert_silent "SKIP_SYMLINK_CHECK=1 silences the check" "$WRONG"
+
+MISSING_REPO="$TEST_ROOT/home/.claude-missing-repo"
+link_all "$MISSING_REPO"
+rm -f "$MISSING_REPO/CLAUDE.md"
+AGENT_CONFIG_REPO="$TEST_ROOT/no-such-repo" CLAUDE_CONFIG_DIR="$MISSING_REPO" \
+  bash "$HOOK" 2>"$TEST_ROOT/err"
+if [ -s "$TEST_ROOT/err" ]; then fail "absent checkout is silent"; else pass "absent checkout is silent"; fi
+
+ABSENT_DIR="$TEST_ROOT/home/.claude-does-not-exist"
+assert_silent "absent config dir is silent" "$ABSENT_DIR"
+
+echo ""
+echo "$PASSED passed; $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What does this PR do?

Removes the second copy of the Claude link manifest, and makes the shell test suites actually run.

- **`symlink-check.sh` kept its own copy of the link list, and the copy had already drifted.** It checked 9 paths while `setup-hosts.sh` creates 12, omitting `docs`, `references` and `templates`. A config dir missing exactly those three reported clean. The hook now invokes `setup-hosts.sh --check --host claude` and translates the result, which is what the pi `drift-check` extension already does and what its header calls "the single drift oracle".
- **`tests/setup-hosts.sh` ran nowhere.** 131 assertions guarding the one script that moves files around in `$HOME`, and `npm test` only globs `tests/*.test.ts`. A `Shell Tests` job now runs it alongside the new suite, and both are wired into the `Gate` aggregator.

The new test reads the manifest out of `setup-hosts.sh` with `sed` rather than restating it, so it cannot become the third copy of the list it exists to prevent.

## Category

- [x] Bugfix
- [x] CI/CD

## Linked issues

Follows #134, from the same review.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

The blind spot, reproduced against a dir where only the three omitted paths are broken:

```
=== OLD symlink-check (from main) ===
  -> reported nothing
=== NEW symlink-check ===
  - .../docs MISSING       would link to .../docs
  - .../references MISSING would link to .../references
  - .../templates MISSING  would link to .../templates
```

- `tests/symlink-check.sh`: 10 passed, covering converged, each omitted path, wrong link target, real-path conflict, the convergence hint, the bypass, an absent checkout and an absent config dir
- `tests/setup-hosts.sh`: 131 passed
- Both suites run under `ubuntu:24.04` in a container, since the job runs on Linux and the hooks are developed on macOS
- `npm test` 40 passed, prose gate exit 0, budget within limits, shellcheck clean on both new files
- Workflow YAML parsed; `Gate` needs all five jobs
