### PR TITLE
feat: make ~/.agents the host-neutral shared root

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Test the drift check
         run: bash tests/symlink-check.sh
 
+      - name: Check shared paths resolve
+        run: bash tests/shared-paths.sh
+
   # ==============================================
   # Gate
   # ==============================================

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,8 +15,12 @@ The concise root `AGENTS.md`, which holds only always-needed host-neutral guidan
 _Avoid_: "Codex instructions", "Claude rules" when the guidance applies across hosts.
 
 **Shared skill library**:
-The repo's `skills/` tree, exposed to Claude Code through `~/.claude/skills` and to Codex and Pi through the repo-owned `~/.agents/skills` symlink.
+The repo's `skills/` tree, exposed to Claude Code through `~/.claude/skills` and to every host through the Shared root.
 _Avoid_: "Claude skills", "Codex skills" when the skill follows the shared Agent Skills format.
+
+**Shared root**:
+The repo-owned `~/.agents/` directory, linked on every host, holding the trees a shared skill may name by absolute path: `skills`, `rules`, `scripts`, `templates`, `references`, `agents`, and the pull request template. A shared file names `~/.agents/...`, never a host's own config dir.
+_Avoid_: `~/.claude/...` inside `skills/`, `rules/`, or `agents/` for anything but a genuinely Claude-only mechanism such as hooks.
 
 **Compatibility notation**:
 Legacy Claude-oriented names in shared skills that each agent host interprets through its equivalent capability, including `/name`, `$ARGUMENTS`, `Agent`, and `SendMessage`.
@@ -140,6 +144,7 @@ _Avoid_: "soft rules", "style guide".
 
 - Each **Agent host** loads the **Shared instruction source** through its **Host adapter**.
 - Each **Agent host** discovers the same **Shared skill library** through its native user-level path.
+- Every **Agent host** also gets the **Shared root**, so one absolute path in a shared file resolves everywhere.
 - Each **Agent host** maps **Compatibility notation** to its native skill and teammate mechanisms.
 - The **Host bootstrap** installs every **Host adapter** while the legacy Claude setup command remains a compatibility entrypoint.
 - The **Host bootstrap** leaves provider, model, and credential choices to each **Agent host** user.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Shared behavioral configuration for Claude Code, Codex, and Pi. It provides stru
 
 The root `AGENTS.md` is the concise shared instruction source. `skills/`, `rules/`, and the historical `.claude/state/` path are shared across agent hosts. Hooks, permissions, notifications, and teammate mechanics remain host-specific.
 
-Claude Code uses selective links under `~/.claude/` plus a second account dir (default `~/.claude-personal`) via `CLAUDE_CONFIG_DIRS`. Codex and Pi link their native instruction paths to `AGENTS.md`, while Codex and Pi discover the repo's skills through `~/.agents/skills`.
+Claude Code uses selective links under `~/.claude/` plus a second account dir (default `~/.claude-personal`) via `CLAUDE_CONFIG_DIRS`. Codex and Pi link their native instruction paths to `AGENTS.md`.
+
+Every host also gets `~/.agents/`, the shared root. It holds `skills`, `rules`, `scripts`, `templates`, `references`, `agents`, and the pull request template. A shared skill names `~/.agents/...` so one path resolves on every host.
 
 ## Quick start
 

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -14,7 +14,7 @@ You review pull requests and working diffs in a TypeScript/Node.js-centric stack
 
 - Fetch the real diff first (`gh pr diff`, `gh pr view`, or `git diff` for a working tree) and read the PR description, commits, and linked issues before judging any line.
 - Read the diff systematically: schema/type changes, then business logic, then tests. Cross-reference - do tests exercise the new behavior, do migrations match model changes.
-- Work through the detailed checklist at `~/.claude/skills/review-pr/checklist.md` and the security checklist at `~/.claude/references/security-checklist.md`.
+- Work through the detailed checklist at `~/.agents/skills/review-pr/checklist.md` and the security checklist at `~/.agents/references/security-checklist.md`.
 - Return ALL findings ranked by severity in your final message - never write report files, and never suppress findings to seem conservative; filtering happens downstream.
 - Judge scope: flag changes unrelated to the PR's stated goal, and 15+ file diffs without a rename/migration justification.
 

--- a/agents/qa-expert.md
+++ b/agents/qa-expert.md
@@ -18,7 +18,7 @@ You design and write tests as a risk-routing exercise: business logic at unit le
 
 ## Guardrails
 
-- Prove-it pattern for every bug fix: first write a test that fails proving the bug exists; the fix is only valid when that test turns green. If you cannot write a failing test, you do not understand the bug: investigate further before coding a fix. See `~/.claude/references/testing-patterns.md` for the full pattern `(persona)`
+- Prove-it pattern for every bug fix: first write a test that fails proving the bug exists; the fix is only valid when that test turns green. If you cannot write a failing test, you do not understand the bug: investigate further before coding a fix. See `~/.agents/references/testing-patterns.md` for the full pattern `(persona)`
 - No E2E tests for business logic: business rules belong in unit tests; E2E covers user journeys and integration seams only `(persona)`
 - UI assertions use Testing Library queries (role, label, text), never CSS selectors or test IDs as primary selectors `(persona)`
 - No arbitrary waits (`waitForTimeout`, sleeps) in E2E: use condition-based waiting `(persona)`

