### PR TITLE
ci: gate config integrity and shell lint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,7 @@ jobs:
   lint:
     name: Lint Markdown
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: domengabrovsek/github-actions/.github/actions/checkout@main
@@ -23,6 +24,7 @@ jobs:
   budget:
     name: Config Budget
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: domengabrovsek/github-actions/.github/actions/checkout@main
@@ -33,6 +35,7 @@ jobs:
   prose:
     name: Prose Gate
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: domengabrovsek/github-actions/.github/actions/checkout@main
@@ -55,6 +58,20 @@ jobs:
 
       - name: Run pi extension tests
         run: npm test
+
+  config:
+    name: Config Integrity
+    runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: domengabrovsek/github-actions/.github/actions/checkout@main
+
+      - name: Check tracked configuration
+        run: ./scripts/config-integrity.sh
+
+      - name: Lint shell scripts
+        run: ./scripts/shellcheck-all.sh
 
   shell-tests:
     name: Shell Tests
@@ -84,6 +101,7 @@ jobs:
       - prose
       - tests
       - shell-tests
+      - config
     runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
     timeout-minutes: 1
     steps:
@@ -95,6 +113,7 @@ jobs:
             "${{ needs.prose.result }}"
             "${{ needs.tests.result }}"
             "${{ needs.shell-tests.result }}"
+            "${{ needs.config.result }}"
           )
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ git config filter.strip-ephemeral-state.clean 'jq "del(.feedbackSurveyState, .la
 git config filter.strip-ephemeral-state.smudge cat
 ```
 
+The filter is per-clone, so a checkout that skips those two commands will commit whatever the host wrote at runtime, including the `autoMode` environment inventory. `scripts/config-integrity.sh` fails the build when that reaches a commit, and prints the two commands to fix it.
+
 `--check` is read-only and exits nonzero when drift exists. `--apply` never replaces a real path or wrong symlink. `--adopt` is the only replacement mode, and it moves every conflict to an adjacent `<path>.bak.<timestamp>` backup instead of deleting it. The existing `scripts/setup-symlinks.sh` command remains a Claude-only compatibility wrapper.
 
 ### Machine host scope
@@ -82,4 +84,5 @@ The pi resources themselves live in `pi/` (`settings.json`, `extensions/`) and a
 ## More
 
 - **Security boundaries** - deny list, Bash restrictions, and lock-file protection live in [`settings.json`](settings.json).
-- **CI** - markdown linting on push/PR (`.github/workflows/`).
+- **CI** - `.github/workflows/pull-request.yml` runs six jobs. They cover markdown linting, the rule budget, the prose gate, the pi extension tests, the shell test suites, and config integrity. A single `Gate` check aggregates them.
+- **Local gate** - `scripts/config-budget.sh`, `scripts/config-integrity.sh`, and `scripts/shellcheck-all.sh` each run standalone and are what CI invokes.

--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -147,7 +147,7 @@ esac
 
 # --- 9. `:latest` Docker tag in Dockerfile / compose / k8s (rules/infrastructure.md) ---
 case "$FILE" in
-  *Dockerfile*|*docker-compose*.y*ml|*compose.y*ml|*/k8s/*.y*ml|*/k8s/*.yaml)
+  *Dockerfile*|*docker-compose*.y*ml|*compose.y*ml|*/k8s/*.y*ml)
     LATEST_TAG=$(echo "$ADDED" | grep -nE '^[[:space:]]*(FROM[[:space:]]+[^:[:space:]]+:latest\b|image:[[:space:]]*[^:[:space:]]+:latest\b)' 2>/dev/null || true)
     if [ -n "$LATEST_TAG" ]; then
       VIOLATIONS+="\`:latest\` Docker tag detected. rules/infrastructure.md: pin a specific version so the build is reproducible:

--- a/hooks/prose-gate.sh
+++ b/hooks/prose-gate.sh
@@ -21,6 +21,9 @@
 # doc-title convention and the "term: definition" rule format rely on both.
 #
 # Bypass: SKIP_PROSE_GATE=1.
+#
+# shellcheck disable=SC1112  # the curly quotes below are the patterns
+# this gate detects, inside the embedded python; they are not typos.
 
 MODE="${1:-file}"
 

--- a/hooks/prose-gate.test.sh
+++ b/hooks/prose-gate.test.sh
@@ -16,7 +16,7 @@ set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GATE="$ROOT/hooks/prose-gate.sh"
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 PASSED=0
 FAILED=0

--- a/scripts/config-integrity.sh
+++ b/scripts/config-integrity.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Integrity gate for the tracked configuration files.
+#
+# Three checks, all cheap enough to run on every PR:
+#   1. every tracked JSON file parses
+#   2. no runtime-written ephemeral state reached a committed settings file
+#   3. .gitattributes still declares the filter that strips it
+#
+# Check 2 matters because the strip filter is per-clone: `git config
+# filter.strip-ephemeral-state.clean` has to be set in each checkout, and a
+# clone without it commits whatever the host wrote at runtime, including the
+# autoMode environment inventory (hostnames, domains, bucket and secret paths).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Keys the strip filter deletes. Keep in step with the filter command in
+# README.md; this check is what catches a clone that never configured it.
+EPHEMERAL_KEYS=(feedbackSurveyState lastChangelogVersion autoMode)
+FILTERED_FILES=(settings.json pi/settings.json)
+
+fail=0
+
+note_fail() {
+  echo "FAIL: $1" >&2
+  fail=1
+}
+
+echo "== JSON parses =="
+while IFS= read -r f; do
+  if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" 2>/dev/null; then
+    printf '  ok   %s\n' "$f"
+  else
+    printf '  BAD  %s\n' "$f"
+    note_fail "$f is not valid JSON."
+  fi
+done < <(git ls-files '*.json')
+
+echo
+echo "== no ephemeral state committed =="
+# Read the stored blob, not the working file. In a clone that has the filter
+# configured, the working file legitimately carries runtime state that the
+# filter strips on the way into the index; only what reached a commit is a
+# leak. Without the filter the two are identical, which is the case CI runs.
+for f in "${FILTERED_FILES[@]}"; do
+  git cat-file -e "HEAD:$f" 2>/dev/null || continue
+  blob=$(mktemp "${TMPDIR:-/tmp}/config-integrity.XXXXXX")
+  git cat-file blob "HEAD:$f" > "$blob"
+  found=$(python3 - "$blob" "${EPHEMERAL_KEYS[@]}" <<'PY'
+import json, sys
+path, keys = sys.argv[1], sys.argv[2:]
+data = json.load(open(path))
+print(" ".join(k for k in keys if k in data))
+PY
+)
+  rm -f "$blob"
+  if [ -n "$found" ]; then
+    printf '  BAD  %s carries %s\n' "$f" "$found"
+    note_fail "$f carries ephemeral key(s): $found."
+    echo "      Configure the strip filter in this clone, then re-stage the file:" >&2
+    echo "      git config filter.strip-ephemeral-state.clean 'jq \"del(.feedbackSurveyState, .lastChangelogVersion, .autoMode)\" 2>/dev/null || cat'" >&2
+    echo "      git config filter.strip-ephemeral-state.smudge cat" >&2
+  else
+    printf '  ok   %s\n' "$f"
+  fi
+done
+
+echo
+echo "== strip filter still declared =="
+for f in "${FILTERED_FILES[@]}"; do
+  if grep -qE "^${f//\//\\/}[[:space:]].*filter=strip-ephemeral-state" .gitattributes; then
+    printf '  ok   %s\n' "$f"
+  else
+    printf '  BAD  %s\n' "$f"
+    note_fail "$f lost its filter=strip-ephemeral-state declaration in .gitattributes."
+  fi
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "OK: configuration is intact."
+else
+  echo "Configuration integrity check failed." >&2
+fi
+exit "$fail"

