### PR TITLE
fix(hooks): repair the PR state probe

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Check shared paths resolve
         run: bash tests/shared-paths.sh
 
+      - name: Test git hook repo resolution
+        run: bash tests/resolve-repo.sh
+
   # ==============================================
   # Gate
   # ==============================================

--- a/hooks/lib/resolve-repo.sh
+++ b/hooks/lib/resolve-repo.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Shared repo resolution for the PreToolUse git hooks.
+#
+# A hook runs with its own cwd, which is not the directory the tool call ran
+# in, so the repo has to be recovered from the payload and the command text.
+# Three hooks need the same answer; a copy each is how they drifted apart in
+# the first place, with one of them ignoring the payload cwd entirely.
+#
+# Precedence, most explicit first:
+#   1. `git -C <path>` in the command
+#   2. a leading `cd <path> &&` prefix, which moves the repo away from the
+#      recorded cwd (that cwd is the shell's directory before the cd runs)
+#   3. the tool call's cwd, since a worktree runs from the worktree while
+#      CLAUDE_PROJECT_DIR stays on the main checkout
+#   4. CLAUDE_PROJECT_DIR, then the hook's own cwd
+
+# resolve_repo_dir <command> <payload-cwd> [subcommand]
+# Prints an absolute directory. Never fails: a garbled parse yields a path
+# that simply does not resolve, and every caller already handles that.
+resolve_repo_dir() {
+  local command="$1"
+  local cwd="$2"
+  local subcommand="${3:-[a-z][a-z-]*}"
+  local c_path cd_path dir
+
+  c_path=$(printf '%s\n' "$command" \
+    | sed -n "s/.*git -C  *\([^ ]*\)  *${subcommand}.*/\1/p" | head -1)
+
+  cd_path=""
+  case "$command" in
+    "cd "*)
+      cd_path=${command#cd }
+      cd_path=${cd_path%%"&&"*}
+      cd_path=${cd_path%%";"*}
+      cd_path=$(printf '%s\n' "$cd_path" \
+        | sed "s/^[[:space:]]*//;s/[[:space:]]*\$//;s/^[\"']//;s/[\"']\$//")
+      ;;
+  esac
+
+  dir="${c_path:-${cd_path:-${cwd:-${CLAUDE_PROJECT_DIR:-$PWD}}}}"
+
+  # A -C or cd path is relative to the tool call's cwd, not the hook's.
+  case "$dir" in
+    /*) ;;
+    *) dir="${cwd:-$PWD}/$dir" ;;
+  esac
+
+  printf '%s\n' "$dir"
+}

--- a/hooks/pre-commit-branch-gate.sh
+++ b/hooks/pre-commit-branch-gate.sh
@@ -5,6 +5,9 @@
 # action and feeds the message back to Claude as a tool result.
 # Bypass with SKIP_COMMIT_BRANCH_GATE=1 in the environment.
 
+# shellcheck source=lib/resolve-repo.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/resolve-repo.sh"
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
@@ -16,34 +19,15 @@ esac
 
 [ "$SKIP_COMMIT_BRANCH_GATE" = "1" ] && exit 0
 
-# `git -C <path> commit` never contains the literal "git commit", so the repo
-# must come from the -C argument. Best-effort parse: unquoted path with the
-# commit subcommand directly after it. A garbled extraction fails open below,
-# because rev-parse on a non-directory yields an empty branch.
-C_PATH=$(printf '%s\n' "$COMMAND" | sed -n 's/.*git -C  *\([^ ]*\)  *commit.*/\1/p' | head -1)
-
+# `git -C <path> commit` never contains the literal "git commit", so a command
+# without either is not ours to gate.
 case "$COMMAND" in
   *"git commit"*) ;;
-  *) [ -z "$C_PATH" ] && exit 0 ;;
+  *) printf '%s\n' "$COMMAND" | grep -q 'git -C  *[^ ]*  *commit' || exit 0 ;;
 esac
 