--- a/rules/git-conventions.md
+++ b/rules/git-conventions.md
@@ -21,7 +21,7 @@ Hooks and deny rules back these. Know them so you do not waste a cycle hitting t
 - PR descriptions use bullets, not prose paragraphs `(review-time: formatting of free-form text)`
 - Never reference `.claude/state/` plans, research, or diaries in a PR description. They are untracked and invisible to reviewers `(review-time: formatting of free-form text)`
 - After pushing new commits to an open PR, update its title and body with `gh pr edit` `(review-time: requires judging whether the body still reflects the diff)`
-- Use the repo's `.github/pull_request_template.md` when it exists, otherwise `~/.claude/pull_request_template.md` `(review-time: template selection requires reading the directory)`
+- Use the repo's `.github/pull_request_template.md` when it exists, otherwise `~/.agents/pull_request_template.md` `(review-time: template selection requires reading the directory)`
 - Editing tests? Update mocks to match the new DB queries, service dependencies, and imports `(review-time: requires understanding mock-target coupling)`
 - Semver: MAJOR for breaking, MINOR for additive, PATCH for fixes `(review-time: classifying a change as breaking needs judgment)`
 - Use `gh` for all GitHub operations. Never MCP tools `(review-time: tool selection per action, not a single regex)`

--- a/rules/rule-authoring.md
+++ b/rules/rule-authoring.md
@@ -23,7 +23,7 @@ Ranked by reliability (earliest catch wins per the shift-left principle):
 | `(hook)` | `~/.claude/hooks/*.sh` via `~/.claude/settings.json` | ~1s, fed back to Claude as a tool result |
 | `(lint)` | Repo `biome.json` / `eslint.config.js` / `.markdownlint*` | `npm run check` run |
 | `(CI)` | `.github/workflows/` and shared reusable workflows | PR cycle |
-| `(persona)` | A `~/.claude/agents/*.md` persona file's guardrail section | Subagent compliance, not global |
+| `(persona)` | A `agents/*.md` persona file's guardrail section | Subagent compliance, not global |
 | `(review-time: <why>)` | Human attention or Claude attention at review or response time | Open-ended |
 
 ## The marker requirement

--- a/scripts/setup-hosts.sh
+++ b/scripts/setup-hosts.sh
@@ -515,8 +515,24 @@ if host_enabled pi; then
   done
 fi
 
-if host_enabled shared || [ "$HOST" = "codex" ] || [ "$HOST" = "pi" ]; then
-  manage_link "shared/skills" "$SHARED_DIR/skills" "$REPO/skills"
+# ~/.agents is the host-neutral root. Shared skills, rules-adjacent resources
+# and personas resolve there on every host, so a shared skill can name one
+# path instead of a Claude-specific one that Codex and Pi never see. An
+# explicit --host always gets these, including --host claude; only the
+# argument-free --host all defers to the machine scope file.
+if host_enabled shared || [ "$HOST" != "all" ]; then
+  while IFS='|' read -r NAME RELATIVE; do
+    [ -n "$NAME" ] || continue
+    manage_link "shared/$NAME" "$SHARED_DIR/$NAME" "$REPO/$RELATIVE"
+  done <<'EOF'
+skills|skills
+rules|rules
+scripts|scripts
+templates|templates
+references|references
+agents|agents
+pull_request_template.md|.github/pull_request_template.md
+EOF
 fi
 
 echo ""

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -11,8 +11,8 @@ description: "Monitor the CI pipeline for the current branch via a background Mo
 
 1. **Detect VCS platform**: `.gitlab-ci.yml` -> glab, `.github/` -> gh `(review-time: see section note)`
 2. **Start a Monitor** with the matching script: `(review-time: see section note)`
-   - GitHub: `bash ~/.claude/skills/ci/scripts/gh-ci-monitor.sh` `(review-time: see section note)`
-   - GitLab: `bash ~/.claude/skills/ci/scripts/glab-ci-monitor.sh` `(review-time: see section note)`
+   - GitHub: `bash scripts/gh-ci-monitor.sh`, resolved inside this skill's own directory `(review-time: see section note)`
+   - GitLab: `bash scripts/glab-ci-monitor.sh`, resolved inside this skill's own directory `(review-time: see section note)`
    - Use `persistent: false`, `timeout_ms: 3600000` (1 hour ceiling - CI pipelines can be long) `(review-time: see section note)`
    - Description: "CI pipeline on <branch-name>" `(review-time: see section note)`
 3. **React to Monitor notifications**: `(review-time: see section note)`
