### PR TITLE
fix(hooks): four silent failures in the edit and commit gates

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Test git hook repo resolution
         run: bash tests/resolve-repo.sh
 
+      - name: Test the commit gates
+        run: bash tests/commit-gates.sh
+
   # ==============================================
   # Gate
   # ==============================================

--- a/hooks/post-edit-lint.sh
+++ b/hooks/post-edit-lint.sh
@@ -27,7 +27,13 @@ esac
 
 # --- 1. Em-dash auto-fix (whole file, idempotent, silent) ---
 if LC_ALL=C grep -q $'\xe2\x80\x94' "$FILE" 2>/dev/null; then
-  sed -i '' $'s/\xe2\x80\x94/-/g' "$FILE"
+  # BSD sed needs an argument to -i, GNU sed refuses one. Write through a
+  # temp file so the hook behaves the same on macOS and Linux.
+  TMP_FILE=$(mktemp "${TMPDIR:-/tmp}/post-edit-lint.XXXXXX")
+  if LC_ALL=C sed $'s/\xe2\x80\x94/-/g' "$FILE" > "$TMP_FILE" 2>/dev/null; then
+    cat "$TMP_FILE" > "$FILE"
+  fi
+  rm -f "$TMP_FILE"
 fi
 
 # --- Skip docs/text: prose comment markers cause false positives ---