-# A leading `cd <path> && git commit` moves the commit's repo away from the
-# recorded tool cwd, which reflects the shell's directory before the cd runs.
-CD_PATH=""
-case "$COMMAND" in
-  "cd "*)
-    CD_PATH=${COMMAND#cd }
-    CD_PATH=${CD_PATH%%"&&"*}
-    CD_PATH=${CD_PATH%%";"*}
-    CD_PATH=$(printf '%s\n' "$CD_PATH" | sed "s/^[[:space:]]*//;s/[[:space:]]*\$//;s/^[\"']//;s/[\"']\$//")
-    ;;
-esac
-
-# Resolve the repo: `git -C` target, then a leading cd prefix, then the tool
-# call's cwd (worktree agents commit from feature-branch worktrees while the
-# shared checkout sits on main), then CLAUDE_PROJECT_DIR.
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-DIR="${C_PATH:-${CD_PATH:-${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}}}"
+DIR=$(resolve_repo_dir "$COMMAND" "$CWD" commit)
 BRANCH=$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
 
 # Not in a git repo, or detached HEAD - let it through. Caller handles their own state.

--- a/hooks/pre-git-state-refresh.sh
+++ b/hooks/pre-git-state-refresh.sh
@@ -12,6 +12,9 @@
 # Always exit 0. Warn-only; never blocks.
 # Bypass with SKIP_PR_STATE_REFRESH=1.
 
+# shellcheck source=lib/resolve-repo.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/resolve-repo.sh"
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
@@ -43,7 +46,11 @@ emit() {
   exit 0
 }
 
-DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+# The hook's own cwd is not the tool call's, so the repo comes from the
+# payload. Reading only CLAUDE_PROJECT_DIR made every probe report
+# "unavailable=not-a-repo" whenever the harness ran hooks from elsewhere.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+DIR=$(resolve_repo_dir "$COMMAND" "$CWD")
 
 # Not in a git repo - nothing to probe.
 if ! git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1; then

--- a/hooks/pre-push-gate.sh
+++ b/hooks/pre-push-gate.sh
@@ -4,6 +4,9 @@
 # Exit code 2 blocks the action and sends the error message to Claude.
 # Bypass with SKIP_PUSH_GATE=1, in the environment or inline in the command.
 
+# shellcheck source=lib/resolve-repo.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/resolve-repo.sh"
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
@@ -27,40 +30,15 @@ if [ "$SKIP_PUSH_GATE" = "1" ]; then
   exit 0
 fi
 
-# `git -C <path> push` never contains the literal "git push", so the repo
-# must come from the -C argument. Best-effort parse: unquoted path with the
-# push subcommand directly after it. A garbled extraction fails open below,
-# because the project-root walk on a bogus path finds nothing.
-C_PATH=$(printf '%s\n' "$COMMAND" | sed -n 's/.*git -C  *\([^ ]*\)  *push.*/\1/p' | head -1)
-
+# `git -C <path> push` never contains the literal "git push", so a command
+# without either is not ours to gate.
 case "$COMMAND" in
   *"git push"*) ;;
-  *) [ -z "$C_PATH" ] && exit 0 ;;
+  *) printf '%s\n' "$COMMAND" | grep -q 'git -C  *[^ ]*  *push' || exit 0 ;;
 esac
 