@@ -20,11 +20,11 @@ description: "Monitor the CI pipeline for the current branch via a background Mo
    - `error|persistent-failure`: the monitor script hit 5 consecutive errors - report and stop `(review-time: see section note)`
    - Status change (e.g., `in_progress|null` → `completed|success`): acknowledge briefly `(review-time: see section note)`
    - **Pipeline passes** (`completed|success`): `(review-time: see section note)`
-     - Run `~/.claude/scripts/notify.sh "CI passed - <branch-name>"` `(review-time: see section note)`
+     - Run `~/.agents/scripts/notify.sh "CI passed - <branch-name>"` `(review-time: see section note)`
      - Report success `(review-time: see section note)`
    - **Pipeline awaiting manual action** (`completed|manual`, GitLab only): `(review-time: see section note)`
      - All automatic jobs completed; the pipeline is paused on a manual gate and will not progress without user action `(review-time: see section note)`
-     - Run `~/.claude/scripts/notify.sh "CI awaiting manual action - <branch-name>"` `(review-time: see section note)`
+     - Run `~/.agents/scripts/notify.sh "CI awaiting manual action - <branch-name>"` `(review-time: see section note)`
      - Report status and stop watching - do NOT trigger the manual job automatically `(review-time: see section note)`
    - **Pipeline fails** (`completed|failure` or any non-success conclusion): `(review-time: see section note)`
      a. Fetch the job log:
@@ -34,7 +34,7 @@ description: "Monitor the CI pipeline for the current branch via a background Mo
      c. Analyze the root cause - identify the specific failure (test, lint, type check, build, coverage, etc.)
      d. **Classify the failure as transient or real before proposing any change** - transient = infra outage, rate limit, queued/timed-out runner, auth/network flake, registry or dependency propagation delay; real = a test/lint/type/build/coverage failure caused by the code under change. State the classification `(review-time: see section note)`
      e. **If transient**: re-run the failed job (`gh run rerun <run-id> --failed` / `glab ci retry <job-id>`) and keep monitoring - do NOT edit code for a transient failure. Escalate to the user only if it recurs after a re-run `(review-time: see section note)`
