### PR TITLE
docs: correct four stale claims and rename the package

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -30,6 +30,11 @@ For full descriptions of each tool see the [README](README.md).
 | Clean up a worktree after its branch merged | `/worktree-merge` |
 | Prune dead worktrees in this repo | `/worktrees [--apply]` |
 | Audit worktrees across all repos under `~/dev/` | `/worktrees --all [--apply]` |
+| Drive several PRs to done in parallel | `/drive-fleet` |
+| Plan an effort too big for one session | `/wayfinder` |
+| Hand this session to a fresh one | `/handoff` |
+| Spike a throwaway prototype to settle a design question | `/prototype` |
+| Review code for over-engineering only | `/prune` |
 
 ## When the slash IS the value
 
@@ -45,6 +50,15 @@ Some skills enforce a discipline plain English would skip. Use the slash when yo
 - `/ship` - pre-launch validation checklist
 - `/fix-issue` - full issue resolution flow
 - `/review-pr` - severity-tagged review scaffolding
+
+## Skills that fire on their own
+
+Model-invoked, so describing the work is enough. Naming them still works:
+
+- `rulebook` - loads the detailed standards a task needs from `rules/`
+- `write-plain` - fires on prose work: docs, ADRs, specs, PR bodies
+- `jira` - fires on a Jira key, ticket mention, or an atlassian.net URL
+- `sentry-issue` - fires on a Sentry short ID or a sentry.io URL
 
 ## When plain English is fine
 
@@ -83,8 +97,7 @@ These run independently of the implementation workflow:
 - `/wait-what` when the last reply did not land
 - `/observability` for instrumenting a feature before the incident
 - `/constraints` for a per-repo quality bar with ratchets
-- `/zoom-out` (deleted, just describe what you want in plain English)
 
 ## Agents
 
-Claude Code agents auto-spawn via `rules/agent-routing.md` when a task touches a specialized domain. Codex maps `Agent` and `SendMessage` references to its teammate mechanisms when available, and follows the workflow locally otherwise. Pi follows the workflow locally because its teammate mechanics are deferred. See [ADR 0008](docs/adr/0008-share-agent-config-across-hosts.md) for the shared boundary.
+Claude Code agents auto-spawn via `rules/agent-routing.md` when a task touches a specialized domain. Pi spawns the same personas as child sessions through the `pi-subagents` package, including background runs and worktree-isolated lanes. Codex maps `Agent` and `SendMessage` to its own teammate mechanisms when available, and follows the workflow locally otherwise. See [ADR 0008](docs/adr/0008-share-agent-config-across-hosts.md) for the shared boundary and [ADR 0009](docs/adr/0009-pi-adapter-vendored-settings-and-extensions.md) for the Pi adapter.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,8 +85,8 @@ Another pi session on this machine, addressable directly for coordination; exist
 _Avoid_: "subagent", "teammate" for cross-session peers.
 
 **Advisory persona**:
-A persona whose frontmatter `tools` list excludes Edit/Write/NotebookEdit, making the panel-mode read-only guarantee mechanical rather than brief-level (PR Reviewer, Cybersecurity Expert, GDPR Expert, Product Manager, UX Expert).
-_Avoid_: "read-only agent", "reviewer agent".
+A persona whose frontmatter `tools` list excludes Edit/Write/NotebookEdit, so mutating a file takes a deliberate shell command rather than one tool call (PR Reviewer, Cybersecurity Expert, GDPR Expert, Product Manager, UX Expert). These personas keep Bash, which they need for `git diff` and `gh`, so the brief still carries the read-only instruction.
+_Avoid_: "read-only agent", "reviewer agent", "mechanically read-only" - Bash makes the guarantee partial.
 
 **Writer persona**:
 A full-tool persona that can mutate files and therefore serve as a lane-mode teammate.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -60,7 +60,7 @@ Every agent follows the same 5-section skeleton (ADR 0007):
 
 Two kinds of persona (see CONTEXT.md glossary):
 
-- **Advisory personas** are mechanically read-only via `tools:` frontmatter (no Edit/Write/NotebookEdit): PR Reviewer, Cybersecurity Expert, GDPR Expert, Product Manager, UX Expert. They cannot be lane-mode writers.
+- **Advisory personas** drop the editing tools via `tools:` frontmatter (no Edit/Write/NotebookEdit): PR Reviewer, Cybersecurity Expert, GDPR Expert, Product Manager, UX Expert. They keep Bash, which they need for `git diff` and `gh`, so a write is still reachable through a shell command; the frontmatter removes the one-call edit and the brief does the rest. They are not lane-mode writers.
 - **Writer personas** (the other 11) omit `tools:` and keep full access for lane-mode implementation work.
 
 ## Routing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "claude-config",
+  "name": "agent-config",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-config",
+      "name": "agent-config",
       "version": "0.1.0",