-# A leading `cd <path> && git push` moves the push's repo away from the
-# recorded tool cwd, which reflects the shell's directory before the cd runs.
-CD_PATH=""
-case "$COMMAND" in
-  "cd "*)
-    CD_PATH=${COMMAND#cd }
-    CD_PATH=${CD_PATH%%"&&"*}
-    CD_PATH=${CD_PATH%%";"*}
-    CD_PATH=$(printf '%s\n' "$CD_PATH" | sed "s/^[[:space:]]*//;s/[[:space:]]*\$//;s/^[\"']//;s/[\"']\$//")
-    ;;
-esac
-
-# Resolve where the push actually runs: `git -C` target, then a leading cd
-# prefix, then the tool call's cwd (worktree pushes run from the worktree
-# while CLAUDE_PROJECT_DIR stays on the main checkout), then CLAUDE_PROJECT_DIR.
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-DIR="${C_PATH:-${CD_PATH:-${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}}}"
-
-# Relative -C / cd paths are relative to the tool call's cwd, not the hook's.
-case "$DIR" in
-  /*) ;;
-  *) DIR="${CWD:-$PWD}/$DIR" ;;
-esac
+DIR=$(resolve_repo_dir "$COMMAND" "$CWD" push)
 
 # Find project root: walk up looking for package.json or *.tf
 PROJECT_ROOT=""

--- a/tests/resolve-repo.sh
+++ b/tests/resolve-repo.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Tests for hooks/lib/resolve-repo.sh and the three hooks that use it.
+#
+# The end-to-end cases run each hook from a cwd that is NOT the repo, with
+# CLAUDE_PROJECT_DIR unset, which is how the harness actually invokes them.
+# That is the shape that had pre-git-state-refresh reporting "not-a-repo" for
+# every git command.
+
+set -u
+
+PROJECT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=../hooks/lib/resolve-repo.sh
+. "$PROJECT_DIR/hooks/lib/resolve-repo.sh"
+
+TMP_ROOT=$(cd "${TMPDIR:-/tmp}" && pwd)
+TEST_ROOT=$(cd "$(mktemp -d "$TMP_ROOT/resolve-repo-test.XXXXXX")" && pwd)
+PASSED=0
+FAILED=0
+
+cleanup() {
+  case "$TEST_ROOT" in
+    "$TMP_ROOT"/resolve-repo-test.*) rm -rf "$TEST_ROOT" ;;
+    *) echo "Refusing to clean unexpected test path: $TEST_ROOT" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+pass() { PASSED=$((PASSED + 1)); echo "ok - $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "not ok - $1" >&2; }
+
+assert_eq() {
+  local name="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then pass "$name"; else
+    echo "    want: $want" >&2
+    echo "    got:  $got" >&2
+    fail "$name"
+  fi
+}
+
+REPO="$TEST_ROOT/repo"
+OTHER="$TEST_ROOT/other"
+mkdir -p "$REPO" "$OTHER"
+CLAUDE_PROJECT_DIR="$TEST_ROOT/project-dir"
+export CLAUDE_PROJECT_DIR
+
+echo "== resolve_repo_dir =="
+assert_eq "payload cwd wins when the command carries no path" \
+  "$REPO" "$(resolve_repo_dir "git push origin main" "$REPO" push)"
+
+assert_eq "git -C beats the payload cwd" \
+  "$OTHER" "$(resolve_repo_dir "git -C $OTHER push origin main" "$REPO" push)"
+
+assert_eq "a leading cd beats the payload cwd" \
+  "$OTHER" "$(resolve_repo_dir "cd $OTHER && git push" "$REPO" push)"
+
+assert_eq "a quoted cd path is unquoted" \
+  "$OTHER" "$(resolve_repo_dir "cd \"$OTHER\" && git push" "$REPO" push)"
+
+assert_eq "a cd terminated by a semicolon still parses" \
+  "$OTHER" "$(resolve_repo_dir "cd $OTHER ; git push" "$REPO" push)"
+
+assert_eq "a relative -C path anchors to the payload cwd" \
+  "$REPO/sub" "$(resolve_repo_dir "git -C sub push" "$REPO" push)"
+
+assert_eq "CLAUDE_PROJECT_DIR is the fallback when no cwd is supplied" \
+  "$CLAUDE_PROJECT_DIR" "$(resolve_repo_dir "git push" "" push)"
+
+assert_eq "the default subcommand matches any git verb" \
+  "$OTHER" "$(resolve_repo_dir "git -C $OTHER commit -m x" "$REPO")"
+
+echo
+echo "== hooks resolve the repo from the payload, not their own cwd =="
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name Test
+: > "$REPO/file"
+git -C "$REPO" add file
+git -C "$REPO" commit -q -m "chore: seed"
+git -C "$REPO" checkout -q -b feature/branch
+
+# Run every hook from a directory that is not a repo, with no project dir,
+# exactly as the harness does.
+run_hook() {
+  local hook="$1" command="$2"
+  printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$REPO" "$command" \
+    | (cd "$TEST_ROOT" && CLAUDE_PROJECT_DIR="" bash "$PROJECT_DIR/hooks/$hook" 2>&1)
+}
+
+OUT=$(run_hook pre-git-state-refresh.sh "git push origin feature/branch")
+case "$OUT" in
+  *"not-a-repo"*) fail "pre-git-state-refresh finds the repo (got not-a-repo)" ;;
+  *"branch=feature/branch"*) pass "pre-git-state-refresh finds the repo and branch" ;;
+  *) echo "    got: $OUT" >&2; fail "pre-git-state-refresh finds the repo and branch" ;;
+esac
+
+# The branch gate must see the payload repo's branch, not the caller's.
+git -C "$REPO" checkout -q -B main
+OUT=$(run_hook pre-commit-branch-gate.sh "git commit -m 'feat: x'")
+STATUS=$?
+if [ "$STATUS" -eq 2 ] || printf '%s' "$OUT" | grep -q "Refusing to commit directly to 'main'"; then
+  pass "pre-commit-branch-gate blocks main in the payload repo"
+else
+  echo "    got: $OUT" >&2
+  fail "pre-commit-branch-gate blocks main in the payload repo"
+fi
+
+git -C "$REPO" checkout -q -b feature/other
+OUT=$(run_hook pre-commit-branch-gate.sh "git commit -m 'feat: x'")
+if [ -z "$OUT" ]; then
+  pass "pre-commit-branch-gate allows a feature branch"
+else
+  echo "    got: $OUT" >&2
+  fail "pre-commit-branch-gate allows a feature branch"
+fi
+
+# The push gate walks up from the resolved dir; a repo with no package.json
+# and no *.tf is skipped silently, which proves it resolved somewhere real
+# rather than walking up from the hook's own cwd.
+OUT=$(run_hook pre-push-gate.sh "git push origin feature/other")
+if [ -z "$OUT" ]; then
+  pass "pre-push-gate skips a project with no manifest"
+else
+  echo "    got: $OUT" >&2
+  fail "pre-push-gate skips a project with no manifest"
+fi
+
+echo ""
+echo "$PASSED passed; $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What does this PR do?

`hooks/pre-git-state-refresh.sh` resolved its repo from `CLAUDE_PROJECT_DIR` alone, never from the cwd the tool call ran in. The harness runs hooks from its own directory, so every probe returned `unavailable=not-a-repo`.

That hook exists to inject a `[pr-state]` line with the PR's real state before write-side git commands, and `rules/git-conventions.md` names it as hook-backed enforcement. It carried nothing. This was not an edge case: it failed on every `git push`, `git commit` and `gh pr` command.

The commit and push gates already read the payload cwd, and each carried its own copy of the parse. Three copies is how this one drifted, so the resolution moves to `hooks/lib/resolve-repo.sh` and the two working gates keep their behaviour under test.

## Category

- [x] Bugfix

## Linked issues

Follows #134, #135, #136 and #137, from the same review.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

The tests were written first and run against the hooks unchanged, so the failure is pinned before the fix:

```
== hooks resolve the repo from the payload, not their own cwd ==
not ok - pre-git-state-refresh finds the repo (got not-a-repo)
ok - pre-commit-branch-gate blocks main in the payload repo
ok - pre-commit-branch-gate allows a feature branch
ok - pre-push-gate skips a project with no manifest

11 passed; 1 failed
```

After the change, 12 passed. The end-to-end cases run each hook from a directory that is not a repo with `CLAUDE_PROJECT_DIR` empty, which is how the harness invokes them.

Observed live in this session. Before, every git command produced:

```
[pr-state] unavailable=not-a-repo
```

After, through the same `~/.claude/hooks` symlink:

```
[pr-state] branch=fix/pr-state-repo-resolution state=NONE
```

- `tests/resolve-repo.sh` 12 passed: unit cases for `git -C`, a leading `cd`, quoted and semicolon-terminated forms, relative paths anchored to the payload cwd, and the `CLAUDE_PROJECT_DIR` fallback
- `tests/setup-hosts.sh` 139, `tests/symlink-check.sh` 10, `tests/shared-paths.sh` 13, `npm test` 40, all passing
- All four shell suites re-run under `ubuntu:24.04`
- `config-integrity`, `shellcheck-all`, prose gate and budget all clean