--- a/scripts/shellcheck-all.sh
+++ b/scripts/shellcheck-all.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Run shellcheck over every tracked shell script.
+#
+# Files are discovered by extension or shebang rather than listed, so a new
+# hook or skill script is covered the day it lands. Severity is "warning":
+# style nits stay advisory, real defects fail the build.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# GitHub's ubuntu images ship shellcheck; install only where it is absent.
+if ! command -v shellcheck >/dev/null 2>&1; then
+  SUDO=""
+  [ "$(id -u)" -eq 0 ] || SUDO="sudo"
+  if command -v apt-get >/dev/null 2>&1; then
+    $SUDO apt-get update -qq && $SUDO apt-get install -y -qq shellcheck
+  elif command -v brew >/dev/null 2>&1; then
+    brew install shellcheck
+  else
+    echo "shellcheck is not installed and no known package manager is available." >&2
+    exit 1
+  fi
+fi
+
+FILES=()
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    *.sh) FILES+=("$f"); continue ;;
+  esac
+  # No extension: fall back to the shebang.
+  if head -1 "$f" | grep -qE '^#!.*(/|env +)(ba)?sh\b'; then
+    FILES+=("$f")
+  fi
+done < <(git ls-files)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "No shell scripts found." >&2
+  exit 1
+fi
+
+echo "Checking ${#FILES[@]} shell script(s) with $(shellcheck --version | awk '/^version:/ {print $2}')."
+printf '  %s\n' "${FILES[@]}"
+echo
+
+shellcheck --severity=warning --format=gcc "${FILES[@]}"
+echo "OK: no shellcheck findings at warning severity or above."