+      "engines": {
+        "node": ">=22.18.0"
+      },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "claude-config",
+  "name": "agent-config",
   "version": "0.1.0",
   "private": true,
   "description": "Shared behavioral configuration for Claude Code, Codex, and Pi, installable as a Pi package.",
+  "type": "module",
+  "engines": {
+    "node": ">=22.18.0"
+  },
   "scripts": {
     "test": "node --test tests/*.test.ts"
   },

--- a/rules/parallel-agents.md
+++ b/rules/parallel-agents.md
@@ -26,6 +26,6 @@ Read-only parallel work (research, grilling, design) runs bounded, never as free
 2. Each sees the others' output and sends targeted challenges - one pass for research, iterate to agreement for grilling and design.
 3. The parent pulls the results together and puts the disagreement to the user as the next question. Teammates never message the user.
 
-Research panels spawn as `Explore`, whose toolset excludes Edit and Write, so read-only is mechanical. Grill and design panels use the domain personas from `rules/agent-routing.md` with a read-only brief, backstopped by the parent's review `(review-time: agent-type selection)`
+Research panels spawn as `Explore`, whose toolset drops Edit and Write, leaving a write reachable only through Bash. Grill and design panels use the domain personas from `rules/agent-routing.md` with a read-only brief, backstopped by the parent's review `(review-time: agent-type selection)`
 
 Merging finished lanes: see the `worktree-merge` skill.

--- a/templates/adr.md
+++ b/templates/adr.md
@@ -1,8 +1,8 @@
-# ADR NNNN: <Title>
+# <Decision stated as a sentence>
 
-- **Status**: Proposed
-- **Date**: YYYY-MM-DD
-- **Deciders**: <names>
+## Status
+
+Proposed - YYYY-MM-DD
 
 ## Context
 
@@ -16,11 +16,15 @@ The chosen option, stated plainly in one or two sentences. No hedging.
 
 What this commits us to. Group as Positive / Negative / Neutral if it helps. Be honest about the downsides.
 
-## Alternatives Considered
+## Considered alternatives
 
 Each alternative in one short paragraph: what it was, why it was rejected. Keep this section tight - the goal is to show the decision was not accidental, not to write a survey.
 
 ---
+
+## Conventions
+
+The title is the decision itself, not a label: "Share agent configuration across hosts", not "ADR 0008: Host sharing". The number lives in the filename, `NNNN-kebab-title.md`.
 
 ## Status values
 


### PR DESCRIPTION
## What does this PR do?

Four documentation claims that no longer matched the repo. No behaviour changes beyond the package metadata.

- **The cheatsheet contradicted the rest of the repo about Pi.** It said Pi teammate mechanics are deferred; README and CONTEXT.md both say the `pi-subagents` package provides them, including background runs and worktree-isolated lanes.
- **Nine skills had no cheatsheet entry**, a deleted one still did, and the four model-invoked skills had nowhere to appear because the table only lists what you type. Every skill in `skills/` is now covered.
- **The ADR template matched none of the nine real ADRs.** It asked for an `ADR NNNN: Title` heading with Status, Date and Deciders metadata lines. All nine use a plain descriptive title with a `## Status` section, and seven use `Considered alternatives` rather than `Alternatives Considered`.
- **Advisory personas were described as mechanically read-only.** All five list `Bash` alongside Read, Grep and Glob, and Bash writes files. The frontmatter removes the one-call edit, which is worth having, but three files described it as a guarantee the brief no longer had to carry. `Explore` has the same shape.
- **`package.json` was still named `claude-config`** after the repo rename, had no `type` (so every test run printed a module warning), and declared no `engines` despite the tests needing Node with type stripping.

## Category

- [x] Chore (dependencies, docs, config)

## Linked issues

Follows #134 through #139, from the same review.

## Review checklist

### General

- [x] Changes have been tested locally
- [x] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant

## Verification

- Every directory under `skills/` now appears in `CHEATSHEET.md`, checked by enumerating the tree against the file
- The template's headings now diff clean against the real ADRs, with `Considered alternatives` added back because seven of nine carry it
- `npm test` 40 passed and the `MODULE_TYPELESS_PACKAGE_JSON` warning is gone
- `package-lock.json` was regenerated with `npm install --package-lock-only`, not hand-edited. The diff is the two name fields and the new engines block
- Full gate green: `tests/setup-hosts.sh` 139, `tests/symlink-check.sh` 10, `tests/shared-paths.sh` 13, `tests/resolve-repo.sh` 12, prose gate 56, config integrity, shellcheck, budget, markdownlint

## Note

`engines` is set to `>=22.18.0`, the first release with unflagged TypeScript type stripping, which `node --test tests/*.test.ts` relies on. CI pins 24, so this only affects contributors on an older runtime, who currently get a confusing parse error instead of an engine warning.