-     f. Run `~/.claude/scripts/notify.sh "CI failed - <failure-summary>"`
+     f. Run `~/.agents/scripts/notify.sh "CI failed - <failure-summary>"`
      g. **If real, propose the fix to the user** - explain what failed and what you'd change. Do NOT push automatically `(review-time: see section note)`
      h. Wait for user approval before implementing the fix `(review-time: see section note)`
      i. After approval: fix, commit with a descriptive message, push `(review-time: see section note)`

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -13,7 +13,7 @@ Hard rule: do NOT write any fix until Phase 3 is reached and the user (or the ev
 
 Gather, do not theorize. Save findings to `.claude/state/research/YYYY-MM-DD-debug-<short-slug>.md`.
 
-- If given a Sentry issue (short ID like `PROJECT-ABC`, numeric ID, or sentry.io URL), fetch the digest first via the `sentry-issue` skill: `~/.claude/skills/sentry-issue/scripts/sentry-issue.sh <id>`. Full payloads land in `/tmp/sentry-{issue,event}-<id>.json` for deeper `jq` queries. `(review-time: see section note)`
+- If given a Sentry issue (short ID like `PROJECT-ABC`, numeric ID, or sentry.io URL), fetch the digest first via the `sentry-issue` skill: `~/.agents/skills/sentry-issue/scripts/sentry-issue.sh <id>`. Full payloads land in `/tmp/sentry-{issue,event}-<id>.json` for deeper `jq` queries. `(review-time: see section note)`
 - Reproduce locally if feasible. Capture exact error, stack trace, request ID, timestamp. `(review-time: see section note)`
 - Pull logs (Sentry, Cloud Run, container, browser console) for the affected window. `(review-time: see section note)`
 - `git log -p --since='2 weeks ago' -- <suspect-paths>` to surface recent changes that touched the code path. `(review-time: see section note)`

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -20,7 +20,7 @@ Parse the first word of `$ARGUMENTS` as the subcommand:
 - `adr "<title>"` - draft the next-numbered ADR in `docs/adr/` `(review-time: see section note)`
 - `diagram <type> <topic>` - add or update a mermaid diagram inside the matching doc `(review-time: see section note)`
 - `audit` - read every `docs/**/*.md`, compare against current code, produce a drift report (read-only, no edits) `(review-time: see section note)`
-- `bootstrap` - create the full `docs/` skeleton in a repo that has none yet (uses `~/.claude/templates/docs-readme.md` and `~/.claude/templates/adr.md`) `(review-time: see section note)`
+- `bootstrap` - create the full `docs/` skeleton in a repo that has none yet (uses `~/.agents/templates/docs-readme.md` and `~/.agents/templates/adr.md`) `(review-time: see section note)`
 
 If no subcommand matches, ask the user which one they meant before writing anything.
 
@@ -96,7 +96,7 @@ When `adr "<title>"`:
 1. Gate check: the decision must be hard to reverse, surprising without context, and a real trade-off. If a criterion fails, name it in one sentence, then write only after the user confirms. `(review-time: see section note)`
 2. Convention scan: look for an existing ADR scheme (directory, numbering, headings). An existing scheme wins; steps 3-5 apply only when none exists. `(review-time: see section note)`
 3. Scan `docs/adr/` for highest existing number. New file = `NNNN-<kebab-title>.md`, zero-padded to 4 digits. `(review-time: see section note)`
-4. Use `~/.claude/templates/adr.md` as the body. Fill `<Title>`, today's date, status `Proposed`. `(review-time: see section note)`
+4. Use `~/.agents/templates/adr.md` as the body. Fill `<Title>`, today's date, status `Proposed`. `(review-time: see section note)`
 5. Append a row to `docs/adr/README.md` table. `(review-time: see section note)`
 6. Ask the user for Context, Decision, Consequences before finalizing - never invent a decision. `(review-time: see section note)`
 

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -10,7 +10,7 @@ Follow this workflow:
 **why-no-hook:** skill workflow guidance; each step requires understanding the issue, the codebase, and the prior state of the work.
 
 1. **Fetch**: run `gh issue view $ARGUMENTS --json title,body,labels,assignees,comments` to get full issue details `(review-time: see section note)`
-2. **Load agents**: based on the issue domain, load the relevant expert agents from `~/.claude/agents/` (see `rules/agent-routing.md`). Their guardrails apply throughout the fix. `(review-time: see section note)`
+2. **Load agents**: based on the issue domain, load the relevant expert agents from `~/.agents/agents/` (see `rules/agent-routing.md`). Their guardrails apply throughout the fix. `(review-time: see section note)`
 3. **Research**: use subagents to explore the codebase and understand the problem area. Read linked files, related tests, and recent git history. Save findings to `.claude/state/research/YYYY-MM-DD-issue-<number>.md`. `(review-time: see section note)`
 4. **Reproduce**: if possible, write a failing test that reproduces the issue `(review-time: see section note)`
 5. **Scope check**: before planning the fix, state the minimal change that would resolve the issue (ideally 1-5 lines). If a larger change is needed, explain why the minimal fix is insufficient. The plan must build from this minimal baseline. `(review-time: see section note)`

--- a/skills/mr/SKILL.md
+++ b/skills/mr/SKILL.md
@@ -30,7 +30,7 @@ description: "Create a merge request or pull request from the current branch: ve
    - Do NOT call `gh pr create` / `glab mr create` until that explicit confirmation arrives `(review-time: see section note)`
 10. **Create MR/PR using the template**: `(review-time: see section note)`
     - If `.github/pull_request_template.md` or `.gitlab/merge_request_templates/` exists, use that template `(review-time: see section note)`
-    - Otherwise use `~/.claude/pull_request_template.md` `(review-time: see section note)`
+    - Otherwise use `~/.agents/pull_request_template.md` `(review-time: see section note)`
     - Fill in the description explaining what changed and why `(review-time: see section note)`
     - Add a "Not touched (intentionally)" list naming adjacent code left alone, when the reviewer could expect it changed; it proves scope discipline and surfaces known adjacent problems `(review-time: see section note)`
     - Check the relevant category box(es) - exactly one or more of: Bugfix, Feature, Refactor, Chore, CI/CD, Infrastructure `(review-time: see section note)`

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -13,7 +13,7 @@ Follow this process:
 2. **Read the diff**: run `gh pr diff $ARGUMENTS` to see all changes `(review-time: see section note)`
 3. **Understand intent**: read the PR description, linked issues, and commit messages before reviewing code `(review-time: see section note)`
 4. **Spec-conformance pass** (when a spec exists): find the originating spec - issue refs in the commits (via `gh`), a linked issue, or a spec under `.claude/state/specs/` - and check the diff against it, ideally in a parallel sub-agent so it does not pollute the main review context: (a) requirements asked for but missing or partial; (b) behaviour in the diff nobody asked for (scope creep); (c) requirements that look implemented but wrong. Quote the spec line for each finding and place it in the severity buckets below. If there is no spec, skip this pass and note it. `(review-time: see section note)`
-5. **Load relevant agents**: based on the files changed, load the appropriate expert agents from `~/.claude/agents/` for domain-specific review `(review-time: see section note)`
+5. **Load relevant agents**: based on the files changed, load the appropriate expert agents from `~/.agents/agents/` for domain-specific review `(review-time: see section note)`
 6. **Review systematically** using the checklist in @checklist.md `(review-time: see section note)`
 7. **Produce structured output** in this format: `(review-time: see section note)`
 

--- a/skills/rulebook/SKILL.md
+++ b/skills/rulebook/SKILL.md
@@ -7,7 +7,7 @@ description: "Routes agent hosts to the applicable detailed standards in this re
 
 Load detailed standards for the current task from `rules/`. Read only the relevant files from the routing table. Do not read every rule by default.
 
-The `rules/` tree sits beside the `skills/` tree in the agent-config checkout, so it resolves as `../../rules/` from this file. Claude Code also reaches it at `~/.claude/rules/`.
+Every host reaches these files at `~/.agents/rules/`. Claude Code also has them at `~/.claude/rules/`.
 
 ## Routing
 

--- a/skills/sentry-issue/SKILL.md
+++ b/skills/sentry-issue/SKILL.md
@@ -10,7 +10,8 @@ Pull everything needed to debug a Sentry issue, starting from just a short ID.
 ## Quick start
 
 ```bash
-~/.claude/skills/sentry-issue/scripts/sentry-issue.sh MY-PROJECT-4X2
+# from this skill's own directory
+scripts/sentry-issue.sh MY-PROJECT-4X2
 ```
 
 Accepts a short ID (`PROJECT-ABC`), a numeric issue ID, or a full issue URL

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -35,6 +35,6 @@ Also output the summary to the conversation. Keep it concise - suitable for a st
 
 ## Worktree auto-cleanup
 
-After saving the diary, run `~/.claude/scripts/worktree-prune.sh --apply` against the current repo. The script applies the conservative rule (upstream-gone OR merged into default) and reports what was removed vs kept. Locked worktrees are auto-unlocked iff safely removable. Anything with unpushed work or open PR is preserved.
+After saving the diary, run `~/.agents/scripts/worktree-prune.sh --apply` against the current repo. The script applies the conservative rule (upstream-gone OR merged into default) and reports what was removed vs kept. Locked worktrees are auto-unlocked iff safely removable. Anything with unpushed work or open PR is preserved.
 
 The same hook fires automatically at SessionEnd, so this step is mostly for explicit closure and surface visibility.

--- a/skills/worktree-merge/SKILL.md
+++ b/skills/worktree-merge/SKILL.md
@@ -37,4 +37,4 @@ When several lane-mode teammates finish, merge their branches into the integrati
 1. Review each teammate's diff for correctness.
 2. Merge one branch. Resolve any conflict by hand before merging the next - never spawn an agent for conflict resolution.
 3. After the last merge, run the full test suite, typecheck, and lint.
-4. Prune the worktrees: `~/.claude/scripts/worktree-prune.sh --apply`. It removes only worktrees whose branch is upstream-gone or merged into the default, which is the post-merge state. Anything still active survives.
+4. Prune the worktrees: `~/.agents/scripts/worktree-prune.sh --apply`. It removes only worktrees whose branch is upstream-gone or merged into the default, which is the post-merge state. Anything still active survives.

--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -15,8 +15,8 @@ Run worktree cleanup: $ARGUMENTS
 
 Strip the `--all` flag from `$ARGUMENTS` and dispatch:
 
-- If `--all` was passed: `~/.claude/scripts/worktree-prune.sh audit-all <remaining-args>`
-- Otherwise: `~/.claude/scripts/worktree-prune.sh <args>`
+- If `--all` was passed: `~/.agents/scripts/worktree-prune.sh audit-all <remaining-args>`
+- Otherwise: `~/.agents/scripts/worktree-prune.sh <args>`
 
 ## Safety rule
 

--- a/tests/setup-hosts.sh
+++ b/tests/setup-hosts.sh
@@ -162,7 +162,17 @@ EOF
 assert_true "Codex AGENTS.md is shared" assert_link "$TEST_HOME/.codex/AGENTS.md" "$TEST_REPO/AGENTS.md"
 assert_true "Pi base dir receives instructions and resources" assert_link "$TEST_HOME/.pi/agent/AGENTS.md" "$TEST_REPO/AGENTS.md" && assert_link "$TEST_HOME/.pi/agent/extensions" "$TEST_REPO/pi/extensions" && assert_link "$TEST_HOME/.pi/agent/settings.json" "$TEST_REPO/pi/settings.json" && assert_link "$TEST_HOME/.pi/agent/models.json" "$TEST_REPO/pi/models.json" && assert_link "$TEST_HOME/.pi/agent/agents" "$TEST_REPO/agents"
 assert_true "Pi personal dir receives instructions and resources" assert_link "$TEST_HOME/.pi-personal/agent/AGENTS.md" "$TEST_REPO/AGENTS.md" && assert_link "$TEST_HOME/.pi-personal/agent/extensions" "$TEST_REPO/pi/extensions" && assert_link "$TEST_HOME/.pi-personal/agent/settings.json" "$TEST_REPO/pi/settings.json" && assert_link "$TEST_HOME/.pi-personal/agent/models.json" "$TEST_REPO/pi/models.json" && assert_link "$TEST_HOME/.pi-personal/agent/agents" "$TEST_REPO/agents"
-assert_true "shared skills are repo-owned" assert_link "$TEST_HOME/.agents/skills" "$TEST_REPO/skills"
+while IFS='|' read -r NAME RELATIVE; do
+  assert_true "shared root exposes $NAME" assert_link "$TEST_HOME/.agents/$NAME" "$TEST_REPO/$RELATIVE"
+done <<'EOF'
+skills|skills
+rules|rules
+scripts|scripts
+templates|templates
+references|references
+agents|agents
+pull_request_template.md|.github/pull_request_template.md
+EOF
 assert_true "Codex fallback is created" grep -Fq 'project_doc_fallback_filenames = ["CLAUDE.md"]' "$TEST_HOME/.codex/config.toml"
 assert_true "Codex status line is created" grep -Fq 'status_line = ["project-name", "git-branch", "model-with-reasoning", "context-used", "five-hour-limit", "weekly-limit", "thread-credits", "estimated-thread-cost"]' "$TEST_HOME/.codex/config.toml"
 assert_true "Codex long context is created" grep -Fq 'model_context_window = 1050000' "$TEST_HOME/.codex/config.toml"
@@ -175,6 +185,8 @@ assert_success "Pi-only apply succeeds" run_setup --apply --host pi
 assert_true "Pi-only apply links instructions" assert_link "$TEST_HOME/.pi/agent/AGENTS.md" "$TEST_REPO/AGENTS.md"
 assert_true "Pi-only apply links the personal dir too" assert_link "$TEST_HOME/.pi-personal/agent/AGENTS.md" "$TEST_REPO/AGENTS.md" && assert_link "$TEST_HOME/.pi-personal/agent/extensions" "$TEST_REPO/pi/extensions" && assert_link "$TEST_HOME/.pi-personal/agent/settings.json" "$TEST_REPO/pi/settings.json" && assert_link "$TEST_HOME/.pi-personal/agent/models.json" "$TEST_REPO/pi/models.json" && assert_link "$TEST_HOME/.pi-personal/agent/agents" "$TEST_REPO/agents"
 assert_true "Pi-only apply links shared skills" assert_link "$TEST_HOME/.agents/skills" "$TEST_REPO/skills"
+assert_true "Pi-only apply links shared scripts" assert_link "$TEST_HOME/.agents/scripts" "$TEST_REPO/scripts"
+assert_true "Pi-only apply links shared templates" assert_link "$TEST_HOME/.agents/templates" "$TEST_REPO/templates"
 assert_true "Pi-only apply skips Codex" test ! -e "$TEST_HOME/.codex"
 assert_success "Pi-only check exits zero" run_setup --check --host pi
 assert_success "Pi-only re-apply is idempotent" run_setup --apply --host pi
@@ -336,7 +348,9 @@ assert_true "legacy wrapper links Claude config" assert_link "$TEST_HOME/.claude
 assert_true "legacy wrapper backs up Claude conflict" test "$(backup_count "$TEST_HOME/.claude/CLAUDE.md")" -eq 1
 assert_true "legacy wrapper does not configure Codex" test ! -e "$TEST_HOME/.codex"
 assert_true "legacy wrapper does not configure Pi" test ! -e "$TEST_HOME/.pi"
-assert_true "legacy wrapper does not configure shared skills" test ! -e "$TEST_HOME/.agents"
+# The shared root is host-neutral, so a Claude-only run creates it too:
+# shared skills name ~/.agents paths and would break without it.
+assert_true "legacy wrapper links the shared root" assert_link "$TEST_HOME/.agents/skills" "$TEST_REPO/skills"
 assert_success "legacy --check remains report-only" run_wrapper --check
 assert_success "legacy -n remains report-only" run_wrapper -n
 assert_success "legacy --dry-run remains report-only" run_wrapper --dry-run

--- a/tests/shared-paths.sh
+++ b/tests/shared-paths.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Every ~/.agents path named in shared content must resolve to a real file in
+# this checkout, and its first segment must be a tree the bootstrap links.
+#
+# This is the guard for the class of bug where a shared file names a path that
+# does not exist: the rulebook skill shipped 14 such rows after a vendoring,
+# and nothing caught it. Repo-only, so it holds in CI and on any machine.
+
+set -u
+
+PROJECT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$PROJECT_DIR" || exit 1
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "ok - $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "not ok - $1" >&2; }
+
+# The shared manifest, read from the bootstrap so this test cannot drift from
+# what --apply actually creates.
+manifest() {
+  awk '/manage_link "shared\/\$NAME"/,/^EOF$/' scripts/setup-hosts.sh \
+    | grep -E '^[A-Za-z0-9_.-]+\|'
+}
+
+repo_path_for() {
+  local segment="$1" entry relative
+  while IFS='|' read -r entry relative; do
+    [ "$entry" = "$segment" ] && { printf '%s\n' "$relative"; return 0; }
+  done <<EOF
+$(manifest)
+EOF
+  return 1
+}
+
+echo "== shared manifest =="
+MANIFEST_COUNT=$(manifest | wc -l | tr -d ' ')
+if [ "$MANIFEST_COUNT" -gt 0 ]; then
+  pass "bootstrap declares $MANIFEST_COUNT shared entries"
+else
+  fail "could not read the shared manifest from scripts/setup-hosts.sh"
+  echo ""
+  echo "$PASSED passed; $FAILED failed"
+  exit 1
+fi
+
+echo
+echo "== ~/.agents references resolve =="
+# shellcheck disable=SC2088  # the tilde is literal text being searched for
+REFS=$(grep -rhoE '~/\.agents/[A-Za-z0-9._/-]+' skills/ rules/ agents/ 2>/dev/null \
+  | sed 's/[.,]$//' | sort -u)
+
+if [ -z "$REFS" ]; then
+  fail "no ~/.agents references found; the grep or the layout changed"
+else
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    rest="${ref#\~/.agents/}"
+    segment="${rest%%/*}"
+    remainder=""
+    case "$rest" in
+      */*) remainder="${rest#*/}" ;;
+    esac
+
+    if ! relative=$(repo_path_for "$segment"); then
+      fail "$ref names '$segment', which the bootstrap does not link"
+      continue
+    fi
+
+    target="$relative"
+    [ -n "$remainder" ] && target="$relative/$remainder"
+    target="${target%/}"
+
+    if [ -e "$target" ]; then
+      pass "$ref -> $target"
+    else
+      fail "$ref -> $target (missing in this checkout)"
+    fi
+  done <<EOF
+$REFS
+EOF
+fi
+
+echo
+echo "== no host-specific paths outside Claude-only mechanisms =="
+# Hooks and settings.json really are Claude-only, so those rows may name
+# ~/.claude. Anything else in shared content should use the shared root.
+# shellcheck disable=SC2088  # the tilde is literal text being searched for
+STRAY=$(grep -rnE '~/\.claude/' skills/ rules/ agents/ 2>/dev/null \
+  | grep -vE '~/\.claude/(hooks|settings\.json|rules)' || true)
+if [ -z "$STRAY" ]; then
+  pass "shared content names no stray ~/.claude paths"
+else
+  fail "shared content still names host-specific paths:"
+  printf '%s\n' "$STRAY" >&2
+fi
+
+echo ""
+echo "$PASSED passed; $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/symlink-check.sh
+++ b/tests/symlink-check.sh
@@ -49,6 +49,19 @@ manifest() {
   sed -n "/^CLAUDE.md|CLAUDE.md$/,/^EOF$/p" "$FAKE_REPO/scripts/setup-hosts.sh" | grep -v '^EOF$'
 }
 