--- a/scripts/worktree-prune.sh
+++ b/scripts/worktree-prune.sh
@@ -36,9 +36,9 @@ done
 
 # Color codes when stdout is a tty
 if [ -t 1 ]; then
-  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
+  C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
 else
-  C_RED=""; C_GREEN=""; C_YELLOW=""; C_DIM=""; C_RESET=""
+  C_GREEN=""; C_YELLOW=""; C_DIM=""; C_RESET=""
 fi
 
 # Determine the repo's default branch (origin/HEAD if set, else main, else master)
@@ -124,6 +124,7 @@ prune_repo() {
 
   printf '%s== %s ==%s\n' "$C_DIM" "$repo" "$C_RESET"
 
+  # shellcheck disable=SC2034  # head is a positional field, read but unused
   while IFS=$'\t' read -r path head branch locked prunable; do
     [ -z "$path" ] && continue
     total=$((total+1))

--- a/skills/wizard/template.sh
+++ b/skills/wizard/template.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 
 if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
   BOLD=$(tput bold); DIM=$(tput dim); RESET=$(tput sgr0)
-  BLUE=$(tput setaf 4); GREEN=$(tput setaf 2); YELLOW=$(tput setaf 3); RED=$(tput setaf 1)
+  BLUE=$(tput setaf 4); GREEN=$(tput setaf 2); YELLOW=$(tput setaf 3)
 else
-  BOLD=""; DIM=""; RESET=""; BLUE=""; GREEN=""; YELLOW=""; RED=""
+  BOLD=""; DIM=""; RESET=""; BLUE=""; GREEN=""; YELLOW=""
 fi
 
 # Author sets this at the top of the stages section.


### PR DESCRIPTION
## What does this PR do?

Adds a `Config Integrity` job and bounds every CI job.

- **`scripts/config-integrity.sh`** checks that every tracked JSON file parses, that no runtime-written ephemeral state reached a committed settings file, and that `.gitattributes` still declares the filter that strips it.
- **`scripts/shellcheck-all.sh`** runs shellcheck over every tracked shell script at warning severity. Files are discovered by extension or shebang, so a new hook is covered the day it lands rather than when someone remembers to update a list. It found 27 scripts.
- **Thirteen pre-existing shellcheck warnings cleared** in a separate commit, so the new gate starts green.
- **`timeout-minutes` on every job.** Only the aggregator had one; the four working jobs could hang for the runner default.

### Why the ephemeral-state check matters

The strip filter is per-clone. `git config filter.strip-ephemeral-state.clean` has to be set in each checkout, and a clone that skips it commits whatever the host wrote at runtime, including the `autoMode` environment block: hostnames, internal domains, the terraform state bucket, and the paths where secrets live. Nothing caught that before.

The check reads the stored blob rather than the working file. A correctly configured clone legitimately carries that state on disk, and the filter strips it on the way into the index; only what reached a commit is a leak. Without the filter the two are identical, which is the case CI runs.

## Category

- [x] CI/CD
- [x] Chore (dependencies, docs, config)

## Linked issues

Follows #134 and #135, from the same review.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

Each integrity check was driven to failure, not just to green. In a scratch clone that never configured the filter and then committed `settings.json`:

```
  BAD  settings.json carries autoMode
FAIL: settings.json carries ephemeral key(s): autoMode.
      git config filter.strip-ephemeral-state.clean 'jq "del(...)" 2>/dev/null || cat'
      git config filter.strip-ephemeral-state.smudge cat
```

Malformed JSON and a dropped `.gitattributes` declaration were each reproduced the same way.

- The one behaviour change in the shellcheck cleanup is the removed `*/k8s/*.yaml` case pattern. `.yaml`, `.yml` and `Dockerfile` inputs were run against both the old and new hook and exit identically
- Both new scripts run under `ubuntu:24.04` in a container, including the shellcheck install path, since the jobs run on Linux
- `tests/setup-hosts.sh` 131 passed, `tests/symlink-check.sh` 10 passed, `npm test` 40 passed, prose gate exit 0, budget within limits, markdownlint clean
- Workflow YAML parsed; every job has a timeout and `Gate` needs all six

## Note

While checking item 13 from the review I found the derived permission policy already has a byte-for-byte drift test in `tests/permission-gate.test.ts`. I confirmed it fails when a deny surface is removed, so nothing was needed there.