@@ -148,7 +154,7 @@ esac
 # --- 9. `:latest` Docker tag in Dockerfile / compose / k8s (rules/infrastructure.md) ---
 case "$FILE" in
   *Dockerfile*|*docker-compose*.y*ml|*compose.y*ml|*/k8s/*.y*ml)
-    LATEST_TAG=$(echo "$ADDED" | grep -nE '^[[:space:]]*(FROM[[:space:]]+[^:[:space:]]+:latest\b|image:[[:space:]]*[^:[:space:]]+:latest\b)' 2>/dev/null || true)
+    LATEST_TAG=$(echo "$ADDED" | grep -nE '^[[:space:]]*(FROM[[:space:]]+[^:[:space:]]+:latest\b|-?[[:space:]]*image:[[:space:]]*[^:[:space:]]+:latest\b)' 2>/dev/null || true)
     if [ -n "$LATEST_TAG" ]; then
       VIOLATIONS+="\`:latest\` Docker tag detected. rules/infrastructure.md: pin a specific version so the build is reproducible:
 $LATEST_TAG

--- a/hooks/pre-commit-conventional-gate.sh
+++ b/hooks/pre-commit-conventional-gate.sh
@@ -30,12 +30,18 @@ import sys, re
 
 cmd = sys.stdin.read()
 
+# Only a heredoc opened after `git commit` can carry its message. A command
+# chain may open others first, such as a PR body written to a file, and
+# reading those attributes unrelated prose to this change.
+anchor = cmd.find("git commit")
+scope = cmd[anchor:] if anchor != -1 else cmd
+
 # Prefer heredoc when the command uses one - it carries the structured message.
 heredoc_re = re.compile(r"<<-?[\047\"]?(\w+)[\047\"]?")
-m = heredoc_re.search(cmd)
+m = heredoc_re.search(scope)
 if m:
     delim = m.group(1)
-    after = cmd[m.end():]
+    after = scope[m.end():]
     # Drop everything up to and including the first newline after the opener.
     nl = after.find("\n")
     if nl != -1:
@@ -50,7 +56,7 @@ if m:
             sys.exit(0)
 
 # Fall back to the first -m / --message value.
-m_re = re.search(r"(?:-m|--message)[=\s]+[\047\"]([^\047\"]+)[\047\"]", cmd)
+m_re = re.search(r"(?:-m|--message)[=\s]+[\047\"]([^\047\"]+)[\047\"]", scope)
 if m_re:
     print(m_re.group(1).splitlines()[0])
     sys.exit(0)

--- a/hooks/pre-pr-test-gate.sh
+++ b/hooks/pre-pr-test-gate.sh
@@ -12,10 +12,16 @@ case "$COMMAND" in
   *) exit 0 ;;
 esac
 
-# Find project root (look for package.json)
-DIR="${CLAUDE_PROJECT_DIR:-.}"
+# Find project root (look for package.json). The walk needs an absolute
+# start: dirname "." is ".", so a relative path would loop forever.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+DIR="${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+case "$DIR" in
+  /*) ;;
+  *) DIR="$PWD/$DIR" ;;
+esac
 PROJECT_ROOT=""
-while [ "$DIR" != "/" ]; do
+while [ "$DIR" != "/" ] && [ -n "$DIR" ]; do
   [ -f "$DIR/package.json" ] && PROJECT_ROOT="$DIR" && break
   DIR=$(dirname "$DIR")
 done

--- a/hooks/prose-gate.sh
+++ b/hooks/prose-gate.sh
@@ -89,11 +89,17 @@ import sys, re
 
 cmd = sys.stdin.read()
 
+# Only a heredoc opened after `git commit` can carry its message. A command
+# chain may open others first, such as a PR body written to a file, and
+# reading those attributes unrelated prose to this change.
+anchor = cmd.find("git commit")
+scope = cmd[anchor:] if anchor != -1 else cmd
+
 # A heredoc carries the structured multi-line message when one is used.
-m = re.search(r"<<-?[\x27\"]?(\w+)[\x27\"]?", cmd)
+m = re.search(r"<<-?[\x27\"]?(\w+)[\x27\"]?", scope)
 if m:
     delim = m.group(1)
-    after = cmd[m.end():]
+    after = scope[m.end():]
     nl = after.find("\n")
     if nl != -1:
         out = []
@@ -107,7 +113,7 @@ if m:
 # Otherwise collect every -m / --message value. The backreference keeps a
 # quote of the other kind inside the message from ending the match early.
 vals = [m.group(2) for m in
-        re.finditer(r"(?:-m|--message)[=\s]+([\x27\"])(.*?)\1", cmd, re.S)]
+        re.finditer(r"(?:-m|--message)[=\s]+([\x27\"])(.*?)\1", scope, re.S)]
 if vals:
     print("\n".join(vals))
 ' 2>/dev/null)

--- a/tests/commit-gates.sh
+++ b/tests/commit-gates.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Tests for the PreToolUse commit gates: conventional format, and the commit
+# mode of the prose gate.
+#
+# Both extract the message from the command string, and both used to take the
+# first heredoc anywhere in it. A command that writes a PR body and then
+# commits therefore had someone elses prose read as its commit subject.
+
+set -u
+
+PROJECT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+CONVENTIONAL="$PROJECT_DIR/hooks/pre-commit-conventional-gate.sh"
+PROSE="$PROJECT_DIR/hooks/prose-gate.sh"
+# Assembled so this file never carries the literal phrase the hooks trigger on.
+GIT_COMMIT="git ""commit"
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "ok - $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "not ok - $1" >&2; }
+
+payload() {
+  COMMAND="$1" python3 -c 'import json,os,sys; print(json.dumps({"tool_input":{"command":os.environ["COMMAND"]}}))'
+}
+
+# assert_gate <name> <hook-invocation> <command> <expected-exit>
+assert_gate() {
+  local name="$1" hook="$2" command="$3" want="$4" got
+  payload "$command" | bash $hook >/dev/null 2>&1
+  got=$?
+  if [ "$got" -eq "$want" ]; then pass "$name"; else
+    echo "    want exit $want, got $got" >&2
+    fail "$name"
+  fi
+}
+
+echo "== conventional format =="
+assert_gate "a conventional subject passes" "$CONVENTIONAL" \
+  "$GIT_COMMIT -m \"fix(hooks): repair the thing\"" 0
+assert_gate "a non-conventional subject blocks" "$CONVENTIONAL" \
+  "$GIT_COMMIT -m \"just some words\"" 2
+assert_gate "an unknown type blocks" "$CONVENTIONAL" \
+  "$GIT_COMMIT -m \"wibble: a subject\"" 2
+assert_gate "a scoped breaking change passes" "$CONVENTIONAL" \
+  "$GIT_COMMIT -m \"feat(api)!: drop v1\"" 0
+assert_gate "amend is skipped" "$CONVENTIONAL" \
+  "$GIT_COMMIT --amend --no-edit" 0
+assert_gate "a merge subject is skipped" "$CONVENTIONAL" \
+  "$GIT_COMMIT -m \"Merge branch main\"" 0
+
+echo
+echo "== the message comes from this command, not an unrelated heredoc =="
+UNRELATED="cat > /tmp/body.md <<'BODY'
+## What does this PR do?
+Prose that is not a commit subject.
+BODY
+$GIT_COMMIT -m \"fix(hooks): a valid subject\""
+assert_gate "an unrelated heredoc does not become the subject" "$CONVENTIONAL" "$UNRELATED" 0
+assert_gate "an unrelated heredoc is not linted as the message" "$PROSE commit" "$UNRELATED" 0
+
+REAL_HEREDOC="$GIT_COMMIT -F- <<'MSG'
+not a conventional subject
+
+body
+MSG"
+assert_gate "a real heredoc message is still read" "$CONVENTIONAL" "$REAL_HEREDOC" 2
+
+echo
+echo "== prose gate, commit mode =="
+assert_gate "a plain message passes" "$PROSE commit" \
+  "$GIT_COMMIT -m \"fix(hooks): read the payload cwd\"" 0
+assert_gate "a blocked word is caught" "$PROSE commit" \
+  "$GIT_COMMIT -m \"fix(x): utilize the thing\"" 2
+assert_gate "a blocked word in a real heredoc is caught" "$PROSE commit" \
+  "$GIT_COMMIT -F- <<'MSG'
+fix(x): a fine subject
+
+This body will utilize a blocked word.
+MSG" 2
+
+echo ""
+echo "$PASSED passed; $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What does this PR do?

Four hook defects found while verifying earlier work in this review. Each was silently doing nothing, or blocking the wrong thing, rather than failing loudly.

- **The `:latest` Docker tag check missed the YAML list form.** It anchored on `image:` at line start, so `- image: nginx:latest`, the usual spelling in k8s manifests and compose files, never fired.
- **The em-dash autofix did nothing on Linux.** BSD sed needs an argument to `-i` and GNU sed refuses one, so on Linux the rewrite silently no-opped. It now writes through a temp file.
- **`pre-pr-test-gate.sh` looped forever with `CLAUDE_PROJECT_DIR` unset.** The walk started at `.`, and `dirname "."` is `.`, so it burned the hook's full 120 second timeout on every PR creation.
- **Both commit gates read the wrong heredoc.** They took the first one anywhere in the command string, so a chain that writes a PR body to a file and then records a change had unrelated prose read as its subject.

## Category

- [x] Bugfix
- [x] CI/CD

## Linked issues

Follows #134 through #138, from the same review.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

The heredoc bug was hit live while opening PR #136 in this series. The gate rejected a valid subject, reporting it as `## What does this PR do?`. `tests/commit-gates.sh` pins it: against the gates on `main` it reports 11 passed, 1 failed, and that one failure is the misattribution case.

`:latest` detection, exit 2 means flagged:

| Input | main | this PR |
| --- | --- | --- |
| `- image: nginx:latest` (list form) | 0 | 2 |
| `image: nginx:latest` | 2 | 2 |
| `FROM node:latest` | 2 | 2 |
| `- image: nginx:1.27` (pinned) | 0 | 0 |

Em-dash autofix under GNU sed in `ubuntu:24.04`, same input to both:

```
--- old hook ---
const a = 1; /* one - two */     <- em dash untouched
--- new hook ---
const a = 1; /* one - two */     <- replaced
```

The loop, run from `/` with `CLAUDE_PROJECT_DIR` empty:

```
OLD: still running after 6s -> infinite loop confirmed
NEW: exit=0 elapsed=0s
```

`tests/commit-gates.sh` adds 12 assertions across both gates: conventional format acceptance and rejection, breaking-change scopes, amend and merge skips, the misattribution case, and that a genuine heredoc message is still read and still linted.

Full gate green: `tests/setup-hosts.sh` 139, `tests/symlink-check.sh` 10, `tests/shared-paths.sh` 13, `tests/commit-gates.sh` 12, `hooks/prose-gate.test.sh` 56, `npm test` 40, plus config integrity, shellcheck and budget. Shell suites re-run under `ubuntu:24.04`.

## Note

While patching the prose gate I broke its `pr` mode, and its own suite caught it before commit. That is the suite doing its job, and it is why the commit gates now have one too.

`post-edit-lint.sh` still has no test file. The `:latest` and em-dash results above are manual reproductions, not regression guards. Worth a suite of its own rather than bundling a new harness into this.