+# The bootstrap audits the shared root as well, so a converged fixture needs
+# it. Read the entries from the bootstrap rather than restating them.
+link_shared() {
+  local dir="$TEST_HOME/.agents" entry relative
+  mkdir -p "$dir"
+  while IFS='|' read -r entry relative; do
+    [ -n "$entry" ] || continue
+    ln -sfn "$FAKE_REPO/$relative" "$dir/$entry"
+  done <<EOF
+$(awk '/manage_link "shared\/\$NAME"/,/^EOF$/' "$FAKE_REPO/scripts/setup-hosts.sh" | grep -E '^[A-Za-z0-9_.-]+\|')
+EOF
+}
+
 link_all() {
   local dir="$1" entry relative
   mkdir -p "$dir"
@@ -61,6 +74,9 @@ EOF
 }
 
 run_hook() {
+  # HOME is sandboxed too: the bootstrap resolves the shared root from it, and
+  # without this the hook would audit the caller's real ~/.agents.
+  HOME="$TEST_HOME" \
   AGENT_CONFIG_REPO="$FAKE_REPO" \
   CLAUDE_DOTFILES_REPO="" \
   CLAUDE_CONFIG_DIR="$1" \
@@ -84,34 +100,37 @@ assert_reports() {
   local name="$1" dir="$2" needle="$3"
   [ -n "$needle" ] || { fail "$name (empty needle)"; return; }
   run_hook "$dir"
-  if grep -q -- "$needle" "$TEST_ROOT/err"; then pass "$name"; else
+  if grep -qE -- "$needle" "$TEST_ROOT/err"; then pass "$name"; else
     sed -n '1,20p' "$TEST_ROOT/err" >&2
     fail "$name"
   fi
 }
 
+TEST_HOME="$TEST_ROOT/home"
+link_shared
+
 # A fully linked dir is silent.
-CONVERGED="$TEST_ROOT/home/.claude-converged"
+CONVERGED="$TEST_HOME/.claude-converged"
 link_all "$CONVERGED"
 assert_silent "converged dir reports nothing" "$CONVERGED"
 
 # Every manifest entry is audited. The old hand-maintained list omitted docs,
 # references and templates, so a dir missing only those looked converged.
 for entry in docs references templates; do
-  PARTIAL="$TEST_ROOT/home/.claude-no-$entry"
+  PARTIAL="$TEST_HOME/.claude-no-$entry"
   link_all "$PARTIAL"
   rm -f "$PARTIAL/$entry"
-  assert_reports "missing $entry is reported" "$PARTIAL" "/$entry MISSING"
+  assert_reports "missing $entry is reported" "$PARTIAL" "/${entry}[[:space:]]+MISSING"
 done
 
 # A link pointing at the wrong target is drift, not convergence.
-WRONG="$TEST_ROOT/home/.claude-wrong"
+WRONG="$TEST_HOME/.claude-wrong"
 link_all "$WRONG"
 ln -sfn "$FAKE_REPO/rules" "$WRONG/skills"
 assert_reports "wrong link target is reported" "$WRONG" "WRONG-LINK"
 
 # A real file where a link belongs needs --adopt, so it must surface.
-REAL="$TEST_ROOT/home/.claude-real"
+REAL="$TEST_HOME/.claude-real"
 link_all "$REAL"
 rm -f "$REAL/CLAUDE.md"
 echo "real file" > "$REAL/CLAUDE.md"
@@ -123,14 +142,14 @@ assert_reports "drift output names the bootstrap" "$WRONG" "setup-hosts.sh --app
 # Escape hatches stay quiet.
 SKIP=1 assert_silent "SKIP_SYMLINK_CHECK=1 silences the check" "$WRONG"
 
-MISSING_REPO="$TEST_ROOT/home/.claude-missing-repo"
+MISSING_REPO="$TEST_HOME/.claude-missing-repo"
 link_all "$MISSING_REPO"
 rm -f "$MISSING_REPO/CLAUDE.md"
-AGENT_CONFIG_REPO="$TEST_ROOT/no-such-repo" CLAUDE_CONFIG_DIR="$MISSING_REPO" \
+HOME="$TEST_HOME" AGENT_CONFIG_REPO="$TEST_ROOT/no-such-repo" CLAUDE_CONFIG_DIR="$MISSING_REPO" \
   bash "$HOOK" 2>"$TEST_ROOT/err"
 if [ -s "$TEST_ROOT/err" ]; then fail "absent checkout is silent"; else pass "absent checkout is silent"; fi
 
-ABSENT_DIR="$TEST_ROOT/home/.claude-does-not-exist"
+ABSENT_DIR="$TEST_HOME/.claude-does-not-exist"
 assert_silent "absent config dir is silent" "$ABSENT_DIR"
 
 echo ""


### PR DESCRIPTION
## What does this PR do?

Makes `~/.agents` the host-neutral root, so a shared skill can name one path that resolves on Claude, Codex and Pi.

Shared skills and rules named `~/.claude/...` for scripts, templates, references and personas. Codex and Pi never get those links, so a shared skill telling any host to read `~/.claude/templates/adr.md` only worked on one of the three. `~/.agents` already held the shared skill library for the other two hosts; it now holds the rest of the shared surface, and every host gets it.

- **`~/.agents` gains `skills`, `rules`, `scripts`, `templates`, `references`, `agents` and the pull request template.** An explicit `--host` of any kind creates them, Claude included. Only an argument-free `--host all` defers to the machine scope file. The legacy Claude-only wrapper creates them too, otherwise a user who only ever runs `setup-symlinks.sh` gets shared skills naming paths that do not exist.
- **Sixteen references moved to `~/.agents`.** Two more became relative: a skill pointing at its own scripts resolves beside its `SKILL.md` whatever root the host discovered it through.
- **Two references stay on `~/.claude` deliberately.** Hooks and `settings.json` are genuinely Claude-only, so the `rules/rule-authoring.md` enforcement table naming them is correct.
- **`tests/shared-paths.sh` guards the class.** The rulebook skill shipped 14 rows pointing at a directory that did not exist and nothing caught it.

## Category

- [x] Refactor
- [x] CI/CD

## Linked issues

Follows #134, #135 and #136, from the same review.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

`tests/shared-paths.sh` was driven to failure on each mode it guards, not just to green:

| Injected fault | Result |
| --- | --- |
| Path that does not exist in the checkout | `~/.agents/scripts/does-not-exist.sh -> scripts/does-not-exist.sh (missing in this checkout)` |
| Tree the bootstrap never links | `~/.agents/nosuchtree/thing.sh names 'nosuchtree', which the bootstrap does not link` |
| Stray host-specific path | `shared content still names host-specific paths` |

- `tests/setup-hosts.sh` 139 passed (up from 131; new assertions cover every shared entry and the wrapper's changed contract)
- `tests/symlink-check.sh` 10 passed. It also gained a sandboxed `HOME`: the bootstrap resolves the shared root from `HOME`, so without it the test read the caller's real `~/.agents`
- `tests/shared-paths.sh` 13 passed, `npm test` 40 passed, prose gate exit 0, budget within limits
- All three shell suites re-run under `ubuntu:24.04`, since the job runs on Linux
- Applied on a real machine: 6 of 7 shared links created, and 9 of the 11 rewritten absolute paths verified against the filesystem

## Known follow-up

The two remaining paths (`~/.agents/skills/review-pr/checklist.md` and `~/.agents/skills/sentry-issue/scripts/sentry-issue.sh`) do not resolve on my machine because `~/.agents/skills` is a real directory owned by the `vercel-labs/skills` installer, which has `find-skills` installed there. The bootstrap refuses to replace it without `--adopt`, which is correct.

This collision predates the PR: `setup-hosts.sh` has always wanted to own `~/.agents/skills`, and `--check` already reported it. On a machine without that tool, `--apply` creates the link and both paths resolve. Resolving it means either adopting the directory or splitting ownership, which is a decision rather than a fix.
