### PR TITLE
chore(pi): default to GPT-5.6 Sol

### DIFF
--- a/pi/settings.json
+++ b/pi/settings.json
@@ -21,6 +21,6 @@
     "npm:pi-mcp-adapter@2.31.0",
     "npm:pi-intercom@0.12.1"
   ],
-  "defaultProvider": "anthropic",
-  "defaultModel": "claude-opus-5"
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.6-sol"
 }


### PR DESCRIPTION
## What does this PR do?

- Sets Pi's startup provider to `openai-codex`.
- Sets Pi's startup model to `gpt-5.6-sol`.

## Category

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Chore (dependencies, docs, config)
- [ ] CI/CD
- [ ] Infrastructure

## Linked issues

None.

## Review checklist

### General

- [x] Changes have been tested locally
- [ ] Tests have been added or updated where needed
- [x] No unnecessary changes outside the scope of this PR

### Security

- [x] Considered the security impact of these changes
- [x] No credentials or secrets in the code

### For reviewers

- [x] PR description provides enough context to understand the change
- [x] Screenshots or logs included where relevant
